### PR TITLE
Improve RepoCloner

### DIFF
--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/Main.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/Main.java
@@ -18,8 +18,11 @@
 
 package eu.fasten.analyzer.repoclonerplugin;
 
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.Scanner;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.slf4j.Logger;
@@ -37,6 +40,36 @@ public class Main implements Runnable {
                     + "groupId and optional version")
     String jsonFile;
 
+    @CommandLine.Option(names = {"-l", "--url-list"},
+            paramLabel = "FILE_WITH_URLS",
+            description = "Path to file which contains a list of repository URLs to clone")
+    String urlsFile;
+
+    @CommandLine.Option(names = {"-u", "--url"},
+            paramLabel = "REPO_URL",
+            description = "URL of the repository to clone")
+    String repoUrl;
+
+
+    @CommandLine.Option(names = {"-a", "--artifactId"},
+            paramLabel = "ARTIFACT",
+            description = "artifactId of the Maven coordinate",
+            defaultValue = "n/a")
+    String artifact;
+
+    @CommandLine.Option(names = {"-g", "--groupId"},
+            paramLabel = "GROUP",
+            description = "groupId of the Maven coordinate",
+            defaultValue = "n/a")
+    String group;
+
+    @CommandLine.Option(names = {"-v", "--version"},
+            paramLabel = "VERSION",
+            description = "version of the Maven coordinate",
+            defaultValue = "n/a")
+    String version;
+
+
     @CommandLine.Option(names = {"-d", "--base-dir"},
             paramLabel = "Directory",
             description = "Path to base directory where repository hierarchy will be created")
