### PR TITLE
Improve POM Analyzer

### DIFF
--- a/analyzer/pom-analyzer/pom.xml
+++ b/analyzer/pom-analyzer/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>pom-analyzer</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>pom-analyzer</name>

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -124,7 +124,7 @@ public class POMAnalyzerPlugin extends Plugin {
                         metadataDao.setContext(DSL.using(transaction));
                         long id;
                         try {
-                            id = saveToDatabase(group + "." + artifact, version, repoUrl,
+                            id = saveToDatabase(group + ":" + artifact, version, repoUrl,
                                     commitTag, sourcesUrl, packagingType, dependencyData,
                                     metadataDao);
                         } catch (RuntimeException e) {

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -59,6 +59,7 @@ public class POMAnalyzerPlugin extends Plugin {
         private String commitTag = null;
         private String sourcesUrl = null;
         private String packagingType = null;
+        private String projectName = null;
         private boolean restartTransaction = false;
         private final int transactionRestartLimit = 3;
         private boolean processedRecord = false;
@@ -90,6 +91,7 @@ public class POMAnalyzerPlugin extends Plugin {
             commitTag = null;
             sourcesUrl = null;
             packagingType = null;
+            projectName = null;
             this.processedRecord = false;
             this.restartTransaction = false;
             logger.info("Consumed: " + record);
@@ -116,6 +118,8 @@ public class POMAnalyzerPlugin extends Plugin {
             logger.info("Generated link to Maven sources for " + product);
             packagingType = dataExtractor.extractPackagingType(group, artifact, version);
             logger.info("Extracted packaging type from " + product);
+            projectName = dataExtractor.extractProjectName(group, artifact, version);
+            logger.info("Extracted project name from " + product);
             int transactionRestartCount = 0;
             do {
                 try {
@@ -125,8 +129,8 @@ public class POMAnalyzerPlugin extends Plugin {
                         long id;
                         try {
                             id = saveToDatabase(group + ":" + artifact, version, repoUrl,
-                                    commitTag, sourcesUrl, packagingType, dependencyData,
-                                    metadataDao);
+                                    commitTag, sourcesUrl, packagingType, projectName,
+                                    dependencyData, metadataDao);
                         } catch (RuntimeException e) {
                             logger.error("Error saving data to the database: '" + product + "'", e);
                             processedRecord = false;
@@ -162,14 +166,15 @@ public class POMAnalyzerPlugin extends Plugin {
          * @param commitTag      Commit tag of the version of the artifact in the repository
          * @param sourcesUrl     Link to Maven sources Jar file
          * @param packagingType  Packaging type of the artifact
+         * @param projectName    Project name to which artifact belongs
          * @param dependencyData Dependency information from POM
          * @param metadataDao    Metadata Database Access Object
          * @return ID of the package version in the database
          */
         public long saveToDatabase(String product, String version, String repoUrl, String commitTag,
-                                   String sourcesUrl, String packagingType,
+                                   String sourcesUrl, String packagingType, String projectName,
                                    DependencyData dependencyData, MetadataDao metadataDao) {
-            final var packageId = metadataDao.insertPackage(product, "mvn", null, repoUrl, null);
+            final var packageId = metadataDao.insertPackage(product, "mvn", projectName, repoUrl, null);
             var packageVersionMetadata = new JSONObject();
             packageVersionMetadata.put("dependencyManagement",
                     (dependencyData.dependencyManagement != null)
@@ -199,6 +204,7 @@ public class POMAnalyzerPlugin extends Plugin {
             json.put("commitTag", (commitTag != null) ? commitTag : "");
             json.put("sourcesUrl", sourcesUrl);
             json.put("packagingType", packagingType);
+            json.put("projectName", (projectName != null) ? projectName : "");
             json.put("dependencyData", dependencyData.toJSON());
             return Optional.of(json.toString());
         }
@@ -225,7 +231,7 @@ public class POMAnalyzerPlugin extends Plugin {
 
         @Override
         public String version() {
-            return "0.0.1";
+            return "0.1.0";
         }
 
         @Override

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractor.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractor.java
@@ -138,8 +138,15 @@ public class DataExtractor {
                 refValue = properties.get(refValue);
                 found = true;
             } else {
-                var nodePath = "/" + refValue.replace(".", "/");
-                var node = pom.selectSingleNode(nodePath);
+                var path = refValue.replaceFirst("project\\.", "");
+                var pathParts = path.split("\\.");
+                Node node = pom;
+                for (var nodeName : pathParts) {
+                    if (node == null) {
+                        break;
+                    }
+                    node = node.selectSingleNode("./*[local-name()='" + nodeName + "']");
+                }
                 if (node != null) {
                     refValue = node.getText();
                     found = true;

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractor.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractor.java
@@ -37,9 +37,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.InvalidXPathException;
 import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
 import org.slf4j.Logger;
@@ -100,11 +103,7 @@ public class DataExtractor {
             var properties = this.resolutionMetadata.getRight().getLeft();
             var packagingNode = pom.selectSingleNode("./*[local-name()='packaging']");
             if (packagingNode != null) {
-                packaging = packagingNode.getText();
-                if (packaging.startsWith("$")
-                        && properties.containsKey(packaging.substring(2, packaging.length() - 1))) {
-                    packaging = properties.get(packaging.substring(2, packaging.length() - 1));
-                }
+                packaging = replacePropertyReferences(packagingNode.getText(), properties, pom);
             }
         } catch (DocumentException e) {
             logger.error("Error parsing POM file for: "
@@ -114,6 +113,68 @@ public class DataExtractor {
                     + groupId + ":" + artifactId + ":" + version);
         }
         return packaging;
+    }
+
+    /**
+     * Replaces all property references with their actual values.
+     *
+     * @param ref        String that can contain property references
+     * @param properties Properties extracted from the artifact
+     * @param pom        POM root element for accessing DOM tree
+     * @return String that has all property references substituted with their values
+     */
+    public String replacePropertyReferences(String ref, Map<String, String> properties, Element pom) {
+        var propertyIndexes = getPropertyReferencesIndexes(ref);
+        if (propertyIndexes == null) {
+            return ref;
+        }
+        var refBuilder = new StringBuilder();
+        var i = 0;
+        for (var property : propertyIndexes) {
+            var found = false;
+            refBuilder.append(ref, i, property[0]);
+            var refValue = ref.substring(property[0] + 2, property[1]);
+            if (properties.containsKey(refValue)) {
+                refValue = properties.get(refValue);
+                found = true;
+            } else {
+                var nodePath = "/" + refValue.replace(".", "/");
+                var node = pom.selectSingleNode(nodePath);
+                if (node != null) {
+                    refValue = node.getText();
+                    found = true;
+                }
+            }
+            if (!found) {
+                refValue = "${" + refValue + "}";
+            }
+            refBuilder.append(refValue);
+            i = property[1] + 1;
+        }
+        refBuilder.append(ref, i, ref.length());
+        return refBuilder.toString();
+    }
+
+    private int[][] getPropertyReferencesIndexes(String ref) {
+        if (!ref.contains("${")) {
+            return null;
+        }
+        var numProperties = StringUtils.countMatches(ref, "${");
+        var indexes = new int[numProperties][2];
+        int count = 0;
+        int i = 0;
+        while (count < numProperties && i < ref.length()) {
+            while (!ref.startsWith("${", i) && i < ref.length()) {
+                i++;
+            }
+            indexes[count][0] = i;
+            while (!ref.startsWith("}", i) && i < ref.length()) {
+                i++;
+            }
+            indexes[count][1] = i;
+            count++;
+        }
+        return indexes;
     }
 
     /**
@@ -127,7 +188,16 @@ public class DataExtractor {
     public String extractRepoUrl(String groupId, String artifactId, String version) {
         String repoUrl = null;
         try {
-            var scm = extractScm(groupId, artifactId, version);
+            ByteArrayInputStream pomByteStream;
+            if ((groupId + ":" + artifactId + ":" + version).equals(this.mavenCoordinate)) {
+                pomByteStream = new ByteArrayInputStream(this.pomContents.getBytes());
+            } else {
+                pomByteStream = new ByteArrayInputStream(
+                        this.downloadPom(artifactId, groupId, version)
+                                .orElseThrow(FileNotFoundException::new).getBytes());
+            }
+            var pom = new SAXReader().read(pomByteStream).getRootElement();
+            var scm = extractScm(groupId, artifactId, version, pom);
             if (scm != null) {
                 var url = scm.selectSingleNode("./*[local-name()='url']");
                 if (url != null) {
@@ -136,10 +206,7 @@ public class DataExtractor {
             }
             if (repoUrl != null) {
                 var properties = this.resolutionMetadata.getRight().getLeft();
-                if (repoUrl.startsWith("$")
-                        && properties.containsKey(repoUrl.substring(2, repoUrl.length() - 1))) {
-                    repoUrl = properties.get(repoUrl.substring(2, repoUrl.length() - 1));
-                }
+                repoUrl = replacePropertyReferences(repoUrl, properties, pom);
             }
         } catch (DocumentException e) {
             logger.error("Error parsing POM file for: "
@@ -162,17 +229,23 @@ public class DataExtractor {
     public String extractCommitTag(String groupId, String artifactId, String version) {
         String commitTag = null;
         try {
-            var scm = extractScm(groupId, artifactId, version);
+            ByteArrayInputStream pomByteStream;
+            if ((groupId + ":" + artifactId + ":" + version).equals(this.mavenCoordinate)) {
+                pomByteStream = new ByteArrayInputStream(this.pomContents.getBytes());
+            } else {
+                pomByteStream = new ByteArrayInputStream(
+                        this.downloadPom(artifactId, groupId, version)
+                                .orElseThrow(FileNotFoundException::new).getBytes());
+            }
+            var pom = new SAXReader().read(pomByteStream).getRootElement();
+            var scm = extractScm(groupId, artifactId, version, pom);
             if (scm != null) {
                 var tag = scm.selectSingleNode("./*[local-name()='tag']");
                 commitTag = (tag != null) ? tag.getText() : null;
             }
             if (commitTag != null) {
                 var properties = this.resolutionMetadata.getRight().getLeft();
-                if (commitTag.startsWith("$")
-                        && properties.containsKey(commitTag.substring(2, commitTag.length() - 1))) {
-                    commitTag = properties.get(commitTag.substring(2, commitTag.length() - 1));
-                }
+                commitTag = replacePropertyReferences(commitTag, properties, pom);
             }
         } catch (DocumentException e) {
             logger.error("Error parsing POM file for: "
@@ -184,16 +257,7 @@ public class DataExtractor {
         return commitTag;
     }
 
-    private Node extractScm(String groupId, String artifactId, String version) throws FileNotFoundException, DocumentException {
-        ByteArrayInputStream pomByteStream;
-        if ((groupId + ":" + artifactId + ":" + version).equals(this.mavenCoordinate)) {
-            pomByteStream = new ByteArrayInputStream(this.pomContents.getBytes());
-        } else {
-            pomByteStream = new ByteArrayInputStream(
-                    this.downloadPom(artifactId, groupId, version)
-                            .orElseThrow(FileNotFoundException::new).getBytes());
-        }
-        var pom = new SAXReader().read(pomByteStream).getRootElement();
+    private Node extractScm(String groupId, String artifactId, String version, Element pom) {
         if (this.resolutionMetadata == null || !this.resolutionMetadata.getLeft().equals(groupId + ":" + artifactId + ":" + version)) {
             var metadata = this.extractDependencyResolutionMetadata(pom);
             this.resolutionMetadata = new ImmutablePair<>(groupId + ":" + artifactId + ":" + version, metadata);
@@ -233,7 +297,7 @@ public class DataExtractor {
             for (int i = 0; i < parentDependencyManagements.size(); i++) {
                 var depManagement = parentDependencyManagements.get(i);
                 var resolvedDependencies = resolveDependencyVersions(depManagement.dependencies,
-                        properties, new ArrayList<>());
+                        properties, new ArrayList<>(), pom);
                 parentDependencyManagements.set(i, new DependencyManagement(resolvedDependencies));
             }
             var dependencyManagementNode = pom.selectSingleNode("./*[local-name()='dependencyManagement']");
@@ -243,7 +307,7 @@ public class DataExtractor {
                         .selectSingleNode("./*[local-name()='dependencies']");
                 var dependencies = extractDependencies(dependenciesNode);
                 dependencies = this.resolveDependencyVersions(dependencies, properties,
-                        parentDependencyManagements);
+                        parentDependencyManagements, pom);
                 dependencyManagement = new DependencyManagement(dependencies);
             } else {
                 dependencyManagement = new DependencyManagement(new ArrayList<>());
@@ -251,7 +315,7 @@ public class DataExtractor {
             var dependenciesNode = pom.selectSingleNode("./*[local-name()='dependencies']");
             var dependencies = extractDependencies(dependenciesNode);
             dependencies = this.resolveDependencyVersions(dependencies, properties,
-                    parentDependencyManagements);
+                    parentDependencyManagements, pom);
             dependencyData = new DependencyData(dependencyManagement, dependencies);
         } catch (DocumentException e) {
             logger.error("Error parsing POM file for: "
@@ -265,7 +329,8 @@ public class DataExtractor {
 
     private List<Dependency> resolveDependencyVersions(List<Dependency> dependencies,
                                                        Map<String, String> properties,
-                                                       List<DependencyManagement> depManagements) {
+                                                       List<DependencyManagement> depManagements,
+                                                       Element pom) {
         var resolvedDependencies = new ArrayList<Dependency>();
         for (var dependency : dependencies) {
             if (dependency.versionConstraints.get(0).lowerBound.equals("*")) {
@@ -289,10 +354,9 @@ public class DataExtractor {
             } else if (dependency.versionConstraints.get(0).lowerBound.startsWith("$")) {
                 var property = dependency.versionConstraints.get(0).lowerBound;
                 var version = "";
-                for (var entry : properties.entrySet()) {
-                    if (entry.getKey().equals(property.substring(2, property.length() - 1))) {
-                        version = entry.getValue();
-                    }
+                var value = replacePropertyReferences(property, properties, pom);
+                if (!value.equals(property)) {
+                    version = value;
                 }
                 resolvedDependencies.add(new Dependency(
                         dependency.artifactId,

--- a/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPluginTest.java
+++ b/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPluginTest.java
@@ -50,6 +50,7 @@ public class POMAnalyzerPluginTest {
         var repoUrl = "http://github.com/junit-team/junit/tree/master";
         var sourcesUrl = "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar";
         var packagingType = "jar";
+        var projectName = "JUnit";
         var dependencyData = DependencyData.fromJSON(new JSONObject("{\n" +
                 "   \"dependencyManagement\":{\n" +
                 "      \"dependencies\":[\n" +
@@ -88,6 +89,7 @@ public class POMAnalyzerPluginTest {
         assertEquals(repoUrl, json.getString("repoUrl"));
         assertEquals(sourcesUrl, json.getString("sourcesUrl"));
         assertEquals(packagingType, json.getString("packagingType"));
+        assertEquals(projectName, json.getString("projectName"));
         assertEquals(dependencyData, DependencyData.fromJSON(json.getJSONObject("dependencyData")));
     }
 
@@ -97,6 +99,7 @@ public class POMAnalyzerPluginTest {
         var repoUrl = "http://github.com/junit-team/junit/tree/master";
         var sourcesUrl = "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar";
         var packagingType = "jar";
+        var projectName = "JUnit";
         var dependencyData = DependencyData.fromJSON(new JSONObject("{\n" +
                 "   \"dependencyManagement\":{\n" +
                 "      \"dependencies\":[\n" +
@@ -141,7 +144,7 @@ public class POMAnalyzerPluginTest {
         final var dependencyId = 16L;
         Mockito.when(metadataDao.insertPackage("org.hamcrest.hamcrest-core", "mvn", null, null, null))
                 .thenReturn(dependencyId);
-        var result = pomAnalyzer.saveToDatabase("junit.junit", "4.12", repoUrl, commitTag, sourcesUrl, packagingType, dependencyData, metadataDao);
+        var result = pomAnalyzer.saveToDatabase("junit.junit", "4.12", repoUrl, commitTag, sourcesUrl, packagingType, projectName, dependencyData, metadataDao);
         assertEquals(packageVersionId, result);
     }
 
@@ -179,7 +182,7 @@ public class POMAnalyzerPluginTest {
 
     @Test
     public void versionTest() {
-        var version = "0.0.1";
+        var version = "0.1.0";
         assertEquals(version, pomAnalyzer.version());
     }
 }

--- a/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
+++ b/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
@@ -19,9 +19,13 @@
 package eu.fasten.analyzer.pomanalyzer.pom;
 
 import eu.fasten.analyzer.pomanalyzer.pom.data.DependencyData;
+import org.dom4j.DocumentException;
+import org.dom4j.io.SAXReader;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DataExtractorTest {
@@ -287,5 +291,52 @@ public class DataExtractorTest {
         assertEquals(expectedCommitTag, actualCommitTag);
         assertEquals(expectedSourcesUrl, actualSourcesUrl);
         assertEquals(expectedPackagingType, actualPackagingType);
+    }
+
+//    @Test
+//    public void replaceDomTreeReferenceTest() throws DocumentException {
+//        var name = "fasten";
+//        var xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">" +
+//                    "<name>" + name + "</name>" +
+//                "</project>";
+//        var value = dataExtractor.replacePropertyReferences("${project.name}", new HashMap<>(), new SAXReader().read(new ByteArrayInputStream(xml.getBytes())).getRootElement());
+//        assertEquals(name, value);
+//    }
+
+    @Test
+    public void replaceSubStringReferenceTest() throws DocumentException {
+        var xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">" + "</project>";
+        var map = new HashMap<String, String>();
+        map.put("name", "FASTEN");
+        var value = dataExtractor.replacePropertyReferences("Welcome to ${name} Project!", map, new SAXReader().read(new ByteArrayInputStream(xml.getBytes())).getRootElement());
+        assertEquals("Welcome to FASTEN Project!", value);
+    }
+
+    @Test
+    public void replaceMultipleSubStringReferenceTest() throws DocumentException {
+        var xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">" + "</project>";
+        var map = new HashMap<String, String>();
+        map.put("i", "1");
+        map.put("j", "2");
+        var value = dataExtractor.replacePropertyReferences("a${i}b${j}c", map, new SAXReader().read(new ByteArrayInputStream(xml.getBytes())).getRootElement());
+        assertEquals("a1b2c", value);
+    }
+
+    @Test
+    public void noReferenceTest() throws DocumentException {
+        var xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">" + "</project>";
+        var map = new HashMap<String, String>();
+        var str = "hello world";
+        var value = dataExtractor.replacePropertyReferences(str, map, new SAXReader().read(new ByteArrayInputStream(xml.getBytes())).getRootElement());
+        assertEquals(str, value);
+    }
+
+    @Test
+    public void noReferenceValueTest() throws DocumentException {
+        var xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">" + "</project>";
+        var map = new HashMap<String, String>();
+        var str = "hello ${world}";
+        var value = dataExtractor.replacePropertyReferences(str, map, new SAXReader().read(new ByteArrayInputStream(xml.getBytes())).getRootElement());
+        assertEquals(str, value);
     }
 }

--- a/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
+++ b/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
@@ -293,15 +293,15 @@ public class DataExtractorTest {
         assertEquals(expectedPackagingType, actualPackagingType);
     }
 
-//    @Test
-//    public void replaceDomTreeReferenceTest() throws DocumentException {
-//        var name = "fasten";
-//        var xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">" +
-//                    "<name>" + name + "</name>" +
-//                "</project>";
-//        var value = dataExtractor.replacePropertyReferences("${project.name}", new HashMap<>(), new SAXReader().read(new ByteArrayInputStream(xml.getBytes())).getRootElement());
-//        assertEquals(name, value);
-//    }
+    @Test
+    public void replaceDomTreeReferenceTest() throws DocumentException {
+        var name = "fasten";
+        var xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">" +
+                    "<name>" + name + "</name>" +
+                "</project>";
+        var value = dataExtractor.replacePropertyReferences("${project.name}", new HashMap<>(), new SAXReader().read(new ByteArrayInputStream(xml.getBytes())).getRootElement());
+        assertEquals(name, value);
+    }
 
     @Test
     public void replaceSubStringReferenceTest() throws DocumentException {

--- a/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
+++ b/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
@@ -286,11 +286,14 @@ public class DataExtractorTest {
         var actualSourcesUrl = dataExtractor.generateMavenSourcesLink("junit", "junit", "4.12");
         var expectedPackagingType = "jar";
         var actualPackagingType = dataExtractor.extractPackagingType("junit", "junit", "4.12");
+        var expectedProjectName = "JUnit";
+        var actualProjectName = dataExtractor.extractProjectName("junit", "junit", "4.12");
         assertEquals(expectedRepoUrl, actualRepoUrl);
         assertEquals(expectedDependencyData, actualDependencyData);
         assertEquals(expectedCommitTag, actualCommitTag);
         assertEquals(expectedSourcesUrl, actualSourcesUrl);
         assertEquals(expectedPackagingType, actualPackagingType);
+        assertEquals(expectedProjectName, actualProjectName);
     }
 
     @Test

--- a/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
+++ b/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/pom/DataExtractorTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DataExtractorTest {
 
@@ -294,6 +295,12 @@ public class DataExtractorTest {
         assertEquals(expectedSourcesUrl, actualSourcesUrl);
         assertEquals(expectedPackagingType, actualPackagingType);
         assertEquals(expectedProjectName, actualProjectName);
+    }
+
+    @Test
+    public void noProjectNameTest() {
+        var result = dataExtractor.extractProjectName("com.alicp.jetcache", "jetcache-redis-lettuce", "2.5.13");
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR improves the functionality of the POM Analyzer, fixes a bug with duplicate package names in the database, and adds extractions of project names.

## Motivation and context
### Propery references
The most significant improvement is related to property references. Previously there were three problems which prevented a lot of references to be replaced with their actual values:
1) Could not resolve substring references like `hello ${reference}!`
2) Could not resolve multiple references in one string (relates to 1) like `abc ${reference1} de ${reference2}`
3) Could not resolve references to DOM tree of `pom.xml` file like `${project.artifactId}`
This PR fixes all 3 above-mentioned problems, thus allowing for resolution of quite complex strings like `https://github.com/${project.groupId}/${project.artifactId}` to their actual value of for example`https://github.com/junit/junit` even if no properties are specified in the `pom.xml` file.

### Duplicate package names bug
POM Analyzer was saving package names as `<groupId>.<artifactId>` while OPAL renamed it `<groupId>:<artifactId>` and Metadata plugin was saving it as received from OPAL (with `:`), thus causing a lot of records in the database to be different when they are actually the same. For example, both `junit:junit` and `junit.junit` would be saved in the database while there should be only `junit:junit`.

### Extracting project names
The metadata database has a `packages.project_name` attribute which was always `null` because we did not have this information. In this PR POM Analyzer also extracts `project.name` (if it is present) from `pom.xml` and inserts it in the database along with producing it to Kafka topic.

## Testing
Changes were quite isolated thus were tested with unit testing using JUnit.

## Task list  
- [x] Resolution of multiple substring property references
- [x] Resolution of DOM tree property references
- [x] Change `.` to `:` when saving package name to the database
- [x] Extract and save project name
