### PR TITLE
Improved upsert strategy using constraints and batches

### DIFF
--- a/analyzer/metadata-plugin/pom.xml
+++ b/analyzer/metadata-plugin/pom.xml
@@ -53,21 +53,21 @@
 <!--            <scope>provided</scope>-->
         </dependency>
 <!--        NB! Uncomment the following 3 dependencies if you want to run Main class-->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
-        </dependency>
-        <dependency>
-            <groupId>org.pf4j</groupId>
-            <artifactId>pf4j</artifactId>
-            <version>3.1.0</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.slf4j</groupId>-->
+<!--            <artifactId>slf4j-simple</artifactId>-->
+<!--            <version>1.7.30</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.slf4j</groupId>-->
+<!--            <artifactId>slf4j-api</artifactId>-->
+<!--            <version>1.7.30</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.pf4j</groupId>-->
+<!--            <artifactId>pf4j</artifactId>-->
+<!--            <version>3.1.0</version>-->
+<!--        </dependency>-->
     </dependencies>
 
     <build>

--- a/analyzer/metadata-plugin/pom.xml
+++ b/analyzer/metadata-plugin/pom.xml
@@ -21,7 +21,14 @@
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
             <version>3.12.3</version>
-            <scope>provided</scope>
+<!--            <scope>provided</scope>-->
+        </dependency>
+        <dependency>
+            <!-- This dependency can be removed once jOOQ v3.15 is out,
+                because the required functionality will be implemented there -->
+            <groupId>com.github.t9t.jooq</groupId>
+            <artifactId>jooq-postgresql-json</artifactId>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/analyzer/metadata-plugin/pom.xml
+++ b/analyzer/metadata-plugin/pom.xml
@@ -53,21 +53,21 @@
 <!--            <scope>provided</scope>-->
         </dependency>
 <!--        NB! Uncomment the following 3 dependencies if you want to run Main class-->
-<!--        <dependency>-->
-<!--            <groupId>org.slf4j</groupId>-->
-<!--            <artifactId>slf4j-simple</artifactId>-->
-<!--            <version>1.7.30</version>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.slf4j</groupId>-->
-<!--            <artifactId>slf4j-api</artifactId>-->
-<!--            <version>1.7.30</version>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.pf4j</groupId>-->
-<!--            <artifactId>pf4j</artifactId>-->
-<!--            <version>3.1.0</version>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.pf4j</groupId>
+            <artifactId>pf4j</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.metadataplugin;
 
 import eu.fasten.analyzer.metadataplugin.db.MetadataDao;
 import eu.fasten.core.data.ExtendedRevisionCallGraph;
+import eu.fasten.core.data.metadatadb.codegen.tables.records.EdgesRecord;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaConsumer;
 import java.sql.Timestamp;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jooq.DSLContext;
+import org.jooq.JSONB;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.json.JSONException;
@@ -179,14 +181,15 @@ public class MetadataDatabasePlugin extends Plugin {
             }
 
             final var graph = callGraph.getGraph();
-
+            var edges = new ArrayList<EdgesRecord>(graph.getInternalCalls().size()
+                    + graph.getExternalCalls().size());
             final var internalCalls = graph.getInternalCalls();
             for (var call : internalCalls) {
                 var sourceLocalId = call.get(0);
                 var targetLocalId = call.get(1);
                 var sourceGlobalId = globalIdsMap.get(sourceLocalId);
                 var targetGlobalId = globalIdsMap.get(targetLocalId);
-                metadataDao.insertEdge(sourceGlobalId, targetGlobalId, new JSONObject("{}"));
+                edges.add(new EdgesRecord(sourceGlobalId, targetGlobalId, JSONB.valueOf("{}")));
             }
 
             final var externalCalls = graph.getExternalCalls();
@@ -198,7 +201,20 @@ public class MetadataDatabasePlugin extends Plugin {
                 var targetId = metadataDao.insertCallable(null, uri, false, null, null);
                 var edgeMetadata = new JSONObject(callEntry.getValue());
                 metadataDao.insertEdge(sourceGlobalId, targetId, edgeMetadata);
+                edges.add(new EdgesRecord(sourceGlobalId, targetId,
+                        JSONB.valueOf(edgeMetadata.toString())));
             }
