### PR TITLE
Improve error handling in OPAL plugin

### DIFF
--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>javacg-opal</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>javacg-opal</name>

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -148,7 +148,7 @@ public class OPALPlugin extends Plugin {
 
         @Override
         public String version() {
-            return "0.1.0";
+            return "0.1.1";
         }
     }
 }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/CallGraphConstructor.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/CallGraphConstructor.java
@@ -37,12 +37,8 @@ import org.opalj.tac.cg.CHACallGraphKey$;
 import org.opalj.tac.cg.CallGraph;
 import org.opalj.tac.cg.RTACallGraphKey$;
 import org.opalj.tac.cg.TypeBasedPointsToCallGraphKey$;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CallGraphConstructor {
-
-    private static final Logger logger = LoggerFactory.getLogger(CallGraphConstructor.class);
 
     private final Project<URL> project;
     private final CallGraph callGraph;
@@ -57,8 +53,6 @@ public class CallGraphConstructor {
     public CallGraphConstructor(final File file, final String mainClass, final String algorithm)
             throws OPALException {
         try {
-
-            logger.debug("Free heap before generating a call graph with Opal: {}", Runtime.getRuntime().freeMemory());
             OPALLogger.updateLogger(GlobalLogContext$.MODULE$,
                     new ConsoleOPALLogger(false, Fatal$.MODULE$));
 

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
@@ -193,9 +193,11 @@ public class MavenCoordinate {
                     }
                 }
             }
-            return jar.orElseThrow(() -> new FileNotFoundException(
-                    mavenCoordinate.toURL(mavenCoordinate.getMavenRepos().get(0)) + " | "
-                            + mavenCoordinate.getPackaging()));
+            throw new FileNotFoundException(
+                    mavenCoordinate.toURL(mavenCoordinate.getMavenRepos().size() > 0
+                            ? mavenCoordinate.getMavenRepos().get(0)
+                            : "no repos specified") + " | "
+                            + mavenCoordinate.getPackaging());
         }
 
         /**

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
@@ -27,7 +27,6 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
@@ -63,13 +63,10 @@ public class PartialCallGraph {
 
         try {
             logger.info("Creating internal CHA");
-            logger.debug("Free heap before creating internal CHA: {}", Runtime.getRuntime().freeMemory());
             final var cha = createInternalCHA(constructor.getProject());
 
             logger.info("Creating graph with external CHA");
-            logger.debug("Free heap before creating external CHA: {}", Runtime.getRuntime().freeMemory());
             createGraphWithExternalCHA(constructor.getCallGraph(), cha);
-            logger.debug("Free heap after coordinate processing: {}", Runtime.getRuntime().freeMemory());
 
             this.nodeCount = cha.getNodeCount();
             this.classHierarchy = cha.asURIHierarchy(constructor.getProject().classHierarchy());

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
@@ -111,7 +111,7 @@ public class PartialCallGraph {
             final MavenCoordinate coordinate, final String mainClass,
             final String algorithm, final long timestamp)
             throws FileNotFoundException, OPALException {
-        final var file = new MavenCoordinate.MavenResolver().downloadJar(coordinate);
+        final var file = new MavenCoordinate.MavenResolver().downloadArtifact(coordinate);
 
         logger.info("OPAL is analysing the artifact");
         final var opalCG = new CallGraphConstructor(file, mainClass, algorithm);

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinateTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinateTest.java
@@ -80,7 +80,7 @@ class MavenCoordinateTest {
         coordinate.setMavenRepos(new ArrayList<>());
         var resolver = new MavenCoordinate.MavenResolver();
 
-        assertThrows(FileNotFoundException.class, () -> resolver.downloadJar(coordinate));
+        assertThrows(FileNotFoundException.class, () -> resolver.downloadArtifact(coordinate));
     }
 
     @Test
@@ -89,7 +89,7 @@ class MavenCoordinateTest {
         coordinate.setMavenRepos(new ArrayList<>(Collections.singletonList("repo")));
         var resolver = new MavenCoordinate.MavenResolver();
 
-        assertThrows(FileNotFoundException.class, () -> resolver.downloadJar(coordinate));
+        assertThrows(FileNotFoundException.class, () -> resolver.downloadArtifact(coordinate));
     }
 
     @Test
@@ -98,6 +98,6 @@ class MavenCoordinateTest {
         coordinate.setMavenRepos(new ArrayList<>(Collections.singletonList("repo")));
         var resolver = new MavenCoordinate.MavenResolver();
 
-        assertThrows(FileNotFoundException.class, () -> resolver.downloadJar(coordinate));
+        assertThrows(FileNotFoundException.class, () -> resolver.downloadArtifact(coordinate));
     }
 }

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinateTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinateTest.java
@@ -19,6 +19,7 @@
 package eu.fasten.analyzer.javacgopal.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
@@ -99,5 +100,13 @@ class MavenCoordinateTest {
         var resolver = new MavenCoordinate.MavenResolver();
 
         assertThrows(FileNotFoundException.class, () -> resolver.downloadArtifact(coordinate));
+    }
+
+    @Test
+    void downloadJarWrongPackaging() throws FileNotFoundException {
+        var coordinate = new MavenCoordinate("org.slf4j", "slf4j-api", "1.7.30", "wrongPackagingType");
+        var resolver = new MavenCoordinate.MavenResolver();
+
+        assertNotNull(resolver.downloadArtifact(coordinate));
     }
 }

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraphTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraphTest.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.javacgopal.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import eu.fasten.analyzer.javacgopal.data.exceptions.OPALException;
@@ -146,6 +147,36 @@ class PartialCallGraphTest {
     @Test
     void getNodeCount() {
         assertEquals(4, singleCallCG.getNodeCount());
+    }
+
+    @Test
+    void OPALExceptionInConstructorNotFromOpalTest() {
+        var constructor = Mockito.mock(CallGraphConstructor.class);
+        var exception = new RuntimeException("some message");
+        exception.setStackTrace(new StackTraceElement[]{new StackTraceElement("some.class", "some method", "some file", 10)});
+        Mockito.when(constructor.getProject()).thenThrow(exception);
+
+        assertThrows(RuntimeException.class, () -> new PartialCallGraph(constructor));
+    }
+
+    @Test
+    void OPALExceptionInConstructorFromOpalTest() {
+        var constructor = Mockito.mock(CallGraphConstructor.class);
+        var exception = Mockito.mock(RuntimeException.class);
+        Mockito.when(exception.getStackTrace()).thenReturn(new StackTraceElement[]{new StackTraceElement("org.opalj", "some method", "some file", 10)});
+        Mockito.when(constructor.getProject()).thenThrow(exception);
+
+        assertThrows(OPALException.class, () -> new PartialCallGraph(constructor));
+    }
+
+    @Test
+    void OPALExceptionInConstructorEmptyStacktraceTest() {
+        var constructor = Mockito.mock(CallGraphConstructor.class);
+        var exception = Mockito.mock(RuntimeException.class);
+        Mockito.when(exception.getStackTrace()).thenReturn(new StackTraceElement[]{});
+        Mockito.when(constructor.getProject()).thenThrow(exception);
+
+        assertThrows(RuntimeException.class, () -> new PartialCallGraph(constructor));
     }
 
     @Test


### PR DESCRIPTION
## Description
Improvements to the error handling of OPAL plugin. Now the plugin will throw more specific exceptions which simplifies debugging. It will also support multiple Maven repositories to download artifacts from.

## Motivation and context
After running the OPAL plugin against the full Maven ecosystem ~50K IO exception were classified as FileNotFoundException, which skewed the plugin statistics. 
closes #57 

## Testing
As MavenCoordinate is the most affected by changes class. part of its new functionality will be tested using Mockito, and the other part will require downloading actual artifacts from Maven Central. 

## Task list  
- [x] Throw RuntimeException whenever an artifact is available, but couldn't be downloaded, written, or read
- [x] Allow to pass multiple Maven repositories to download artifacts from