@@ -51,16 +84,82 @@ public class Main implements Runnable {
     public void run() {
         var repoCloner = new RepoClonerPlugin.RepoCloner();
         repoCloner.setBaseDir(baseDir);
-        final FileReader reader;
-        try {
-            reader = new FileReader(jsonFile);
-        } catch (FileNotFoundException e) {
-            logger.error("Could not find input JSON " + jsonFile, e);
+        if (repoUrl != null) {
+            var json = new JSONObject();
+            json.put("artifactId", artifact);
+            json.put("groupId", group);
+            json.put("version", version);
+            json.put("repoUrl", repoUrl);
+            repoCloner.consume(json.toString());
+            var resultOptional = repoCloner.produce();
+            resultOptional.ifPresent(System.out::println);
             return;
         }
-        final JSONObject json = new JSONObject(new JSONTokener(reader));
-        repoCloner.consume(json.toString());
-        var resultOptional = repoCloner.produce();
-        resultOptional.ifPresent(System.out::println);
+        if (jsonFile != null) {
+            final FileReader reader;
+            try {
+                reader = new FileReader(jsonFile);
+            } catch (FileNotFoundException e) {
+                logger.error("Could not find input JSON " + jsonFile, e);
+                return;
+            }
+            final JSONObject json = new JSONObject(new JSONTokener(reader));
+            repoCloner.consume(json.toString());
+            var resultOptional = repoCloner.produce();
+            resultOptional.ifPresent(System.out::println);
+            return;
+        }
+        if (urlsFile != null) {
+            Scanner reader;
+            try {
+                reader = new Scanner(new FileInputStream(urlsFile));
+            } catch (FileNotFoundException e) {
+                logger.error("Could not find input file " + urlsFile, e);
+                return;
+            }
+            var successful = 0F;
+            var total = 0F;
+            var failedUrls = new ArrayList<String>();
+            var emptyOutputUrls = new ArrayList<String>();
+            while (reader.hasNextLine()) {
+                total++;
+                var url = reader.nextLine();
+                var json = new JSONObject();
+                json.put("artifactId", String.valueOf((int) total % 10));
+                json.put("groupId", String.valueOf((int) total % 10));
+                json.put("version", String.valueOf((int) total % 10));
+                json.put("repoUrl", url);
+                repoCloner.consume(json.toString());
+                var resultOptional = repoCloner.produce();
+                if (resultOptional.isPresent()) {
+                    var result = new JSONObject(resultOptional.get());
+                    if (result.getString("repoPath").isEmpty()) {
+                        logger.error("Could not clone repo from URL #" + (int) total + ": " + url);
+                        failedUrls.add(url);
+                    } else {
+                        successful++;
+                        logger.info("Cloned repository from URL #" + (int) total + ": " + url);
+                    }
+                } else {
+                    logger.error("No output from URL #" + (int) total + ": " + url);
+                    emptyOutputUrls.add(url);
+                }
+                logger.info("Current success rate is " + successful / total);
+            }
+            logger.info("==================================================");
+            logger.info("Finished cloning repositories");
+            logger.info("Final success rate is " + successful / total);
+            logger.info("==================================================");
+            if (failedUrls.size() > 0) {
+                logger.info("Failed URLs:");
+                failedUrls.forEach(logger::info);
+            }
+            if (emptyOutputUrls.size() > 0) {
+                logger.info("URLs that produced empty output:");
+                emptyOutputUrls.forEach(logger::info);
+            }
+            return;
+        }
+        System.err.println("Invalid arguments!");
     }
 }

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/GitCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/GitCloner.java
@@ -20,7 +20,6 @@ package eu.fasten.analyzer.repoclonerplugin.utils;
 
 import java.io.IOException;
 import java.util.Arrays;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/utils/HgCloner.java
@@ -21,18 +21,6 @@ public class HgCloner {
 
     public String cloneRepo(String repoUrl, String repoName, String repoOwner)
             throws MalformedURLException, HgException, CancelledException {
-//        var urlParts = repoUrl.split("/");
-//        if (urlParts[urlParts.length - 1].contains("?at=")) {
-//            urlParts = Arrays.stream(urlParts)
-//                    .filter(x -> !x.contains("?at=")).toArray(String[]::new);
-//            repoUrl = String.join("/", urlParts);
-//        }
-//        if (repoUrl.endsWith("/")) {
-//            repoUrl = repoUrl.substring(0, repoUrl.length() - 1);
-//        }
-//        if (repoUrl.endsWith("/src")) {
-//            repoUrl = repoUrl.substring(0, repoUrl.length() - 4);
-//        }
         var dirHierarchy = new DirectoryHierarchyBuilder(baseDir);
         var dir = dirHierarchy.getDirectoryFromHierarchy(repoOwner, repoName);
         var hgRepo = new HgRepoFacade();

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
@@ -114,8 +114,8 @@ public class RepoClonerPluginTest {
         var hgCloner = Mockito.mock(HgCloner.class);
         var svnCloner = Mockito.mock(SvnCloner.class);
         Mockito.when(hgCloner.cloneRepo("https://testurl.com", "name", "owner")).thenReturn("test/path");
-        repoCloner.cloneRepo("https://testurl.com", "name", "owner", gitCloner, hgCloner, svnCloner);
-        assertEquals("test/path", repoCloner.getRepoPath());
+        var path = repoCloner.cloneRepo("https://testurl.com", "name", "owner", gitCloner, hgCloner, svnCloner);
+        assertEquals("test/path", path);
     }
 
     @Test
@@ -124,8 +124,8 @@ public class RepoClonerPluginTest {
         var hgCloner = Mockito.mock(HgCloner.class);
         var svnCloner = Mockito.mock(SvnCloner.class);
         Mockito.when(gitCloner.cloneRepo(Mockito.anyString(), Mockito.eq("name"), Mockito.eq("owner"))).thenReturn("test/path");
-        repoCloner.cloneRepo("https://testurl.com/repo.git", "name", "owner", gitCloner, hgCloner, svnCloner);
-        assertEquals("test/path", repoCloner.getRepoPath());
+        var path = repoCloner.cloneRepo("https://testurl.com/repo.git", "name", "owner", gitCloner, hgCloner, svnCloner);
+        assertEquals("test/path", path);
     }
 
     @Test
@@ -134,8 +134,8 @@ public class RepoClonerPluginTest {
         var hgCloner = Mockito.mock(HgCloner.class);
         var svnCloner = Mockito.mock(SvnCloner.class);
         Mockito.when(svnCloner.cloneRepo(Mockito.anyString(), Mockito.eq("name"), Mockito.eq("owner"))).thenReturn("test/path");
-        repoCloner.cloneRepo("svn://testurl.com/repo", "name", "owner", gitCloner, hgCloner, svnCloner);
-        assertEquals("test/path", repoCloner.getRepoPath());
+        var path = repoCloner.cloneRepo("svn://testurl.com/repo", "name", "owner", gitCloner, hgCloner, svnCloner);
+        assertEquals("test/path", path);
     }
 
     @Test

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPluginTest.java
@@ -65,6 +65,8 @@ public class RepoClonerPluginTest {
                 "\t\t\"artifactId\": \"fasten\",\n" +
                 "\t\t\"groupId\": \"fasten-project\",\n" +
                 "\t\t\"version\": \"1\",\n" +
+                "\t\t\"commitTag\": \"123\",\n" +
+                "\t\t\"sourcesUrl\": \"someURL\",\n" +
                 "\t\t\"repoUrl\": \"https://github.com/fasten-project/fasten.git\"\n" +
                 "\t}\n" +
                 "}");
@@ -74,29 +76,9 @@ public class RepoClonerPluginTest {
                 "\t\"artifactId\": \"fasten\",\n" +
                 "\t\"groupId\": \"fasten-project\",\n" +
                 "\t\"version\": \"1\",\n" +
-                "\t\"repoPath\": \"" + repoPath + "\"\n" +
-                "}").toString();
-        var actual = repoCloner.produce().isPresent() ? repoCloner.produce().get() : null;
-        assertEquals(expected, actual);
-        assertTrue(new File(repoPath).exists());
-        assertTrue(new File(repoPath).isDirectory());
-    }
-
-    @Test
-    public void consumeWithoutVersionTest() {
-        var json = new JSONObject("{\n" +
-                "\t\"payload\": {\n" +
-                "\t\t\"artifactId\": \"fasten\",\n" +
-                "\t\t\"groupId\": \"fasten-project\",\n" +
-                "\t\t\"repoUrl\": \"https://github.com/fasten-project/fasten.git\"\n" +
-                "\t}\n" +
-                "}");
-        repoCloner.consume(json.toString());
-        var repoPath = Paths.get(baseDir, "f", "fasten-project", "fasten").toAbsolutePath().toString();
-        var expected = new JSONObject("{\n" +
-                "\t\"artifactId\": \"fasten\",\n" +
-                "\t\"groupId\": \"fasten-project\",\n" +
-                "\t\"repoPath\": \"" + repoPath + "\"\n" +
+                "\t\"repoPath\": \"" + repoPath + "\",\n" +
+                "\t\"commitTag\": \"123\",\n" +
+                "\t\"sourcesUrl\": \"someURL\"\n" +
                 "}").toString();
         var actual = repoCloner.produce().isPresent() ? repoCloner.produce().get() : null;
         assertEquals(expected, actual);
@@ -117,33 +99,13 @@ public class RepoClonerPluginTest {
         var expected = new JSONObject("{\n" +
                 "\t\"artifactId\": \"fasten\",\n" +
                 "\t\"groupId\": \"fasten-project\",\n" +
-                "\t\"version\": \"1\"\n" +
+                "\t\"version\": \"1\",\n" +
+                "\t\"repoPath\": \"\",\n" +
+                "\t\"commitTag\": \"\",\n" +
+                "\t\"sourcesUrl\": \"\"\n" +
                 "}").toString();
         var actual = repoCloner.produce().isPresent() ? repoCloner.produce().get() : null;
         assertEquals(expected, actual);
-    }
-
-    @Test
-    public void consumeOnlyCoordinateWithoutVersionTest() {
-        var json = new JSONObject("{\n" +
-                "\t\"payload\": {\n" +
-                "\t\t\"artifactId\": \"fasten\",\n" +
-                "\t\t\"groupId\": \"fasten-project\",\n" +
-                "\t}\n" +
-                "}");
-        repoCloner.consume(json.toString());
-        var expected = new JSONObject("{\n" +
-                "\t\"artifactId\": \"fasten\",\n" +
-                "\t\"groupId\": \"fasten-project\",\n" +
-                "}").toString();
-        var actual = repoCloner.produce().isPresent() ? repoCloner.produce().get() : null;
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void produceWithoutConsumeTest() {
-        var optionalResult = repoCloner.produce();
-        assertTrue(optionalResult.isEmpty());
     }
 
     @Test

--- a/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
+++ b/analyzer/repo-cloner-plugin/src/test/java/eu/fasten/analyzer/repoclonerplugin/utils/HgClonerTest.java
@@ -31,17 +31,8 @@ public class HgClonerTest {
 
     @Test
     public void cloneRepoTest() throws CancelledException, HgException, MalformedURLException {
-        var repo = Path.of(baseDir, "b", "bluefen", "html5app").toFile();
-        var result = this.hgCloner.cloneRepo("https://bitbucket.org/bluefen/html5app", "html5app", "bluefen");
-        assertTrue(repo.exists());
-        assertTrue(repo.isDirectory());
-        assertEquals(repo.getAbsolutePath(), result);
-    }
-
-    @Test
-    public void cloneRepoWithVersionTest() throws CancelledException, HgException, MalformedURLException {
-        var repo = Path.of(baseDir, "r", "redberry", "redberry-physics").toFile();
-        var result = this.hgCloner.cloneRepo("https://bitbucket.org/redberry/redberry-physics/src/?at=v1.1", "redberry-physics", "redberry");
+        var repo = Path.of(baseDir, "t", "test", "repo").toFile();
+        var result = this.hgCloner.cloneRepo("http://channelfinder.hg.sourceforge.net/hgweb/channelfinder/ChannelFinderAPI", "repo", "test");
         assertTrue(repo.exists());
         assertTrue(repo.isDirectory());
         assertEquals(repo.getAbsolutePath(), result);


### PR DESCRIPTION
## Description
This PR improves RepoCloner even further. It copies `commitTag` and `sourcesUrl` from `fasten.POMAnalyzer.out` (RepoCloner's input) to `fasten.RepoCloner.out` (RepoCloner's output) as requested by partners. It also improves the error handling of the plugin.

## Motivation and context
resolves #58 
fixes #60 

## Testing
Mainly used unit testing with JUnit and Mockito, but also performed trial run on 500 repository URLs taken from FASTEN Metadata database. The success rate remained the same (about 77%) however the speed increased by the factor of 2.2 (around 330 repositories per hour).

## Task list  
- [x] Copy `commitTag` and `sourcesUrl` to the output
- [x] Improve error handling

## Additional context
Previously RepoCloner had a speed of around 150 cloned repositories per hour and an error rate of around 77%.