+
+            final int batchSize = 4096;
+            final var edgesIterator = edges.iterator();
+            while (edgesIterator.hasNext()) {
+                var edgesBatch = new ArrayList<EdgesRecord>(batchSize);
+                while (edgesIterator.hasNext() && edgesBatch.size() < batchSize) {
+                    edgesBatch.add(edgesIterator.next());
+                }
+                metadataDao.batchInsertEdges(edgesBatch);
+            }
+
             return packageId;
         }
 

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -49,7 +49,7 @@ public class MetadataDatabasePlugin extends Plugin {
     public static class MetadataDBExtension implements KafkaConsumer<String>, DBConnector {
 
         private String topic = "opal_callgraphs";
-        static private DSLContext dslContext;
+        private static DSLContext dslContext;
         private boolean processedRecord = false;
         private String pluginError = "";
         private final Logger logger = LoggerFactory.getLogger(MetadataDBExtension.class.getName());
@@ -57,7 +57,9 @@ public class MetadataDatabasePlugin extends Plugin {
         private final int transactionRestartLimit = 3;
 
         @Override
-        public void setDBConnection(DSLContext dslContext) { MetadataDBExtension.dslContext = dslContext; }
+        public void setDBConnection(DSLContext dslContext) {
+            MetadataDBExtension.dslContext = dslContext;
+        }
 
         @Override
         public List<String> consumerTopics() {

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -186,7 +186,7 @@ public class MetadataDatabasePlugin extends Plugin {
                 var targetLocalId = call.get(1);
                 var sourceGlobalId = globalIdsMap.get(sourceLocalId);
                 var targetGlobalId = globalIdsMap.get(targetLocalId);
-                metadataDao.insertEdge(sourceGlobalId, targetGlobalId, null);
+                metadataDao.insertEdge(sourceGlobalId, targetGlobalId, new JSONObject("{}"));
             }
 
             final var externalCalls = graph.getExternalCalls();

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
@@ -508,22 +508,10 @@ public class MetadataDao {
                 Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID, Edges.EDGES.METADATA)
                 .values(sourceId, targetId, metadataJsonb)
                 .onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET).doUpdate()
-                .set(Edges.EDGES.METADATA,
-                        concatEdgeMetadata(Edges.EDGES.as("excluded").METADATA, sourceId, targetId))
+                .set(Edges.EDGES.METADATA, JsonbDSL.concat(Edges.EDGES.METADATA,
+                        Edges.EDGES.as("excluded").METADATA))
                 .returning(Edges.EDGES.SOURCE_ID).fetchOne();
         return resultRecord.getValue(Edges.EDGES.SOURCE_ID);
-    }
-
-    private Field<JSONB> concatEdgeMetadata(Field<JSONB> newMetadata, long source, long target) {
-        var record = context.selectFrom(Edges.EDGES)
-                .where(Edges.EDGES.SOURCE_ID.eq(source))
-                .and(Edges.EDGES.TARGET_ID.eq(target))
-                .fetchOne();
-        if (record == null) {
-            return newMetadata;
-        } else {
-            return JsonbDSL.concat(record.field(Edges.EDGES.METADATA), newMetadata);
-        }
     }
 
     /**

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.jooq.DSLContext;
-import org.jooq.Field;
 import org.jooq.JSONB;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
@@ -18,7 +18,6 @@
 
 package eu.fasten.analyzer.metadataplugin.db;
 
-import com.github.t9t.jooq.json.JsonDSL;
 import com.github.t9t.jooq.json.JsonbDSL;
 import eu.fasten.core.data.metadatadb.codegen.Keys;
 import eu.fasten.core.data.metadatadb.codegen.tables.Callables;
@@ -31,8 +30,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import eu.fasten.core.data.metadatadb.codegen.tables.records.EdgesRecord;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.JSONB;
@@ -512,8 +509,8 @@ public class MetadataDao {
                 .values(sourceId, targetId, metadataJsonb)
                 .onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET).doUpdate()
                 .set(Edges.EDGES.METADATA,
-                        concatEdgeMetadata(Edges.EDGES.as("excluded").METADATA, sourceId, targetId)
-                ).returning(Edges.EDGES.SOURCE_ID).fetchOne();
+                        concatEdgeMetadata(Edges.EDGES.as("excluded").METADATA, sourceId, targetId))
+                .returning(Edges.EDGES.SOURCE_ID).fetchOne();
         return resultRecord.getValue(Edges.EDGES.SOURCE_ID);
     }
 

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/db/MetadataDao.java
@@ -511,13 +511,13 @@ public class MetadataDao {
                 Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID, Edges.EDGES.METADATA)
                 .values(sourceId, targetId, metadataJsonb)
                 .onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET).doUpdate()
-                .set(Edges.EDGES.METADATA, concatEdgeMetadata(Edges.EDGES.as("excluded").METADATA, sourceId, targetId))
-                .returning(Edges.EDGES.SOURCE_ID).fetchOne();
+                .set(Edges.EDGES.METADATA,
+                        concatEdgeMetadata(Edges.EDGES.as("excluded").METADATA, sourceId, targetId)
+                ).returning(Edges.EDGES.SOURCE_ID).fetchOne();
         return resultRecord.getValue(Edges.EDGES.SOURCE_ID);
     }
 
-    public Field<JSONB> concatEdgeMetadata(Field<JSONB> newMetadata, long source, long target) {
-        //TODO: Fix concatenation (currently doesn't replace values of existing keys)
+    private Field<JSONB> concatEdgeMetadata(Field<JSONB> newMetadata, long source, long target) {
         var record = context.selectFrom(Edges.EDGES)
                 .where(Edges.EDGES.SOURCE_ID.eq(source))
                 .and(Edges.EDGES.TARGET_ID.eq(target))
@@ -525,7 +525,7 @@ public class MetadataDao {
         if (record == null) {
             return newMetadata;
         } else {
-            return JsonbDSL.concat(newMetadata, record.field(Edges.EDGES.METADATA));
+            return JsonbDSL.concat(record.field(Edges.EDGES.METADATA), newMetadata);
         }
     }
 

--- a/analyzer/metadata-plugin/src/main/resources/metadata_db_init.sql
+++ b/analyzer/metadata-plugin/src/main/resources/metadata_db_init.sql
@@ -57,4 +57,7 @@ CREATE INDEX package_versions_compound_index ON package_versions (package_id, ve
 CREATE INDEX dependencies_compound_index ON dependencies (package_version_id, dependency_id, version_range);
 CREATE INDEX modules_compound_index ON modules (package_version_id, namespaces);
 CREATE INDEX callables_compound_index ON callables (fasten_uri, is_resolved_call);
-CREATE INDEX edges_compound_index ON edges (source_id, target_id);
+-- CREATE INDEX edges_compound_index ON edges (source_id, target_id);
+
+CREATE UNIQUE INDEX CONCURRENTLY unique_source_target ON edges USING btree (source_id, target_id);
+ALTER TABLE edges ADD CONSTRAINT unique_source_target UNIQUE USING INDEX unique_source_target;

--- a/analyzer/metadata-plugin/src/main/resources/metadata_db_init.sql
+++ b/analyzer/metadata-plugin/src/main/resources/metadata_db_init.sql
@@ -49,7 +49,7 @@ CREATE TABLE edges
 (
     source_id BIGINT NOT NULL REFERENCES callables (id),
     target_id BIGINT NOT NULL REFERENCES callables (id),
-    metadata  JSONB
+    metadata  JSONB NOT NULL
 );
 
 CREATE INDEX packages_compound_index ON packages (package_name, forge);
@@ -57,7 +57,6 @@ CREATE INDEX package_versions_compound_index ON package_versions (package_id, ve
 CREATE INDEX dependencies_compound_index ON dependencies (package_version_id, dependency_id, version_range);
 CREATE INDEX modules_compound_index ON modules (package_version_id, namespaces);
 CREATE INDEX callables_compound_index ON callables (fasten_uri, is_resolved_call);
--- CREATE INDEX edges_compound_index ON edges (source_id, target_id);
 
 CREATE UNIQUE INDEX CONCURRENTLY unique_source_target ON edges USING btree (source_id, target_id);
 ALTER TABLE edges ADD CONSTRAINT unique_source_target UNIQUE USING INDEX unique_source_target;

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
@@ -20,13 +20,16 @@ package eu.fasten.analyzer.metadataplugin;
 
 import java.sql.Timestamp;
 import java.util.Collections;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import eu.fasten.analyzer.metadataplugin.db.MetadataDao;
 import eu.fasten.core.data.ExtendedRevisionCallGraph;
+import eu.fasten.core.data.metadatadb.codegen.tables.records.EdgesRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jooq.DSLContext;
+import org.jooq.JSONB;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -114,19 +117,15 @@ public class MetadataDatabasePluginTest {
                 ".lang%2FVoid", true, null, null)).thenReturn(64L);
         Mockito.when(metadataDao.insertCallable(moduleId, "/package/class.toString()%2Fjava" +
                 ".lang%2FString", true, null, null)).thenReturn(65L);
-        Mockito.when(metadataDao.insertEdge(64L, 65L, null)).thenReturn(1L);
-
         Mockito.when(metadataDao.insertCallable(null, "///dep/service.call()%2Fjava" +
                 ".lang%2FObject", false, null, null)).thenReturn(100L);
         var callMetadata = new JSONObject("{\"invokevirtual\": \"1\"}");
-        Mockito.when(metadataDao.insertEdge(64L, 100L, callMetadata)).thenReturn(5L);
-
         long id = metadataDBExtension.saveToDatabase(new ExtendedRevisionCallGraph(json), metadataDao);
         assertEquals(packageId, id);
 
         Mockito.verify(metadataDao).insertPackage(json.getString("product"), "mvn", null, null, null);
         Mockito.verify(metadataDao).insertPackageVersion(packageId, json.getString("generator"),
-                json.getString("version"), new Timestamp(json.getLong("timestamp")), null);
+                json.getString("version"), new Timestamp(json.getLong("timestamp") * 1000), null);
     }
 
     @Test

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/db/MetadataDaoTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/db/MetadataDaoTest.java
@@ -821,103 +821,103 @@ public class MetadataDaoTest {
         });
     }
 
-    @Test
-    public void insertEdgeTest() {
-        long sourceId = 1;
-        long targetId = 2;
-        var metadata = new JSONObject("{\"foo\":\"bar\"}");
-        var selectStep = Mockito.mock(SelectWhereStep.class);
-        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.fetch()).thenReturn(null);
-        var insertValues = Mockito.mock(InsertValuesStep3.class);
-        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
-                Edges.EDGES.METADATA)).thenReturn(insertValues);
-        Mockito.when(insertValues.values(sourceId, targetId, JSONB.valueOf(metadata.toString()))).thenReturn(insertValues);
-        var insertResult = Mockito.mock(InsertResultStep.class);
-        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
-        var record = new EdgesRecord(sourceId, targetId, JSONB.valueOf(metadata.toString()));
-        Mockito.when(insertResult.fetchOne()).thenReturn(record);
-        long result = metadataDao.insertEdge(sourceId, targetId, metadata);
-        assertEquals(sourceId, result);
-    }
+//    @Test
+//    public void insertEdgeTest() {
+//        long sourceId = 1;
+//        long targetId = 2;
+//        var metadata = new JSONObject("{\"foo\":\"bar\"}");
+//        var selectStep = Mockito.mock(SelectWhereStep.class);
+//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
+//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
+//        Mockito.when(selectCondStep.fetch()).thenReturn(null);
+//        var insertValues = Mockito.mock(InsertValuesStep3.class);
+//        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
+//                Edges.EDGES.METADATA)).thenReturn(insertValues);
+//        Mockito.when(insertValues.values(sourceId, targetId, JSONB.valueOf(metadata.toString()))).thenReturn(insertValues);
+//        var insertResult = Mockito.mock(InsertResultStep.class);
+//        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
+//        var record = new EdgesRecord(sourceId, targetId, JSONB.valueOf(metadata.toString()));
+//        Mockito.when(insertResult.fetchOne()).thenReturn(record);
+//        long result = metadataDao.insertEdge(sourceId, targetId, metadata);
+//        assertEquals(sourceId, result);
+//    }
 
-    @Test
-    public void insertEdgeNullTest() {
-        long sourceId = 1;
-        long targetId = 2;
-        var selectStep = Mockito.mock(SelectWhereStep.class);
-        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-        var resultSet = Mockito.mock(Result.class);
-        Mockito.when(resultSet.isEmpty()).thenReturn(true);
-        Mockito.when(selectCondStep.fetch()).thenReturn(resultSet);
-        var insertValues = Mockito.mock(InsertValuesStep3.class);
-        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
-                Edges.EDGES.METADATA)).thenReturn(insertValues);
-        Mockito.when(insertValues.values(sourceId, targetId, null)).thenReturn(insertValues);
-        var insertResult = Mockito.mock(InsertResultStep.class);
-        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
-        var record = new EdgesRecord(sourceId, targetId, null);
-        Mockito.when(insertResult.fetchOne()).thenReturn(record);
-        long result = metadataDao.insertEdge(sourceId, targetId, null);
-        assertEquals(sourceId, result);
-    }
+//    @Test
+//    public void insertEdgeNullTest() {
+//        long sourceId = 1;
+//        long targetId = 2;
+//        var selectStep = Mockito.mock(SelectWhereStep.class);
+//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
+//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
+//        var resultSet = Mockito.mock(Result.class);
+//        Mockito.when(resultSet.isEmpty()).thenReturn(true);
+//        Mockito.when(selectCondStep.fetch()).thenReturn(resultSet);
+//        var insertValues = Mockito.mock(InsertValuesStep3.class);
+//        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
+//                Edges.EDGES.METADATA)).thenReturn(insertValues);
+//        Mockito.when(insertValues.values(sourceId, targetId, null)).thenReturn(insertValues);
+//        var insertResult = Mockito.mock(InsertResultStep.class);
+//        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
+//        var record = new EdgesRecord(sourceId, targetId, null);
+//        Mockito.when(insertResult.fetchOne()).thenReturn(record);
+//        long result = metadataDao.insertEdge(sourceId, targetId, null);
+//        assertEquals(sourceId, result);
+//    }
 
-    @Test
-    public void insertExistingEdgeTest() {
-        long sourceId = 1;
-        long targetId = 2;
-        var metadata = new JSONObject();
-        var selectStep = Mockito.mock(SelectWhereStep.class);
-        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-        var resultSet = Mockito.mock(Result.class);
-        Mockito.when(resultSet.isEmpty()).thenReturn(false);
-        Mockito.when(resultSet.getValues(Edges.EDGES.SOURCE_ID)).thenReturn(Collections.singletonList(sourceId));
-        Mockito.when(selectCondStep.fetch()).thenReturn(resultSet);
-        var updateSetStart = Mockito.mock(UpdateSetFirstStep.class);
-        Mockito.when(context.update(Edges.EDGES)).thenReturn(updateSetStart);
-        var updateSet = Mockito.mock(UpdateSetMoreStep.class);
-        Mockito.when(updateSetStart.set(Edges.EDGES.METADATA, JSONB.valueOf(metadata.toString()))).thenReturn(updateSet);
-        var updateCond = Mockito.mock(UpdateConditionStep.class);
-        Mockito.when(updateSet.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(updateCond);
-        long result = metadataDao.insertEdge(sourceId, targetId, metadata);
-        assertEquals(sourceId, result);
-    }
+//    @Test
+//    public void insertExistingEdgeTest() {
+//        long sourceId = 1;
+//        long targetId = 2;
+//        var metadata = new JSONObject();
+//        var selectStep = Mockito.mock(SelectWhereStep.class);
+//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
+//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
+//        var resultSet = Mockito.mock(Result.class);
+//        Mockito.when(resultSet.isEmpty()).thenReturn(false);
+//        Mockito.when(resultSet.getValues(Edges.EDGES.SOURCE_ID)).thenReturn(Collections.singletonList(sourceId));
+//        Mockito.when(selectCondStep.fetch()).thenReturn(resultSet);
+//        var updateSetStart = Mockito.mock(UpdateSetFirstStep.class);
+//        Mockito.when(context.update(Edges.EDGES)).thenReturn(updateSetStart);
+//        var updateSet = Mockito.mock(UpdateSetMoreStep.class);
+//        Mockito.when(updateSetStart.set(Edges.EDGES.METADATA, JSONB.valueOf(metadata.toString()))).thenReturn(updateSet);
+//        var updateCond = Mockito.mock(UpdateConditionStep.class);
+//        Mockito.when(updateSet.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(updateCond);
+//        long result = metadataDao.insertEdge(sourceId, targetId, metadata);
+//        assertEquals(sourceId, result);
+//    }
 
-    @Test
-    public void insertMultipleEdgesTest() throws IllegalArgumentException {
-        var sourceIds = Arrays.asList(1L, 2L);
-        var targetIds = Arrays.asList(3L, 4L);
-        var metadata = Arrays.asList(new JSONObject("{\"foo\":\"bar\"}"), new JSONObject("{\"hello\":\"world\"}"));
-        var selectStep = Mockito.mock(SelectWhereStep.class);
-        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(0)))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(0)))).thenReturn(selectCondStep);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(1)))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(1)))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.fetch()).thenReturn(null);
-        var insertValues = Mockito.mock(InsertValuesStep3.class);
-        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
-                Edges.EDGES.METADATA)).thenReturn(insertValues);
-        Mockito.when(insertValues.values(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()))).thenReturn(insertValues);
-        Mockito.when(insertValues.values(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()))).thenReturn(insertValues);
-        var insertResult = Mockito.mock(InsertResultStep.class);
-        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
-        var record1 = new EdgesRecord(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()));
-        var record2 = new EdgesRecord(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()));
-        Mockito.when(insertResult.fetchOne()).thenReturn(record1, record2);
-        var result = metadataDao.insertEdges(sourceIds, targetIds, metadata);
-        assertEquals(sourceIds, result);
-    }
+//    @Test
+//    public void insertMultipleEdgesTest() throws IllegalArgumentException {
+//        var sourceIds = Arrays.asList(1L, 2L);
+//        var targetIds = Arrays.asList(3L, 4L);
+//        var metadata = Arrays.asList(new JSONObject("{\"foo\":\"bar\"}"), new JSONObject("{\"hello\":\"world\"}"));
+//        var selectStep = Mockito.mock(SelectWhereStep.class);
+//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(0)))).thenReturn(selectCondStep);
+//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(0)))).thenReturn(selectCondStep);
+//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(1)))).thenReturn(selectCondStep);
+//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(1)))).thenReturn(selectCondStep);
+//        Mockito.when(selectCondStep.fetch()).thenReturn(null);
+//        var insertValues = Mockito.mock(InsertValuesStep3.class);
+//        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
+//                Edges.EDGES.METADATA)).thenReturn(insertValues);
+//        Mockito.when(insertValues.values(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()))).thenReturn(insertValues);
+//        Mockito.when(insertValues.values(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()))).thenReturn(insertValues);
+//        var insertResult = Mockito.mock(InsertResultStep.class);
+//        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
+//        var record1 = new EdgesRecord(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()));
+//        var record2 = new EdgesRecord(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()));
+//        Mockito.when(insertResult.fetchOne()).thenReturn(record1, record2);
+//        var result = metadataDao.insertEdges(sourceIds, targetIds, metadata);
+//        assertEquals(sourceIds, result);
+//    }
 
     @Test
     public void insertMultipleEdgesErrorTest() {
@@ -1007,17 +1007,4 @@ public class MetadataDaoTest {
         Mockito.verify(updateCond).execute();
     }
 
-    @Test
-    public void updateEdgeTest() {
-        long edgeId = 1;
-        JSONB metadata = JSONB.valueOf("{\"foo\":\"bar\"}");
-        var updateSetStart = Mockito.mock(UpdateSetFirstStep.class);
-        Mockito.when(context.update(Edges.EDGES)).thenReturn(updateSetStart);
-        var updateSet = Mockito.mock(UpdateSetMoreStep.class);
-        Mockito.when(updateSetStart.set(Edges.EDGES.METADATA, metadata)).thenReturn(updateSet);
-        var updateCond = Mockito.mock(UpdateConditionStep.class);
-        Mockito.when(updateSet.where(Edges.EDGES.SOURCE_ID.eq(edgeId))).thenReturn(updateCond);
-        this.metadataDao.updateEdge(edgeId, metadata);
-        Mockito.verify(updateCond).execute();
-    }
 }

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/db/MetadataDaoTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/db/MetadataDaoTest.java
@@ -827,12 +827,6 @@ public class MetadataDaoTest {
         long sourceId = 1;
         long targetId = 2;
         var metadata = new JSONObject("{\"foo\":\"bar\"}");
-        var selectStep = Mockito.mock(SelectWhereStep.class);
-        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.fetchOne()).thenReturn(null);
         var insertValues = Mockito.mock(InsertValuesStep3.class);
         Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
                 Edges.EDGES.METADATA)).thenReturn(insertValues);
@@ -855,41 +849,6 @@ public class MetadataDaoTest {
     public void insertNullEdgeTest() {
         long sourceId = 1;
         long targetId = 2;
-        var selectStep = Mockito.mock(SelectWhereStep.class);
-        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.fetchOne()).thenReturn(null);
-        var insertValues = Mockito.mock(InsertValuesStep3.class);
-        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
-                Edges.EDGES.METADATA)).thenReturn(insertValues);
-        Mockito.when(insertValues.values(sourceId, targetId, null)).thenReturn(insertValues);
-        var insertConflict = Mockito.mock(InsertOnConflictDoUpdateStep.class);
-        Mockito.when(insertValues.onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET)).thenReturn(insertConflict);
-        var insertDuplicate = Mockito.mock(InsertOnDuplicateSetStep.class);
-        Mockito.when(insertConflict.doUpdate()).thenReturn(insertDuplicate);
-        var insertDuplicateMore = Mockito.mock(InsertOnDuplicateSetMoreStep.class);
-        Mockito.when(insertDuplicate.set(Mockito.eq(Edges.EDGES.METADATA), Mockito.any(Field.class))).thenReturn(insertDuplicateMore);
-        var insertResult = Mockito.mock(InsertResultStep.class);
-        Mockito.when(insertDuplicateMore.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
-        var record = new EdgesRecord(sourceId, targetId, null);
-        Mockito.when(insertResult.fetchOne()).thenReturn(record);
-        long result = metadataDao.insertEdge(sourceId, targetId, null);
-        assertEquals(sourceId, result);
-    }
-
-    @Test
-    public void insertExistingEdgeTest() {
-        long sourceId = 1;
-        long targetId = 2;
-        var selectStep = Mockito.mock(SelectWhereStep.class);
-        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-        var existingEdge = new EdgesRecord(1L, 2L, JSONB.valueOf("{\"foo\": \"bar\"}"));
-        Mockito.when(selectCondStep.fetchOne()).thenReturn(existingEdge);
         var insertValues = Mockito.mock(InsertValuesStep3.class);
         Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
                 Edges.EDGES.METADATA)).thenReturn(insertValues);
@@ -915,12 +874,6 @@ public class MetadataDaoTest {
         var metadata = Arrays.asList(new JSONObject("{\"foo\":\"bar\"}"), new JSONObject("{\"hello\":\"world\"}"));
         var selectStep = Mockito.mock(SelectWhereStep.class);
         Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(0)))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(0)))).thenReturn(selectCondStep);
-        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(1)))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(1)))).thenReturn(selectCondStep);
-        Mockito.when(selectCondStep.fetchOne()).thenReturn(null);
         var insertValues = Mockito.mock(InsertValuesStep3.class);
         Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
                 Edges.EDGES.METADATA)).thenReturn(insertValues);

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/db/MetadataDaoTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/db/MetadataDaoTest.java
@@ -18,6 +18,7 @@
 
 package eu.fasten.analyzer.metadataplugin.db;
 
+import eu.fasten.core.data.metadatadb.codegen.Keys;
 import eu.fasten.core.data.metadatadb.codegen.tables.Callables;
 import eu.fasten.core.data.metadatadb.codegen.tables.Dependencies;
 import eu.fasten.core.data.metadatadb.codegen.tables.Edges;
@@ -821,103 +822,124 @@ public class MetadataDaoTest {
         });
     }
 
-//    @Test
-//    public void insertEdgeTest() {
-//        long sourceId = 1;
-//        long targetId = 2;
-//        var metadata = new JSONObject("{\"foo\":\"bar\"}");
-//        var selectStep = Mockito.mock(SelectWhereStep.class);
-//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-//        Mockito.when(selectCondStep.fetch()).thenReturn(null);
-//        var insertValues = Mockito.mock(InsertValuesStep3.class);
-//        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
-//                Edges.EDGES.METADATA)).thenReturn(insertValues);
-//        Mockito.when(insertValues.values(sourceId, targetId, JSONB.valueOf(metadata.toString()))).thenReturn(insertValues);
-//        var insertResult = Mockito.mock(InsertResultStep.class);
-//        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
-//        var record = new EdgesRecord(sourceId, targetId, JSONB.valueOf(metadata.toString()));
-//        Mockito.when(insertResult.fetchOne()).thenReturn(record);
-//        long result = metadataDao.insertEdge(sourceId, targetId, metadata);
-//        assertEquals(sourceId, result);
-//    }
+    @Test
+    public void insertEdgeTest() {
+        long sourceId = 1;
+        long targetId = 2;
+        var metadata = new JSONObject("{\"foo\":\"bar\"}");
+        var selectStep = Mockito.mock(SelectWhereStep.class);
+        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.fetchOne()).thenReturn(null);
+        var insertValues = Mockito.mock(InsertValuesStep3.class);
+        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
+                Edges.EDGES.METADATA)).thenReturn(insertValues);
+        Mockito.when(insertValues.values(sourceId, targetId, JSONB.valueOf(metadata.toString()))).thenReturn(insertValues);
+        var insertConflict = Mockito.mock(InsertOnConflictDoUpdateStep.class);
+        Mockito.when(insertValues.onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET)).thenReturn(insertConflict);
+        var insertDuplicate = Mockito.mock(InsertOnDuplicateSetStep.class);
+        Mockito.when(insertConflict.doUpdate()).thenReturn(insertDuplicate);
+        var insertDuplicateMore = Mockito.mock(InsertOnDuplicateSetMoreStep.class);
+        Mockito.when(insertDuplicate.set(Mockito.eq(Edges.EDGES.METADATA), Mockito.any(Field.class))).thenReturn(insertDuplicateMore);
+        var insertResult = Mockito.mock(InsertResultStep.class);
+        Mockito.when(insertDuplicateMore.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
+        var record = new EdgesRecord(sourceId, targetId, JSONB.valueOf(metadata.toString()));
+        Mockito.when(insertResult.fetchOne()).thenReturn(record);
+        long result = metadataDao.insertEdge(sourceId, targetId, metadata);
+        assertEquals(sourceId, result);
+    }
 
-//    @Test
-//    public void insertEdgeNullTest() {
-//        long sourceId = 1;
-//        long targetId = 2;
-//        var selectStep = Mockito.mock(SelectWhereStep.class);
-//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-//        var resultSet = Mockito.mock(Result.class);
-//        Mockito.when(resultSet.isEmpty()).thenReturn(true);
-//        Mockito.when(selectCondStep.fetch()).thenReturn(resultSet);
-//        var insertValues = Mockito.mock(InsertValuesStep3.class);
-//        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
-//                Edges.EDGES.METADATA)).thenReturn(insertValues);
-//        Mockito.when(insertValues.values(sourceId, targetId, null)).thenReturn(insertValues);
-//        var insertResult = Mockito.mock(InsertResultStep.class);
-//        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
-//        var record = new EdgesRecord(sourceId, targetId, null);
-//        Mockito.when(insertResult.fetchOne()).thenReturn(record);
-//        long result = metadataDao.insertEdge(sourceId, targetId, null);
-//        assertEquals(sourceId, result);
-//    }
+    @Test
+    public void insertNullEdgeTest() {
+        long sourceId = 1;
+        long targetId = 2;
+        var selectStep = Mockito.mock(SelectWhereStep.class);
+        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.fetchOne()).thenReturn(null);
+        var insertValues = Mockito.mock(InsertValuesStep3.class);
+        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
+                Edges.EDGES.METADATA)).thenReturn(insertValues);
+        Mockito.when(insertValues.values(sourceId, targetId, null)).thenReturn(insertValues);
+        var insertConflict = Mockito.mock(InsertOnConflictDoUpdateStep.class);
+        Mockito.when(insertValues.onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET)).thenReturn(insertConflict);
+        var insertDuplicate = Mockito.mock(InsertOnDuplicateSetStep.class);
+        Mockito.when(insertConflict.doUpdate()).thenReturn(insertDuplicate);
+        var insertDuplicateMore = Mockito.mock(InsertOnDuplicateSetMoreStep.class);
+        Mockito.when(insertDuplicate.set(Mockito.eq(Edges.EDGES.METADATA), Mockito.any(Field.class))).thenReturn(insertDuplicateMore);
+        var insertResult = Mockito.mock(InsertResultStep.class);
+        Mockito.when(insertDuplicateMore.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
+        var record = new EdgesRecord(sourceId, targetId, null);
+        Mockito.when(insertResult.fetchOne()).thenReturn(record);
+        long result = metadataDao.insertEdge(sourceId, targetId, null);
+        assertEquals(sourceId, result);
+    }
 
-//    @Test
-//    public void insertExistingEdgeTest() {
-//        long sourceId = 1;
-//        long targetId = 2;
-//        var metadata = new JSONObject();
-//        var selectStep = Mockito.mock(SelectWhereStep.class);
-//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
-//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
-//        var resultSet = Mockito.mock(Result.class);
-//        Mockito.when(resultSet.isEmpty()).thenReturn(false);
-//        Mockito.when(resultSet.getValues(Edges.EDGES.SOURCE_ID)).thenReturn(Collections.singletonList(sourceId));
-//        Mockito.when(selectCondStep.fetch()).thenReturn(resultSet);
-//        var updateSetStart = Mockito.mock(UpdateSetFirstStep.class);
-//        Mockito.when(context.update(Edges.EDGES)).thenReturn(updateSetStart);
-//        var updateSet = Mockito.mock(UpdateSetMoreStep.class);
-//        Mockito.when(updateSetStart.set(Edges.EDGES.METADATA, JSONB.valueOf(metadata.toString()))).thenReturn(updateSet);
-//        var updateCond = Mockito.mock(UpdateConditionStep.class);
-//        Mockito.when(updateSet.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(updateCond);
-//        long result = metadataDao.insertEdge(sourceId, targetId, metadata);
-//        assertEquals(sourceId, result);
-//    }
+    @Test
+    public void insertExistingEdgeTest() {
+        long sourceId = 1;
+        long targetId = 2;
+        var selectStep = Mockito.mock(SelectWhereStep.class);
+        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceId))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetId))).thenReturn(selectCondStep);
+        var existingEdge = new EdgesRecord(1L, 2L, JSONB.valueOf("{\"foo\": \"bar\"}"));
+        Mockito.when(selectCondStep.fetchOne()).thenReturn(existingEdge);
+        var insertValues = Mockito.mock(InsertValuesStep3.class);
+        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
+                Edges.EDGES.METADATA)).thenReturn(insertValues);
+        Mockito.when(insertValues.values(sourceId, targetId, null)).thenReturn(insertValues);
+        var insertConflict = Mockito.mock(InsertOnConflictDoUpdateStep.class);
+        Mockito.when(insertValues.onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET)).thenReturn(insertConflict);
+        var insertDuplicate = Mockito.mock(InsertOnDuplicateSetStep.class);
+        Mockito.when(insertConflict.doUpdate()).thenReturn(insertDuplicate);
+        var insertDuplicateMore = Mockito.mock(InsertOnDuplicateSetMoreStep.class);
+        Mockito.when(insertDuplicate.set(Mockito.eq(Edges.EDGES.METADATA), Mockito.any(Field.class))).thenReturn(insertDuplicateMore);
+        var insertResult = Mockito.mock(InsertResultStep.class);
+        Mockito.when(insertDuplicateMore.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
+        var record = new EdgesRecord(sourceId, targetId, null);
+        Mockito.when(insertResult.fetchOne()).thenReturn(record);
+        long result = metadataDao.insertEdge(sourceId, targetId, null);
+        assertEquals(sourceId, result);
+    }
 
-//    @Test
-//    public void insertMultipleEdgesTest() throws IllegalArgumentException {
-//        var sourceIds = Arrays.asList(1L, 2L);
-//        var targetIds = Arrays.asList(3L, 4L);
-//        var metadata = Arrays.asList(new JSONObject("{\"foo\":\"bar\"}"), new JSONObject("{\"hello\":\"world\"}"));
-//        var selectStep = Mockito.mock(SelectWhereStep.class);
-//        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
-//        var selectCondStep = Mockito.mock(SelectConditionStep.class);
-//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(0)))).thenReturn(selectCondStep);
-//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(0)))).thenReturn(selectCondStep);
-//        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(1)))).thenReturn(selectCondStep);
-//        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(1)))).thenReturn(selectCondStep);
-//        Mockito.when(selectCondStep.fetch()).thenReturn(null);
-//        var insertValues = Mockito.mock(InsertValuesStep3.class);
-//        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
-//                Edges.EDGES.METADATA)).thenReturn(insertValues);
-//        Mockito.when(insertValues.values(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()))).thenReturn(insertValues);
-//        Mockito.when(insertValues.values(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()))).thenReturn(insertValues);
-//        var insertResult = Mockito.mock(InsertResultStep.class);
-//        Mockito.when(insertValues.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
-//        var record1 = new EdgesRecord(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()));
-//        var record2 = new EdgesRecord(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()));
-//        Mockito.when(insertResult.fetchOne()).thenReturn(record1, record2);
-//        var result = metadataDao.insertEdges(sourceIds, targetIds, metadata);
-//        assertEquals(sourceIds, result);
-//    }
+    @Test
+    public void insertMultipleEdgesTest() throws IllegalArgumentException {
+        var sourceIds = Arrays.asList(1L, 2L);
+        var targetIds = Arrays.asList(3L, 4L);
+        var metadata = Arrays.asList(new JSONObject("{\"foo\":\"bar\"}"), new JSONObject("{\"hello\":\"world\"}"));
+        var selectStep = Mockito.mock(SelectWhereStep.class);
+        Mockito.when(context.selectFrom(Edges.EDGES)).thenReturn(selectStep);
+        var selectCondStep = Mockito.mock(SelectConditionStep.class);
+        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(0)))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(0)))).thenReturn(selectCondStep);
+        Mockito.when(selectStep.where(Edges.EDGES.SOURCE_ID.eq(sourceIds.get(1)))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.and(Edges.EDGES.TARGET_ID.eq(targetIds.get(1)))).thenReturn(selectCondStep);
+        Mockito.when(selectCondStep.fetchOne()).thenReturn(null);
+        var insertValues = Mockito.mock(InsertValuesStep3.class);
+        Mockito.when(context.insertInto(Edges.EDGES, Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID,
+                Edges.EDGES.METADATA)).thenReturn(insertValues);
+        Mockito.when(insertValues.values(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()))).thenReturn(insertValues);
+        Mockito.when(insertValues.values(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()))).thenReturn(insertValues);
+        var insertConflict = Mockito.mock(InsertOnConflictDoUpdateStep.class);
+        Mockito.when(insertValues.onConflictOnConstraint(Keys.UNIQUE_SOURCE_TARGET)).thenReturn(insertConflict);
+        var insertDuplicate = Mockito.mock(InsertOnDuplicateSetStep.class);
+        Mockito.when(insertConflict.doUpdate()).thenReturn(insertDuplicate);
+        var insertDuplicateMore = Mockito.mock(InsertOnDuplicateSetMoreStep.class);
+        Mockito.when(insertDuplicate.set(Mockito.eq(Edges.EDGES.METADATA), Mockito.any(Field.class))).thenReturn(insertDuplicateMore);
+        var insertResult = Mockito.mock(InsertResultStep.class);
+        Mockito.when(insertDuplicateMore.returning(Edges.EDGES.SOURCE_ID)).thenReturn(insertResult);
+        var record1 = new EdgesRecord(sourceIds.get(0), targetIds.get(0), JSONB.valueOf(metadata.get(0).toString()));
+        var record2 = new EdgesRecord(sourceIds.get(1), targetIds.get(1), JSONB.valueOf(metadata.get(1).toString()));
+        Mockito.when(insertResult.fetchOne()).thenReturn(record1, record2);
+        var result = metadataDao.insertEdges(sourceIds, targetIds, metadata);
+        assertEquals(sourceIds, result);
+    }
 
     @Test
     public void insertMultipleEdgesErrorTest() {

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/Indexes.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/Indexes.java
@@ -38,7 +38,7 @@ public class Indexes {
     public static final Index CALLABLES_COMPOUND_INDEX = Indexes0.CALLABLES_COMPOUND_INDEX;
     public static final Index CALLABLES_PKEY = Indexes0.CALLABLES_PKEY;
     public static final Index DEPENDENCIES_COMPOUND_INDEX = Indexes0.DEPENDENCIES_COMPOUND_INDEX;
-    public static final Index EDGES_COMPOUND_INDEX = Indexes0.EDGES_COMPOUND_INDEX;
+    public static final Index UNIQUE_SOURCE_TARGET = Indexes0.UNIQUE_SOURCE_TARGET;
     public static final Index MODULES_COMPOUND_INDEX = Indexes0.MODULES_COMPOUND_INDEX;
     public static final Index MODULES_PKEY = Indexes0.MODULES_PKEY;
     public static final Index PACKAGE_VERSIONS_COMPOUND_INDEX = Indexes0.PACKAGE_VERSIONS_COMPOUND_INDEX;
@@ -54,7 +54,7 @@ public class Indexes {
         public static Index CALLABLES_COMPOUND_INDEX = Internal.createIndex("callables_compound_index", Callables.CALLABLES, new OrderField[] { Callables.CALLABLES.FASTEN_URI, Callables.CALLABLES.IS_RESOLVED_CALL }, false);
         public static Index CALLABLES_PKEY = Internal.createIndex("callables_pkey", Callables.CALLABLES, new OrderField[] { Callables.CALLABLES.ID }, true);
         public static Index DEPENDENCIES_COMPOUND_INDEX = Internal.createIndex("dependencies_compound_index", Dependencies.DEPENDENCIES, new OrderField[] { Dependencies.DEPENDENCIES.PACKAGE_VERSION_ID, Dependencies.DEPENDENCIES.DEPENDENCY_ID, Dependencies.DEPENDENCIES.VERSION_RANGE }, false);
-        public static Index EDGES_COMPOUND_INDEX = Internal.createIndex("edges_compound_index", Edges.EDGES, new OrderField[] { Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID }, false);
+        public static Index UNIQUE_SOURCE_TARGET = Internal.createIndex("unique_source_target", Edges.EDGES, new OrderField[] { Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID }, true);
         public static Index MODULES_COMPOUND_INDEX = Internal.createIndex("modules_compound_index", Modules.MODULES, new OrderField[] { Modules.MODULES.PACKAGE_VERSION_ID, Modules.MODULES.NAMESPACES }, false);
         public static Index MODULES_PKEY = Internal.createIndex("modules_pkey", Modules.MODULES, new OrderField[] { Modules.MODULES.ID }, true);
         public static Index PACKAGE_VERSIONS_COMPOUND_INDEX = Internal.createIndex("package_versions_compound_index", PackageVersions.PACKAGE_VERSIONS, new OrderField[] { PackageVersions.PACKAGE_VERSIONS.PACKAGE_ID, PackageVersions.PACKAGE_VERSIONS.VERSION, PackageVersions.PACKAGE_VERSIONS.CG_GENERATOR }, false);

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/Keys.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/Keys.java
@@ -53,6 +53,7 @@ public class Keys {
     // -------------------------------------------------------------------------
 
     public static final UniqueKey<CallablesRecord> CALLABLES_PKEY = UniqueKeys0.CALLABLES_PKEY;
+    public static final UniqueKey<EdgesRecord> UNIQUE_SOURCE_TARGET = UniqueKeys0.UNIQUE_SOURCE_TARGET;
     public static final UniqueKey<ModulesRecord> MODULES_PKEY = UniqueKeys0.MODULES_PKEY;
     public static final UniqueKey<PackageVersionsRecord> PACKAGE_VERSIONS_PKEY = UniqueKeys0.PACKAGE_VERSIONS_PKEY;
     public static final UniqueKey<PackagesRecord> PACKAGES_PKEY = UniqueKeys0.PACKAGES_PKEY;
@@ -82,6 +83,7 @@ public class Keys {
 
     private static class UniqueKeys0 {
         public static final UniqueKey<CallablesRecord> CALLABLES_PKEY = Internal.createUniqueKey(Callables.CALLABLES, "callables_pkey", Callables.CALLABLES.ID);
+        public static final UniqueKey<EdgesRecord> UNIQUE_SOURCE_TARGET = Internal.createUniqueKey(Edges.EDGES, "unique_source_target", Edges.EDGES.SOURCE_ID, Edges.EDGES.TARGET_ID);
         public static final UniqueKey<ModulesRecord> MODULES_PKEY = Internal.createUniqueKey(Modules.MODULES, "modules_pkey", Modules.MODULES.ID);
         public static final UniqueKey<PackageVersionsRecord> PACKAGE_VERSIONS_PKEY = Internal.createUniqueKey(PackageVersions.PACKAGE_VERSIONS, "package_versions_pkey", PackageVersions.PACKAGE_VERSIONS.ID);
         public static final UniqueKey<PackagesRecord> PACKAGES_PKEY = Internal.createUniqueKey(Packages.PACKAGES, "packages_pkey", Packages.PACKAGES.ID);

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/tables/Edges.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/tables/Edges.java
@@ -42,7 +42,7 @@ import org.jooq.impl.TableImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Edges extends TableImpl<EdgesRecord> {
 
-    private static final long serialVersionUID = -355473986;
+    private static final long serialVersionUID = 906422015;
 
     /**
      * The reference instance of <code>public.edges</code>
@@ -70,7 +70,7 @@ public class Edges extends TableImpl<EdgesRecord> {
     /**
      * The column <code>public.edges.metadata</code>.
      */
-    public final TableField<EdgesRecord, JSONB> METADATA = createField(DSL.name("metadata"), org.jooq.impl.SQLDataType.JSONB, this, "");
+    public final TableField<EdgesRecord, JSONB> METADATA = createField(DSL.name("metadata"), org.jooq.impl.SQLDataType.JSONB.nullable(false), this, "");
 
     /**
      * Create a <code>public.edges</code> table reference

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/tables/Edges.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/codegen/tables/Edges.java
@@ -24,6 +24,7 @@ import org.jooq.Row3;
 import org.jooq.Schema;
 import org.jooq.Table;
 import org.jooq.TableField;
+import org.jooq.UniqueKey;
 import org.jooq.impl.DSL;
 import org.jooq.impl.TableImpl;
 
@@ -41,7 +42,7 @@ import org.jooq.impl.TableImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Edges extends TableImpl<EdgesRecord> {
 
-    private static final long serialVersionUID = 1225996722;
+    private static final long serialVersionUID = -355473986;
 
     /**
      * The reference instance of <code>public.edges</code>
@@ -111,7 +112,12 @@ public class Edges extends TableImpl<EdgesRecord> {
 
     @Override
     public List<Index> getIndexes() {
-        return Arrays.<Index>asList(Indexes.EDGES_COMPOUND_INDEX);
+        return Arrays.<Index>asList(Indexes.UNIQUE_SOURCE_TARGET);
+    }
+
+    @Override
+    public List<UniqueKey<EdgesRecord>> getKeys() {
+        return Arrays.<UniqueKey<EdgesRecord>>asList(Keys.UNIQUE_SOURCE_TARGET);
     }
 
     @Override


### PR DESCRIPTION
- [x] Implement new upsert strategy for `edges` using constraints on index
- [x] Append JSON metadata in `edges` instead of overwriting (if key exists, overwrite its value with new one, otherwise append new key-value pair)
- [x] Implement batch insertion for edges
