### PR TITLE
Adding separate STDOUT and STDERR topics to the FASTEN plug-ins for supporting triggering

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -36,7 +36,7 @@ public class OPALPlugin extends AnalyzerPlugin {
     @Extension
     public static class OPAL extends AnalyzerPlugin.ANALYZER {
 
-        final String produceTopic = "opal_callgraphs";
+        private static String produceTopic = "opal_callgraphs";
 
         @Override
         public ExtendedRevisionCallGraph generateCallGraph(final MavenCoordinate mavenCoordinate,
@@ -52,8 +52,12 @@ public class OPALPlugin extends AnalyzerPlugin {
 
         @Override
         public String producerTopic() {
-            return this.produceTopic;
+            return produceTopic;
         }
 
+        @Override
+        public void setProducerTopic(String topicName) {
+            produceTopic = topicName;
+        }
     }
 }

--- a/analyzer/javacg-wala/src/main/java/eu/fasten/analyzer/javacgwala/WALAPlugin.java
+++ b/analyzer/javacg-wala/src/main/java/eu/fasten/analyzer/javacgwala/WALAPlugin.java
@@ -38,7 +38,7 @@ public class WALAPlugin extends AnalyzerPlugin {
     @Extension
     public static class WALA extends AnalyzerPlugin.ANALYZER {
 
-        final String produceTopic = "wala_callgraphs";
+        private static String produceTopic = "wala_callgraphs";
 
         @Override
         public ExtendedRevisionCallGraph generateCallGraph(final MavenCoordinate mavenCoordinate,
@@ -51,7 +51,12 @@ public class WALAPlugin extends AnalyzerPlugin {
 
         @Override
         public String producerTopic() {
-            return this.produceTopic;
+            return produceTopic;
+        }
+
+        @Override
+        public void setProducerTopic(String topicName) {
+            produceTopic = topicName;
         }
     }
 }

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -261,7 +261,6 @@ public class MetadataDatabasePlugin extends Plugin {
                     new JSONObject().put("plugin", this.getClass().getSimpleName()).put("msg",
                             throwable.getMessage()).put("trace", throwable.getStackTrace())
                             .put("type", throwable.getClass().getSimpleName()).toString();
-            System.out.println(this.pluginError);
         }
 
         @Override

--- a/core/src/main/java/eu/fasten/core/plugins/KafkaProducer.java
+++ b/core/src/main/java/eu/fasten/core/plugins/KafkaProducer.java
@@ -37,4 +37,10 @@ public interface KafkaProducer extends FastenPlugin {
      * implementation can use it to write a set of mechanisms to Kafka, in a blocking fashion.
      */
     public void setKafkaProducer(org.apache.kafka.clients.producer.KafkaProducer<Object, String> producer);
+
+    /**
+     * Overrides the default topic of a KafkaProducer
+     * @param topicName the name of a Kafka topic to set
+     */
+    public void setProducerTopic(String topicName);
 }

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -86,6 +86,9 @@ public class FastenServer implements Runnable {
             defaultValue = "0")
     private int skipOffsets;
 
+    @Option(names = {"-dp, --deploy"})
+    boolean deployMode;
+
     private static Logger logger = LoggerFactory.getLogger(FastenServer.class);
 
     private List<FastenKafkaConsumer> consumers;
@@ -98,9 +101,14 @@ public class FastenServer implements Runnable {
 
     public void run() {
 
-        // TODO: Set log level based on an arg in CLI: either dev or deploy mode.
-        setLoggingLevel(Level.DEBUG);
-        
+        if(deployMode) {
+            setLoggingLevel(Level.INFO);
+            logger.info("FASTEN server started in deployment mode");
+        } else {
+            setLoggingLevel(Level.DEBUG);
+            logger.info("FASTEN server started in development mode");
+        }
+
         // Register shutdown actions
         // TODO: Fix the null pointer exception for the following ShutdownHook
 //        Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -126,23 +126,25 @@ public class FastenServer implements Runnable {
 
         // Change the default topics of the plug-ins if a JSON file of the topics is given
         if(pluginTopic != null) {
+            JSONObject jsonObject;
             try {
-                JSONObject jsonObject = new JSONObject(new String(Files.readAllBytes(Paths.get(pluginTopic))));
-
-                kafkaConsumers.forEach((k) -> {
-                    if(jsonObject.has(k.getClass().getSimpleName())) {
-                        k.setTopic(jsonObject.getJSONObject(k.getClass().getSimpleName()).get("consumer").toString());
-                    }
-                });
-
-                kafkaProducers.forEach((k) ->{
-                    if(jsonObject.has(k.getClass().getSimpleName())) {
-                        k.setProducerTopic(jsonObject.getJSONObject(k.getClass().getSimpleName()).get("producer").toString());
-                    }
-                });
-
+                jsonObject = new JSONObject(new String(Files.readAllBytes(Paths.get(pluginTopic))));
             } catch (IOException e) {
                 logger.error("Failed to read the JSON file of the topics: {}", e.getMessage());
+                // Here, it reads the JSON string directly from the CLI, not a file.
+                jsonObject = new JSONObject(pluginTopic);
+            }
+
+            for(KafkaConsumer k: kafkaConsumers) {
+                if(jsonObject.has(k.getClass().getSimpleName())) {
+                    k.setTopic(jsonObject.getJSONObject(k.getClass().getSimpleName()).get("consumer").toString());
+                }
+            }
+
+            for(KafkaProducer k: kafkaProducers) {
+                if(jsonObject.has(k.getClass().getSimpleName())) {
+                    k.setProducerTopic(jsonObject.getJSONObject(k.getClass().getSimpleName()).get("producer").toString());
+                }
             }
         }
 

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -28,9 +28,7 @@ import eu.fasten.core.plugins.KafkaConsumer;
 import eu.fasten.core.plugins.KafkaProducer;
 import eu.fasten.server.kafka.FastenKafkaConsumer;
 import eu.fasten.server.kafka.FastenKafkaProducer;
-import org.jooq.tools.json.JSONParser;
-import org.jooq.tools.json.ParseException;
-import org.jooq.tools.json.JSONObject;
+import org.json.JSONObject;
 import org.pf4j.JarPluginManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +37,9 @@ import picocli.CommandLine.Option;
 
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -126,17 +126,22 @@ public class FastenServer implements Runnable {
 
         // Change the default topics of the plug-ins if a JSON file of the topics is given
         if(pluginTopic != null) {
-            JSONParser parser = new JSONParser();
             try {
-                JSONObject jsonObject = (JSONObject) parser.parse(new FileReader(pluginTopic));
+                JSONObject jsonObject = new JSONObject(new String(Files.readAllBytes(Paths.get(pluginTopic))));
 
                 kafkaConsumers.forEach((k) -> {
-                    if(jsonObject.containsKey(k.getClass().getSimpleName())) {
-                        k.setTopic(jsonObject.get(k.getClass().getSimpleName()).toString());
+                    if(jsonObject.has(k.getClass().getSimpleName())) {
+                        k.setTopic(jsonObject.getJSONObject(k.getClass().getSimpleName()).get("consumer").toString());
                     }
                 });
 
-            } catch (IOException | ParseException e) {
+                kafkaProducers.forEach((k) ->{
+                    if(jsonObject.has(k.getClass().getSimpleName())) {
+                        k.setProducerTopic(jsonObject.getJSONObject(k.getClass().getSimpleName()).get("producer").toString());
+                    }
+                });
+
+            } catch (IOException e) {
                 logger.error("Failed to read the JSON file of the topics: {}", e.getMessage());
             }
         }

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -65,17 +65,17 @@ public class FastenServer implements Runnable {
             defaultValue = "localhost:9092")
     private List<String> kafkaServers;
 
-    @CommandLine.Option(names = {"-d", "--database"},
+    @Option(names = {"-d", "--database"},
             paramLabel = "dbURL",
             description = "Database URL for connection")
     private String dbUrl;
 
-    @CommandLine.Option(names = {"-u", "--user"},
+    @Option(names = {"-u", "--user"},
             paramLabel = "dbUser",
             description = "Database user name")
     private String dbUser;
 
-    @CommandLine.Option(names = {"-pw", "--pass"},
+    @Option(names = {"-pw", "--pass"},
             paramLabel = "dbPass",
             description = "Database user password")
     private String dbPass;
@@ -86,7 +86,8 @@ public class FastenServer implements Runnable {
             defaultValue = "0")
     private int skipOffsets;
 
-    @Option(names = {"-dp, --deploy"})
+    @Option(names = {"-m", "--mode"},
+            description = "Deployment or Development mode")
     boolean deployMode;
 
     private static Logger logger = LoggerFactory.getLogger(FastenServer.class);

--- a/server/src/main/java/eu/fasten/server/kafka/FastenKafkaConsumer.java
+++ b/server/src/main/java/eu/fasten/server/kafka/FastenKafkaConsumer.java
@@ -147,7 +147,7 @@ public class FastenKafkaConsumer extends FastenKafkaConnection {
 //                .put("partition", String.valueOf(record.partition())).put("offset", String.valueOf(record.offset())).put("record",
 //                        record.value()).put("status", status).toString();
 
-        return new JSONObject(record.key()).put("error", status).toString();
+        return new JSONObject().put("record", record.key()).put("error", status).toString();
     }
 
     /**

--- a/server/src/main/java/eu/fasten/server/kafka/FastenKafkaConsumer.java
+++ b/server/src/main/java/eu/fasten/server/kafka/FastenKafkaConsumer.java
@@ -147,7 +147,7 @@ public class FastenKafkaConsumer extends FastenKafkaConnection {
 //                .put("partition", String.valueOf(record.partition())).put("offset", String.valueOf(record.offset())).put("record",
 //                        record.value()).put("status", status).toString();
 
-        return new JSONObject(record.value()).put("error", status).toString();
+        return new JSONObject(record.key()).put("error", status).toString();
     }
 
     /**

--- a/server/src/main/java/eu/fasten/server/kafka/FastenKafkaConsumer.java
+++ b/server/src/main/java/eu/fasten/server/kafka/FastenKafkaConsumer.java
@@ -299,12 +299,12 @@ public class FastenKafkaConsumer extends FastenKafkaConnection {
                         long startTime = System.currentTimeMillis();
                         kafkaConsumer.consume(topic, r);
 
-                        if(kafkaConsumer.recordProcessSuccessful()){
+                        if(kafkaConsumer.recordProcessSuccessful()) {
                             logToKafka(this.serverLog, this.serverLogTopic, new Date() + "| [" + this.consumerHostName + "] Plug-in " + kafkaConsumer.getClass().getSimpleName() +
                                     " processed successfully record [in " + timeFormatter.format((System.currentTimeMillis() - startTime) / 1000d) + " sec.]: " + r.key());
                         } else {
-                            logToKafka(this.failedRecords, this.failedRecordsTopic, generateRecordStatus(kafkaConsumer.getClass().getSimpleName(),
-                                    r, this.kafkaConsumer.getPluginError()));
+                            logToKafka(this.failedRecords, String.format("fasten.%s.STDERR", kafkaConsumer.getClass().getSimpleName()),
+                                    generateRecordStatus(kafkaConsumer.getClass().getSimpleName(), r, this.kafkaConsumer.getPluginError()));
                         }
                         //kafkaConsumer.freeResource();
                     }


### PR DESCRIPTION
In this PR, we will be working on the following flow strategy that was proposed by Georgios.

> 1- A pkg release arrives in Kafka
> 2- The CG generator creates the CG and writes a DONE msg to its STDOUT topic
> 3- The metadata ingester plug-in writes to Postgres, updates the graph DB and writes a DONE msg to its STDOUT topic
> 4- All the downstream plugins are triggered by reading the DONE msg from the metadata ingester plug-in
>
> In general, triggering must happen by waiting on Kafka messages

This PR's tasks are defined as follows:

- [ ] Design and implement the format of the DONE messages for the plug-ins.
- [x] Add a method to the `KafkaProducer` interface to let the plug-ins override their default producer topic.
- [ ] Write DONE messages (events) for both kinds of plug-ins that have may or may not have a `KafkaProducer`. The DONE messages will be sent to plug-ins' STDOUT topics.
- [x] Write plug-ins errors to their STDERR topics.
- [x] Allow the FASTEN server to override the plug-ins' producer topic, similar to what was done for plug-ins' consumer topic.