### PR TITLE
Improve RepoCloner

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
@@ -96,9 +96,13 @@ public class PartialCallGraph {
             final MavenCoordinate coordinate, final String mainClass,
             final String algorithm, final long timestamp)
             throws FileNotFoundException {
-        final var partialCallGraph = new PartialCallGraph(new CallGraphConstructor(
-                new MavenCoordinate.MavenResolver().downloadJar(coordinate)
-                        .orElseThrow(RuntimeException::new), mainClass, algorithm));
+        final var file = new MavenCoordinate.MavenResolver().downloadJar(coordinate)
+            .orElseThrow(RuntimeException::new);
+
+        logger.info("OPAL is analysing the artifact");
+        final var opalCG = new CallGraphConstructor(file, mainClass, algorithm);
+
+        final var partialCallGraph = new PartialCallGraph(opalCG);
 
         return new ExtendedRevisionCallGraph("mvn", coordinate.getProduct(),
                 coordinate.getVersionConstraint(), timestamp,

--- a/analyzer/repo-cloner-plugin/pom.xml
+++ b/analyzer/repo-cloner-plugin/pom.xml
@@ -41,6 +41,16 @@
             <groupId>org.tmatesoft.svnkit</groupId>
             <artifactId>svnkit</artifactId>
             <version>1.10.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>platform</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jsch.agentproxy.core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/analyzer/repo-cloner-plugin/pom.xml
+++ b/analyzer/repo-cloner-plugin/pom.xml
@@ -38,6 +38,11 @@
             <version>1.1.0-RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>org.tmatesoft.svnkit</groupId>
+            <artifactId>svnkit</artifactId>
+            <version>1.10.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
             <version>5.2.1.201812262042-r</version>

--- a/analyzer/repo-cloner-plugin/pom.xml
+++ b/analyzer/repo-cloner-plugin/pom.xml
@@ -18,11 +18,30 @@
 
     <name>repo-cloner-plugin</name>
 
+    <repositories>
+        <repository>
+            <id>tmatesoft-repo</id>
+            <name>TmateSoft Repository (for hg4j)</name>
+            <url>https://maven.tmatesoft.com/content/repositories/releases/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>eu.fasten</groupId>
             <artifactId>core</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.tmatesoft.hg4j</groupId>
+            <artifactId>hg4j</artifactId>
+            <version>1.1.0-RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.2.1.201812262042-r</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/analyzer/repo-cloner-plugin/pom.xml
+++ b/analyzer/repo-cloner-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>repo-cloner-plugin</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>repo-cloner-plugin</name>

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -23,16 +23,16 @@ import eu.fasten.analyzer.repoclonerplugin.utils.HgCloner;
 import eu.fasten.analyzer.repoclonerplugin.utils.SvnCloner;
 import eu.fasten.core.plugins.DataWriter;
 import eu.fasten.core.plugins.KafkaPlugin;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.json.JSONObject;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.File;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 public class RepoClonerPlugin extends Plugin {
 
@@ -122,7 +122,8 @@ public class RepoClonerPlugin extends Plugin {
                     + (artifact == null ? "" : artifact.charAt(0) + File.separator)
                     + artifact + File.separator
                     + (product == null ? "unknown" : product.replace(":", "_")) + ".json";
-            var repoUrl = json.optString("repoUrl").replaceAll("[\\n\\t ]", "");;
+            var repoUrl = json.optString("repoUrl").replaceAll("[\\n\\t ]", "");
+            ;
             if (!repoUrl.isEmpty()) {
                 var gitCloner = new GitCloner(baseDir);
                 var hgCloner = new HgCloner(baseDir);
@@ -144,7 +145,7 @@ public class RepoClonerPlugin extends Plugin {
         }
 
         public boolean cloneRepo(String repoUrl, String artifact, String group,
-                              GitCloner gitCloner, HgCloner hgCloner, SvnCloner svnCloner) {
+                                 GitCloner gitCloner, HgCloner hgCloner, SvnCloner svnCloner) {
             var cloned = false;
             if (repoUrl.startsWith("scm:git:") || repoUrl.startsWith("scm:svn:")) {
                 repoUrl = repoUrl.substring(8);

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -122,8 +122,8 @@ public class RepoClonerPlugin extends Plugin {
                     + (artifact == null ? "" : artifact.charAt(0) + File.separator)
                     + artifact + File.separator
                     + (product == null ? "unknown" : product.replace(":", "_")) + ".json";
-            var repoUrl = json.optString("repoUrl");
-            if (repoUrl != null && !repoUrl.isEmpty()) {
+            var repoUrl = json.optString("repoUrl").replaceAll("[\\n\\t ]", "");;
+            if (!repoUrl.isEmpty()) {
                 try {
                     var gitCloner = new GitCloner(baseDir);
                     cloneRepo(repoUrl, gitCloner);

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -23,19 +23,16 @@ import eu.fasten.analyzer.repoclonerplugin.utils.HgCloner;
 import eu.fasten.analyzer.repoclonerplugin.utils.SvnCloner;
 import eu.fasten.core.plugins.DataWriter;
 import eu.fasten.core.plugins.KafkaPlugin;
-import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.json.JSONObject;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.tmatesoft.svn.core.SVNException;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 public class RepoClonerPlugin extends Plugin {
 

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -182,6 +182,7 @@ public class RepoClonerPlugin extends Plugin {
             if (!cloned) {
                 try {
                     repoPath = hgCloner.cloneRepo(repoUrl, artifact, group);
+                    cloned = true;
                 } catch (Exception e) {
                     logger.error("Error cloning Hg repository from " + repoUrl, e);
                     cloned = false;

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -116,7 +116,7 @@ public class RepoClonerPlugin extends Plugin {
             String product = null;
             if (artifact != null && !artifact.isEmpty()
                     && group != null && !group.isEmpty()) {
-                product = group + ":" + artifact + ((version == null) ? "" : ":" + version);
+                product = group + ":" + artifact + (version.isEmpty() ? "" : ":" + version);
             }
             outputPath = File.separator
                     + (artifact == null ? "" : artifact.charAt(0) + File.separator)
@@ -136,7 +136,7 @@ public class RepoClonerPlugin extends Plugin {
                 }
                 if (getPluginError() == null) {
                     logger.info("Cloned repository"
-                            + (product == null ? "" : "of '" + product + "'")
+                            + (product == null ? "" : " of '" + product + "'")
                             + " from " + repoUrl + " to " + repoPath);
                 }
             } else {

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/GitCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/GitCloner.java
@@ -18,9 +18,9 @@
 
 package eu.fasten.analyzer.repoclonerplugin.utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 
@@ -41,11 +41,11 @@ public class GitCloner {
      * @throws IOException     if could not create a directory for repository
      */
     public String cloneRepo(String repoUrl) throws GitAPIException, IOException {
-        if (repoUrl.contains("github.com/")) {
+        if (repoUrl.contains("github.com")) {
             return this.cloneGithubRepo(repoUrl);
         } else {
             var dirHierarchy = new DirectoryHierarchyBuilder(baseDir);
-            var urlParts = repoUrl.split("/");
+            var urlParts = Arrays.stream(repoUrl.split("/")).filter(x -> !StringUtils.isBlank(x)).toArray(String[]::new);
             var repoOwner = urlParts[1];
             StringBuilder repoName = new StringBuilder();
             for (var i = 2; i < urlParts.length; i++) {
@@ -76,6 +76,11 @@ public class GitCloner {
         }
         var repoName = urlParts[urlParts.length - 1].split(".git")[0];
         var repoOwner = urlParts[urlParts.length - 2];
+        if (repoUrl.contains("git@github")) {
+            var parts = repoOwner.split(":");
+            repoOwner = parts[parts.length - 1];
+        }
+        repoUrl = "https://github.com/" + repoOwner + "/" + repoName;
         var dirHierarchy = new DirectoryHierarchyBuilder(baseDir);
         var dir = dirHierarchy.getDirectoryFromHierarchy(repoOwner, repoName);
         if (dir.exists()) {

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
@@ -19,24 +19,20 @@ public class HgCloner {
         this.baseDir = baseDir;
     }
 
-    public String cloneRepo(String repoUrl)
+    public String cloneRepo(String repoUrl, String repoName, String repoOwner)
             throws MalformedURLException, HgException, CancelledException {
-        var urlParts = repoUrl.split("/");
-        if (urlParts[urlParts.length - 1].contains("?at=")) {
-            urlParts = Arrays.stream(urlParts)
-                    .filter(x -> !x.contains("?at=")).toArray(String[]::new);
-            repoUrl = String.join("/", urlParts);
-        }
-        if (repoUrl.endsWith("/")) {
-            repoUrl = repoUrl.substring(0, repoUrl.length() - 1);
-        }
-        if (repoUrl.endsWith("/src")) {
-            repoUrl = repoUrl.substring(0, repoUrl.length() - 4);
-        }
-        urlParts = Arrays.stream(repoUrl.split("/"))
-                .filter(x -> !StringUtils.isBlank(x)).toArray(String[]::new);
-        var repoOwner = urlParts[urlParts.length - 2];
-        var repoName = urlParts[urlParts.length - 1];
+//        var urlParts = repoUrl.split("/");
+//        if (urlParts[urlParts.length - 1].contains("?at=")) {
+//            urlParts = Arrays.stream(urlParts)
+//                    .filter(x -> !x.contains("?at=")).toArray(String[]::new);
+//            repoUrl = String.join("/", urlParts);
+//        }
+//        if (repoUrl.endsWith("/")) {
+//            repoUrl = repoUrl.substring(0, repoUrl.length() - 1);
+//        }
+//        if (repoUrl.endsWith("/src")) {
+//            repoUrl = repoUrl.substring(0, repoUrl.length() - 4);
+//        }
         var dirHierarchy = new DirectoryHierarchyBuilder(baseDir);
         var dir = dirHierarchy.getDirectoryFromHierarchy(repoOwner, repoName);
         var hgRepo = new HgRepoFacade();

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
@@ -1,10 +1,12 @@
 package eu.fasten.analyzer.repoclonerplugin.utils;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.tmatesoft.hg.core.HgException;
 import org.tmatesoft.hg.core.HgRepoFacade;
 import org.tmatesoft.hg.repo.HgLookup;
 import org.tmatesoft.hg.util.CancelledException;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
@@ -38,6 +40,13 @@ public class HgCloner {
         var dirHierarchy = new DirectoryHierarchyBuilder(baseDir);
         var dir = dirHierarchy.getDirectoryFromHierarchy(repoOwner, repoName);
         var hgRepo = new HgRepoFacade();
+        if (dir.exists()) {
+            try {
+                FileUtils.deleteDirectory(dir);
+            } catch (IOException e) {
+                return dir.getAbsolutePath();
+            }
+        }
         hgRepo.createCloneCommand()
                 .source(new HgLookup().detect(new URL(repoUrl)))
                 .destination(dir)

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
@@ -1,0 +1,28 @@
+package eu.fasten.analyzer.repoclonerplugin.utils;
+
+import org.tmatesoft.hg.core.HgException;
+import org.tmatesoft.hg.core.HgRepoFacade;
+import org.tmatesoft.hg.repo.HgLookup;
+import org.tmatesoft.hg.util.CancelledException;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class HgCloner {
+
+    private final String baseDir;
+
+    public HgCloner(String baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    public String cloneRepo(String repoUrl) throws MalformedURLException, HgException, CancelledException {
+        var hgRepo = new HgRepoFacade();
+        hgRepo.createCloneCommand()
+                .destination(new File("/home/mihhail/work/test"))
+                .source(new HgLookup().detect(new URL(repoUrl)))
+                .execute();
+        // TODO: Fix cloning; currently cloned repo is empty (only .hg folder)
+        return "Cloned";
+    }
+}

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
@@ -1,12 +1,13 @@
 package eu.fasten.analyzer.repoclonerplugin.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.tmatesoft.hg.core.HgException;
 import org.tmatesoft.hg.core.HgRepoFacade;
 import org.tmatesoft.hg.repo.HgLookup;
 import org.tmatesoft.hg.util.CancelledException;
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 
 public class HgCloner {
 
@@ -16,13 +17,37 @@ public class HgCloner {
         this.baseDir = baseDir;
     }
 
-    public String cloneRepo(String repoUrl) throws MalformedURLException, HgException, CancelledException {
+    public String cloneRepo(String repoUrl)
+            throws MalformedURLException, HgException, CancelledException {
+        var urlParts = repoUrl.split("/");
+        if (urlParts[urlParts.length - 1].contains("?at=")) {
+            urlParts = Arrays.stream(urlParts)
+                    .filter(x -> !x.contains("?at=")).toArray(String[]::new);
+            repoUrl = String.join("/", urlParts);
+        }
+        if (repoUrl.endsWith("/")) {
+            repoUrl = repoUrl.substring(0, repoUrl.length() - 1);
+        }
+        if (repoUrl.endsWith("/src")) {
+            repoUrl = repoUrl.substring(0, repoUrl.length() - 4);
+        }
+        urlParts = Arrays.stream(repoUrl.split("/"))
+                .filter(x -> !StringUtils.isBlank(x)).toArray(String[]::new);
+        var repoOwner = urlParts[urlParts.length - 2];
+        var repoName = urlParts[urlParts.length - 1];
+        var dirHierarchy = new DirectoryHierarchyBuilder(baseDir);
+        var dir = dirHierarchy.getDirectoryFromHierarchy(repoOwner, repoName);
         var hgRepo = new HgRepoFacade();
         hgRepo.createCloneCommand()
-                .destination(new File("/home/mihhail/work/test"))
                 .source(new HgLookup().detect(new URL(repoUrl)))
+                .destination(dir)
                 .execute();
-        // TODO: Fix cloning; currently cloned repo is empty (only .hg folder)
-        return "Cloned";
+        hgRepo.initFrom(dir);
+        var lastRevision = hgRepo.getRepository().getChangelog().getLastRevision();
+        hgRepo.createCheckoutCommand()
+                .clean(true)
+                .changeset(lastRevision)
+                .execute();
+        return dir.getAbsolutePath();
     }
 }

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnCloner.java
@@ -6,7 +6,6 @@ import org.tmatesoft.svn.core.SVNURL;
 import org.tmatesoft.svn.core.io.SVNRepositoryFactory;
 import org.tmatesoft.svn.core.wc.SVNClientManager;
 import org.tmatesoft.svn.core.wc.SVNRevision;
-import java.io.File;
 
 public class SvnCloner {
 
@@ -16,13 +15,25 @@ public class SvnCloner {
         this.baseDir = baseDir;
     }
 
-    public String cloneRepo(String repoUrl) throws SVNException {
+    /**
+     * Clones SVN Repository from repository URL.
+     *
+     * @param repoUrl   URL where repository is located
+     * @param repoName  Name of the repository
+     * @param repoOwner Owner of the repository
+     * @return Path to where repository has been cloned
+     * @throws SVNException if there was an error cloning the repository
+     */
+    public String cloneRepo(String repoUrl, String repoName, String repoOwner) throws SVNException {
         var repository = SVNRepositoryFactory.create(SVNURL.parseURIEncoded(repoUrl));
-        var latestRevision = repository.getLatestRevision();
         var updateClient = SVNClientManager.newInstance().getUpdateClient();
         updateClient.setIgnoreExternals(false);
-        updateClient.doCheckout(SVNURL.parseURIEncoded(repoUrl), new File(baseDir), SVNRevision.create(latestRevision) , SVNRevision.create(latestRevision), SVNDepth.fromRecurse(true), true);
-        // TODO: Fix SVN Repositories cloning. Currently it gives warnings and doesn't halt
-        return baseDir;
+        var url = SVNURL.parseURIEncoded(repoUrl);
+        var revision = SVNRevision.create(repository.getLatestRevision());
+        var depth = SVNDepth.fromRecurse(true);
+        var dirHierarchy = new DirectoryHierarchyBuilder(baseDir);
+        var dir = dirHierarchy.getDirectoryFromHierarchy(repoOwner, repoName);
+        updateClient.doCheckout(url, dir, revision, revision, depth, true);
+        return dir.getAbsolutePath();
     }
 }

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnCloner.java
@@ -1,0 +1,28 @@
+package eu.fasten.analyzer.repoclonerplugin.utils;
+
+import org.tmatesoft.svn.core.SVNDepth;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.SVNURL;
+import org.tmatesoft.svn.core.io.SVNRepositoryFactory;
+import org.tmatesoft.svn.core.wc.SVNClientManager;
+import org.tmatesoft.svn.core.wc.SVNRevision;
+import java.io.File;
+
+public class SvnCloner {
+
+    private final String baseDir;
+
+    public SvnCloner(String baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    public String cloneRepo(String repoUrl) throws SVNException {
+        var repository = SVNRepositoryFactory.create(SVNURL.parseURIEncoded(repoUrl));
+        var latestRevision = repository.getLatestRevision();
+        var updateClient = SVNClientManager.newInstance().getUpdateClient();
+        updateClient.setIgnoreExternals(false);
+        updateClient.doCheckout(SVNURL.parseURIEncoded(repoUrl), new File(baseDir), SVNRevision.create(latestRevision) , SVNRevision.create(latestRevision), SVNDepth.fromRecurse(true), true);
+        // TODO: Fix SVN Repositories cloning. Currently it gives warnings and doesn't halt
+        return baseDir;
+    }
+}

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.repoclonerplugin;
 
 import eu.fasten.analyzer.repoclonerplugin.utils.GitCloner;
 import eu.fasten.analyzer.repoclonerplugin.utils.HgCloner;
+import eu.fasten.analyzer.repoclonerplugin.utils.SvnCloner;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.json.JSONObject;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.tmatesoft.hg.core.HgException;
 import org.tmatesoft.hg.util.CancelledException;
+import org.tmatesoft.svn.core.SVNException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -145,11 +147,12 @@ public class RepoClonerPluginTest {
     }
 
     @Test
-    public void cloneRepoTest() throws GitAPIException, IOException, CancelledException, HgException {
+    public void cloneHgRepoTest() throws IOException, CancelledException, HgException {
         var gitCloner = Mockito.mock(GitCloner.class);
         var hgCloner = Mockito.mock(HgCloner.class);
-        Mockito.when(hgCloner.cloneRepo(Mockito.anyString())).thenReturn("test/path");
-        repoCloner.cloneRepo("https://testurl.com", gitCloner, hgCloner);
+        var svnCloner = Mockito.mock(SvnCloner.class);
+        Mockito.when(hgCloner.cloneRepo(Mockito.anyString(), "name", "owner")).thenReturn("test/path");
+        repoCloner.cloneRepo("https://testurl.com", "name", "owner", gitCloner, hgCloner, svnCloner);
         assertEquals("test/path", repoCloner.getRepoPath());
     }
 
@@ -157,8 +160,19 @@ public class RepoClonerPluginTest {
     public void cloneGitRepoTest() throws GitAPIException, IOException {
         var gitCloner = Mockito.mock(GitCloner.class);
         var hgCloner = Mockito.mock(HgCloner.class);
-        Mockito.when(gitCloner.cloneRepo(Mockito.anyString())).thenReturn("test/path");
-        repoCloner.cloneRepo("https://testurl.com/repo.git", gitCloner, hgCloner);
+        var svnCloner = Mockito.mock(SvnCloner.class);
+        Mockito.when(gitCloner.cloneRepo(Mockito.anyString(), "name", "owner")).thenReturn("test/path");
+        repoCloner.cloneRepo("https://testurl.com/repo.git", "name", "owner", gitCloner, hgCloner, svnCloner);
+        assertEquals("test/path", repoCloner.getRepoPath());
+    }
+
+    @Test
+    public void cloneSvnRepoTest() throws SVNException {
+        var gitCloner = Mockito.mock(GitCloner.class);
+        var hgCloner = Mockito.mock(HgCloner.class);
+        var svnCloner = Mockito.mock(SvnCloner.class);
+        Mockito.when(svnCloner.cloneRepo(Mockito.anyString(), "name", "owner")).thenReturn("test/path");
+        repoCloner.cloneRepo("svn://testurl.com/repo", "name", "owner", gitCloner, hgCloner, svnCloner);
         assertEquals("test/path", repoCloner.getRepoPath());
     }
 

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
@@ -19,6 +19,7 @@
 package eu.fasten.analyzer.repoclonerplugin;
 
 import eu.fasten.analyzer.repoclonerplugin.utils.GitCloner;
+import eu.fasten.analyzer.repoclonerplugin.utils.HgCloner;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.json.JSONObject;
@@ -26,6 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.tmatesoft.hg.core.HgException;
+import org.tmatesoft.hg.util.CancelledException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -142,10 +145,20 @@ public class RepoClonerPluginTest {
     }
 
     @Test
-    public void cloneRepoTest() throws GitAPIException, IOException {
+    public void cloneRepoTest() throws GitAPIException, IOException, CancelledException, HgException {
         var gitCloner = Mockito.mock(GitCloner.class);
+        var hgCloner = Mockito.mock(HgCloner.class);
+        Mockito.when(hgCloner.cloneRepo(Mockito.anyString())).thenReturn("test/path");
+        repoCloner.cloneRepo("https://testurl.com", gitCloner, hgCloner);
+        assertEquals("test/path", repoCloner.getRepoPath());
+    }
+
+    @Test
+    public void cloneGitRepoTest() throws GitAPIException, IOException {
+        var gitCloner = Mockito.mock(GitCloner.class);
+        var hgCloner = Mockito.mock(HgCloner.class);
         Mockito.when(gitCloner.cloneRepo(Mockito.anyString())).thenReturn("test/path");
-        repoCloner.cloneRepo("https://testurl.com", gitCloner);
+        repoCloner.cloneRepo("https://testurl.com/repo.git", gitCloner, hgCloner);
         assertEquals("test/path", repoCloner.getRepoPath());
     }
 

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
@@ -209,7 +209,7 @@ public class RepoClonerPluginTest {
 
     @Test
     public void versionTest() {
-        var version = "0.0.1";
+        var version = "0.1.0";
         assertEquals(version, repoCloner.version());
     }
 }

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
@@ -151,7 +151,7 @@ public class RepoClonerPluginTest {
         var gitCloner = Mockito.mock(GitCloner.class);
         var hgCloner = Mockito.mock(HgCloner.class);
         var svnCloner = Mockito.mock(SvnCloner.class);
-        Mockito.when(hgCloner.cloneRepo(Mockito.anyString(), "name", "owner")).thenReturn("test/path");
+        Mockito.when(hgCloner.cloneRepo("https://testurl.com", "name", "owner")).thenReturn("test/path");
         repoCloner.cloneRepo("https://testurl.com", "name", "owner", gitCloner, hgCloner, svnCloner);
         assertEquals("test/path", repoCloner.getRepoPath());
     }
@@ -161,7 +161,7 @@ public class RepoClonerPluginTest {
         var gitCloner = Mockito.mock(GitCloner.class);
         var hgCloner = Mockito.mock(HgCloner.class);
         var svnCloner = Mockito.mock(SvnCloner.class);
-        Mockito.when(gitCloner.cloneRepo(Mockito.anyString(), "name", "owner")).thenReturn("test/path");
+        Mockito.when(gitCloner.cloneRepo(Mockito.anyString(), Mockito.eq("name"), Mockito.eq("owner"))).thenReturn("test/path");
         repoCloner.cloneRepo("https://testurl.com/repo.git", "name", "owner", gitCloner, hgCloner, svnCloner);
         assertEquals("test/path", repoCloner.getRepoPath());
     }
@@ -171,7 +171,7 @@ public class RepoClonerPluginTest {
         var gitCloner = Mockito.mock(GitCloner.class);
         var hgCloner = Mockito.mock(HgCloner.class);
         var svnCloner = Mockito.mock(SvnCloner.class);
-        Mockito.when(svnCloner.cloneRepo(Mockito.anyString(), "name", "owner")).thenReturn("test/path");
+        Mockito.when(svnCloner.cloneRepo(Mockito.anyString(), Mockito.eq("name"), Mockito.eq("owner"))).thenReturn("test/path");
         repoCloner.cloneRepo("svn://testurl.com/repo", "name", "owner", gitCloner, hgCloner, svnCloner);
         assertEquals("test/path", repoCloner.getRepoPath());
     }

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/GitClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/GitClonerTest.java
@@ -79,4 +79,13 @@ public class GitClonerTest {
         Assertions.assertTrue(repo.exists());
         Assertions.assertTrue(repo.isDirectory());
     }
+
+    @Test
+    public void cloneRepoWithSshTest() throws GitAPIException, IOException {
+        var repo = Path.of(baseDir, "d/delors/opal").toFile();
+        var path = gitCloner.cloneRepo("git@bitbucket.org:delors/opal.git");
+        Assertions.assertEquals(repo.getAbsolutePath(), path);
+        Assertions.assertTrue(repo.exists());
+        Assertions.assertTrue(repo.isDirectory());
+    }
 }

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/GitClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/GitClonerTest.java
@@ -47,7 +47,7 @@ public class GitClonerTest {
     @Test
     public void cloneRepoTest() throws GitAPIException, IOException {
         var repo = Path.of(baseDir, "f/fasten-project/fasten").toFile();
-        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten.git");
+        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten.git", "fasten", "fasten-project");
         Assertions.assertEquals(repo.getAbsolutePath(), path);
         Assertions.assertTrue(repo.exists());
         Assertions.assertTrue(repo.isDirectory());
@@ -56,7 +56,7 @@ public class GitClonerTest {
     @Test
     public void cloneRepoWithoutExtensionTest() throws GitAPIException, IOException {
         var repo = Path.of(baseDir, "f/fasten-project/fasten").toFile();
-        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten");
+        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten", "fasten", "fasten-project");
         Assertions.assertEquals(repo.getAbsolutePath(), path);
         Assertions.assertTrue(repo.exists());
         Assertions.assertTrue(repo.isDirectory());
@@ -65,7 +65,7 @@ public class GitClonerTest {
     @Test
     public void cloneRepoWithoutExtensionWithSlashTest() throws GitAPIException, IOException {
         var repo = Path.of(baseDir, "f/fasten-project/fasten").toFile();
-        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten/");
+        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten/", "fasten", "fasten-project");
         Assertions.assertEquals(repo.getAbsolutePath(), path);
         Assertions.assertTrue(repo.exists());
         Assertions.assertTrue(repo.isDirectory());
@@ -74,7 +74,7 @@ public class GitClonerTest {
     @Test
     public void cloneRepoWithBranchTest() throws GitAPIException, IOException {
         var repo = Path.of(baseDir, "f/fasten-project/fasten").toFile();
-        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten/tree/master/");
+        var path = gitCloner.cloneRepo("https://github.com/fasten-project/fasten/tree/master/", "fasten", "fasten-project");
         Assertions.assertEquals(repo.getAbsolutePath(), path);
         Assertions.assertTrue(repo.exists());
         Assertions.assertTrue(repo.isDirectory());
@@ -83,7 +83,7 @@ public class GitClonerTest {
     @Test
     public void cloneRepoWithSshTest() throws GitAPIException, IOException {
         var repo = Path.of(baseDir, "d/delors/opal").toFile();
-        var path = gitCloner.cloneRepo("git@bitbucket.org:delors/opal.git");
+        var path = gitCloner.cloneRepo("git@bitbucket.org:delors/opal.git", "opal", "delors");
         Assertions.assertEquals(repo.getAbsolutePath(), path);
         Assertions.assertTrue(repo.exists());
         Assertions.assertTrue(repo.isDirectory());

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
@@ -1,0 +1,38 @@
+package eu.fasten.analyzer.repoclonerplugin.utils;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tmatesoft.hg.core.HgException;
+import org.tmatesoft.hg.util.CancelledException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class HgClonerTest {
+
+    private HgCloner hgCloner;
+    private String baseDir;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        this.baseDir = Files.createTempDirectory("").toString();
+        this.hgCloner = new HgCloner(baseDir);
+    }
+
+    @AfterEach
+    public void teardown() throws IOException {
+        FileUtils.deleteDirectory(Path.of(baseDir).toFile());
+    }
+
+    @Test
+    public void cloneRepoTest() {
+        try {
+            this.hgCloner.cloneRepo("https://bitbucket.org/bluefen/html5app");
+        } catch (MalformedURLException | HgException | CancelledException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HgClonerTest {
 
@@ -28,11 +30,20 @@ public class HgClonerTest {
     }
 
     @Test
-    public void cloneRepoTest() {
-        try {
-            this.hgCloner.cloneRepo("https://bitbucket.org/bluefen/html5app");
-        } catch (MalformedURLException | HgException | CancelledException e) {
-            e.printStackTrace();
-        }
+    public void cloneRepoTest() throws CancelledException, HgException, MalformedURLException {
+        var repo = Path.of(baseDir, "b", "bluefen", "html5app").toFile();
+        var result = this.hgCloner.cloneRepo("https://bitbucket.org/bluefen/html5app");
+        assertTrue(repo.exists());
+        assertTrue(repo.isDirectory());
+        assertEquals(repo.getAbsolutePath(), result);
+    }
+
+    @Test
+    public void cloneRepoWithVersionTest() throws CancelledException, HgException, MalformedURLException {
+        var repo = Path.of(baseDir, "r", "redberry", "redberry-physics").toFile();
+        var result = this.hgCloner.cloneRepo("https://bitbucket.org/redberry/redberry-physics/src/?at=v1.1");
+        assertTrue(repo.exists());
+        assertTrue(repo.isDirectory());
+        assertEquals(repo.getAbsolutePath(), result);
     }
 }

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
@@ -32,7 +32,7 @@ public class HgClonerTest {
     @Test
     public void cloneRepoTest() throws CancelledException, HgException, MalformedURLException {
         var repo = Path.of(baseDir, "b", "bluefen", "html5app").toFile();
-        var result = this.hgCloner.cloneRepo("https://bitbucket.org/bluefen/html5app");
+        var result = this.hgCloner.cloneRepo("https://bitbucket.org/bluefen/html5app", "html5app", "bluefen");
         assertTrue(repo.exists());
         assertTrue(repo.isDirectory());
         assertEquals(repo.getAbsolutePath(), result);
@@ -41,7 +41,7 @@ public class HgClonerTest {
     @Test
     public void cloneRepoWithVersionTest() throws CancelledException, HgException, MalformedURLException {
         var repo = Path.of(baseDir, "r", "redberry", "redberry-physics").toFile();
-        var result = this.hgCloner.cloneRepo("https://bitbucket.org/redberry/redberry-physics/src/?at=v1.1");
+        var result = this.hgCloner.cloneRepo("https://bitbucket.org/redberry/redberry-physics/src/?at=v1.1", "redberry-physics", "redberry");
         assertTrue(repo.exists());
         assertTrue(repo.isDirectory());
         assertEquals(repo.getAbsolutePath(), result);

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnClonerTest.java
@@ -8,6 +8,8 @@ import org.tmatesoft.svn.core.SVNException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SvnClonerTest {
 
@@ -27,11 +29,10 @@ public class SvnClonerTest {
 
     @Test
     public void cloneRepoTest() throws SVNException {
-//        var repo = Path.of(baseDir, "a", "asf", "excalibur").toFile();
-        var result = this.svnCloner.cloneRepo("https://svn.apache.org/repos/asf/excalibur");
-        System.out.println(result);
-//        assertTrue(repo.exists());
-//        assertTrue(repo.isDirectory());
-//        assertEquals(repo.getAbsolutePath(), result);
+        var repo = Path.of(baseDir, "n", "net.sf.sparta-spring-web-utils.spring-web-utils", "spring-web-utils").toFile();
+        var result = this.svnCloner.cloneRepo("svn://svn.code.sf.net/p/sparta-spring-web-utils/code/", "spring-web-utils", "net.sf.sparta-spring-web-utils.spring-web-utils");
+        assertTrue(repo.exists());
+        assertTrue(repo.isDirectory());
+        assertEquals(repo.getAbsolutePath(), result);
     }
 }

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/SvnClonerTest.java
@@ -1,0 +1,37 @@
+package eu.fasten.analyzer.repoclonerplugin.utils;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tmatesoft.svn.core.SVNException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SvnClonerTest {
+
+    private SvnCloner svnCloner;
+    private String baseDir;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        this.baseDir = Files.createTempDirectory("").toString();
+        this.svnCloner = new SvnCloner(baseDir);
+    }
+
+    @AfterEach
+    public void teardown() throws IOException {
+        FileUtils.deleteDirectory(Path.of(baseDir).toFile());
+    }
+
+    @Test
+    public void cloneRepoTest() throws SVNException {
+//        var repo = Path.of(baseDir, "a", "asf", "excalibur").toFile();
+        var result = this.svnCloner.cloneRepo("https://svn.apache.org/repos/asf/excalibur");
+        System.out.println(result);
+//        assertTrue(repo.exists());
+//        assertTrue(repo.isDirectory());
+//        assertEquals(repo.getAbsolutePath(), result);
+    }
+}


### PR DESCRIPTION
New features:
- [x] Clone with SSH links from GitHub
- [x] Clone with HTTP links from BitBucket (both Mercurial and Git repositories)
- [x] Clone with SSH links from BitBucket (both Mercurial and Git repositories)
- [x] Clone with HTTP links from Apache (Subversion repositories)
- [x] Investigate other repository hosts 

The functionality has been tested on 500 URLs from the Metadata Database and success rate was reported to be ~77%.