### PR TITLE
Apply the "let it crash" strategy to plug-in failures 

### DIFF
--- a/analyzer/dummy-analyzer/src/main/java/eu/fasten/analyzer/dummyanalyzer/DummyAnalyzerPlugin.java
+++ b/analyzer/dummy-analyzer/src/main/java/eu/fasten/analyzer/dummyanalyzer/DummyAnalyzerPlugin.java
@@ -32,11 +32,6 @@ public class DummyAnalyzerPlugin extends Plugin {
         }
 
         @Override
-        public boolean recordProcessSuccessful() {
-            return true;
-        }
-
-        @Override
         public String name() {
             return "Dummy plugin";
         }
@@ -52,21 +47,6 @@ public class DummyAnalyzerPlugin extends Plugin {
 
         @Override
         public void stop() {
-        }
-
-        @Override
-        public void setPluginError(String exceptionType) {
-
-        }
-
-        @Override
-        public String getPluginError() {
-            return "";
-        }
-
-        @Override
-        public void freeResource() {
-
         }
     }
 }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
@@ -73,7 +73,8 @@ public class Main implements Runnable {
 
     @CommandLine.ArgGroup(exclusive = true)
     MergeGenerateDiff mgd;
-    static class MergeGenerateDiff{
+
+    static class MergeGenerateDiff {
         @CommandLine.Option(names = {"-m", "--merge"},
             paramLabel = "MERGE",
             description = "Merge artifact with the passed dependencies")
@@ -114,19 +115,13 @@ public class Main implements Runnable {
         }
 
         ExtendedRevisionCallGraph revisionCallGraph = null;
-        try {
-            logger.info("Generating call graph for the Maven coordinate: {}", this.fullCoordinate.mavenCoordStr);
-            long startTime = System.currentTimeMillis();
-            revisionCallGraph = ExtendedRevisionCallGraph.create("mvn", mavenCoordinate, Long.parseLong(this.timestamp));
-            logger.info("Generated the call graph in {} seconds.", timeFormatter.format((System.currentTimeMillis() - startTime) / 1000d));
-            //TODO something with the calculated RevesionCallGraph.
-            System.out.println(revisionCallGraph.toJSON());
 
-        } catch (FileNotFoundException e) {
-            logger.error("Could not download the JAR file of Maven coordinate: {}", mavenCoordinate.getCoordinate());
-            e.printStackTrace();
-        }
-
+        logger.info("Generating call graph for the Maven coordinate: {}", this.fullCoordinate.mavenCoordStr);
+        long startTime = System.currentTimeMillis();
+        revisionCallGraph = ExtendedRevisionCallGraph.create("mvn", mavenCoordinate, Long.parseLong(this.timestamp));
+        logger.info("Generated the call graph in {} seconds.", timeFormatter.format((System.currentTimeMillis() - startTime) / 1000d));
+        //TODO something with the calculated RevesionCallGraph.
+        System.out.println(revisionCallGraph.toJSON());
     }
 
     /**

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
@@ -101,9 +101,11 @@ public class MavenCoordinate {
         return groupID + ":" + artifactID + ":" + versionConstraint;
     }
 
-    public String getTimestamp() {return timestamp;}
+    public String getTimestamp() {
+        return timestamp;
+    }
 
-    public String toURL()  {
+    public String toURL() {
         StringBuilder url = new StringBuilder(MAVEN_REPO)
             .append(this.groupID.replace('.', '/'))
             .append("/")
@@ -176,7 +178,7 @@ public class MavenCoordinate {
                     depList.add(dependency);
                     dependencies.add(depList);
                 }
-            } catch (DocumentException | FileNotFoundException e) {
+            } catch (DocumentException e) {
                 logger.error("Error parsing POM file for: " + mavenCoordinate, e);
             }
             return dependencies;
@@ -184,11 +186,12 @@ public class MavenCoordinate {
 
         /**
          * Download a POM file indicated by the provided Maven coordinate
+         *
          * @param mavenCoordinate A Maven coordinate in the for "groupId:artifactId:version"
          * @return The contents of the downloaded POM file as a string
          */
-        public static Optional<String> downloadPom(String mavenCoordinate) throws FileNotFoundException {
-            return httpGetToFile(fromString(mavenCoordinate).toPomUrl(),".pom").
+        public static Optional<String> downloadPom(String mavenCoordinate) {
+            return httpGetToFile(fromString(mavenCoordinate).toPomUrl(), ".pom").
                 flatMap(f -> fileToString(f));
         }
 
@@ -198,9 +201,9 @@ public class MavenCoordinate {
          * @param mavenCoordinate A Maven coordinate in the for "groupId:artifactId:version"
          * @return A temporary file on the filesystem
          */
-        public static Optional<File> downloadJar(String mavenCoordinate) throws FileNotFoundException {
+        public static Optional<File> downloadJar(String mavenCoordinate) {
             logger.debug("Downloading JAR for " + mavenCoordinate);
-            return httpGetToFile(fromString(mavenCoordinate).toJarUrl(),".jar");
+            return httpGetToFile(fromString(mavenCoordinate).toJarUrl(), ".jar");
         }
 
         /**
@@ -227,7 +230,7 @@ public class MavenCoordinate {
         /**
          * Utility function that stores the contents of GET request to a temporary file
          */
-        private static Optional<File> httpGetToFile(String url, String suffix) throws FileNotFoundException {
+        private static Optional<File> httpGetToFile(String url, String suffix) {
             logger.debug("HTTP GET: " + url);
 
             try {
@@ -239,10 +242,7 @@ public class MavenCoordinate {
                 in.close();
 
                 return Optional.of(new File(tempFile.toAbsolutePath().toString()));
-            } catch (FileNotFoundException e) {
-                logger.error("Could not find URL: " + url, e);
-                throw e;
-            } catch (Exception e){
+            } catch (Exception e) {
                 logger.error("Error retrieving URL: " + url, e);
                 return Optional.empty();
             }
@@ -252,6 +252,7 @@ public class MavenCoordinate {
          * A utility method to get a POM file and its timestamp from a URL
          * Please note that this might not be the most efficient way but it works and can be improved
          * later.
+         *
          * @param fileURL
          * @param dest
          * @throws IOException
@@ -269,7 +270,7 @@ public class MavenCoordinate {
 
             Date timestamp = new Date(con.getLastModified());
 
-            if(con.getResponseCode() == HttpURLConnection.HTTP_OK){
+            if (con.getResponseCode() == HttpURLConnection.HTTP_OK) {
 
                 logger.debug("Okay status!");
 
@@ -277,7 +278,7 @@ public class MavenCoordinate {
                 BufferedWriter output = new BufferedWriter(new FileWriter(new File(dest)));
 
                 String line;
-                while((line = input.readLine()) != null) {
+                while ((line = input.readLine()) != null) {
                     output.write(line);
                     output.newLine();
                 }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/callgraph/ExtendedRevisionCallGraph.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/callgraph/ExtendedRevisionCallGraph.java
@@ -170,7 +170,7 @@ public class ExtendedRevisionCallGraph extends RevisionCallGraph {
             PartialCallGraph.toURIHierarchy(partialCallGraph.getClassHierarchy()));
     }
 
-    public static ExtendedRevisionCallGraph create(final String forge, final MavenCoordinate coordinate, final long timestamp) throws FileNotFoundException {
+    public static ExtendedRevisionCallGraph create(final String forge, final MavenCoordinate coordinate, final long timestamp) {
 
         logger.info("Generating call graph using Opal ...");
         final PartialCallGraph partialCallGraph = new PartialCallGraph(

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/OPALPluginTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/OPALPluginTest.java
@@ -103,21 +103,6 @@ public class OPALPluginTest {
     }
 
     @Test
-    public void testFileNotFoundException() {
-        JSONObject noJARFile = new JSONObject("{\n" +
-                "    \"groupId\": \"com.visionarts\",\n" +
-                "    \"artifactId\": \"power-jambda-pom\",\n" +
-                "    \"version\": \"0.9.10\",\n" +
-                "    \"date\":\"1521511260\"\n" +
-                "}");
-
-        opalPlugin.consume(new ConsumerRecord<>(topic, 1, 0, "bar", noJARFile.toString()), false);
-
-        assertEquals(FileNotFoundException.class.getSimpleName(), opalPlugin.getPluginError());
-        assertFalse(opalPlugin.recordProcessSuccessful());
-    }
-
-    @Test
     public void testProducerTopic() {
         assertEquals("opal_callgraphs", opalPlugin.producerTopic());
     }

--- a/analyzer/javacg-wala/src/main/java/eu/fasten/analyzer/javacgwala/WalaJavaCGGen.java
+++ b/analyzer/javacg-wala/src/main/java/eu/fasten/analyzer/javacgwala/WalaJavaCGGen.java
@@ -53,21 +53,6 @@ public class WalaJavaCGGen implements FastenPlugin {
     @Override
     public void stop() { }
 
-    @Override
-    public void setPluginError(String exceptionType) {
-
-    }
-
-    @Override
-    public String getPluginError() {
-        return "";
-    }
-
-    @Override
-    public void freeResource() {
-
-    }
-
     private static List<MavenResolvedCoordinate> buildClasspath(String mavenCoordinate){
         logger.debug("Building classpath for {}", mavenCoordinate);
         var artifacts = Maven.resolver().

--- a/core/src/main/java/eu/fasten/core/plugins/FastenPlugin.java
+++ b/core/src/main/java/eu/fasten/core/plugins/FastenPlugin.java
@@ -62,18 +62,4 @@ public interface FastenPlugin extends ExtensionPoint {
      * Invoked when the server is about to shutdown. This enables the plug-in to shutdown gracefully.
      */
     public void stop();
-
-    /**
-     * These two methods should be implemented so that the FASTEN server can retrieve the plug-in's error and its exception
-     * type. This will help to reprocess certain types of failed records.
-     */
-    public void setPluginError(String exceptionType);
-    public String getPluginError();
-
-    /**
-     * The purpose of this method is to release all the resources of a plug-in. For example, closing a stream or setting
-     * a big object to null.
-     */
-    public void freeResource();
-
 }

--- a/core/src/main/java/eu/fasten/core/plugins/KafkaConsumer.java
+++ b/core/src/main/java/eu/fasten/core/plugins/KafkaConsumer.java
@@ -46,9 +46,4 @@ public interface KafkaConsumer<T> extends FastenPlugin {
      */
     public void consume(String topic, ConsumerRecord<String, T> record);
 
-    /**
-     * This returns true if the plug-in processed the consumed record successfully.
-     * @return
-     */
-    public boolean recordProcessSuccessful();
 }


### PR DESCRIPTION
Our current error handling code delegates too much error handling responsibility to the plug-ins. In this branch, I try to apply the [Let it crash](https://wiki.c2.com/?LetItCrash) design strategy. The idea is that the plug-ins should not do ANY error handling and always raise unchecked exceptions (subclasses of RuntimeException). Methods in plug-ins should not throw / declare checked exceptions, except if those are handled locally in the plug-in. The plug-in runner must install a generic exception handler for RuntimeExceptions and perform the necessary corrective actions.

This is work in progress; PR submitted just to check current status.