### PR TITLE
Fix NullPointerException in OPAL plugin

### DIFF
--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>javacg-opal</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>javacg-opal</name>

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -148,7 +148,7 @@ public class OPALPlugin extends Plugin {
 
         @Override
         public String version() {
-            return "0.1.1";
+            return "0.1.2";
         }
     }
 }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/analysis/OPALClassHierarchy.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/analysis/OPALClassHierarchy.java
@@ -286,13 +286,15 @@ public class OPALClassHierarchy {
      * @return call site
      */
     public Map<Object, Object> getCallSite(final Method source, final Integer pc) {
-        final var instruction = source.instructionsOption().get()[pc].mnemonic();
-        final var receiverType = OPALMethod.getTypeURI(source.instructionsOption().get()[pc]
+        final var instruction = source.instructionsOption().get()[pc];
+        final var receiverType = instruction == null
+                ? "notFound"
+                : OPALMethod.getTypeURI(source.instructionsOption().get()[pc]
                 .asMethodInvocationInstruction().declaringClass());
 
         var callSite = new HashMap<>();
         callSite.put("line", source.body().get().lineNumber(pc).getOrElse(() -> 404));
-        callSite.put("type", instruction);
+        callSite.put("type", instruction == null ? "notFound" : instruction.mnemonic());
         callSite.put("receiver", receiverType.toString());
 
         return Map.of(pc.toString(), callSite);

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/analysis/OPALClassHierarchyTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/analysis/OPALClassHierarchyTest.java
@@ -716,4 +716,27 @@ class OPALClassHierarchyTest {
         assertEquals("/some.package/typeName", ((HashMap<String, Object>) callSite.get("0")).get("receiver"));
         assertEquals("testType", ((HashMap<String, Object>) callSite.get("0")).get("type"));
     }
+
+    @Test
+    void getCallSiteNotFoundInstruction() {
+        var methodInvocationInstruction = Mockito.mock(MethodInvocationInstruction.class);
+        Mockito.when(methodInvocationInstruction.declaringClass()).thenReturn(type);
+
+        var code = Mockito.mock(Code.class);
+        Mockito.when(code.lineNumber(0)).thenReturn(Option.apply(30));
+
+        var source = Mockito.mock(Method.class);
+        Mockito.when(source.instructionsOption())
+                .thenReturn(Option.apply(new Instruction[]{null}));
+        Mockito.when(source.body()).thenReturn(Option.apply(code));
+
+        var classHierarchy = new OPALClassHierarchy(new HashMap<>(), new HashMap<>(), 5);
+        var callSite = classHierarchy.getCallSite(source, 0);
+
+        assertNotNull(callSite);
+
+        assertEquals(30, ((HashMap<String, Object>) callSite.get("0")).get("line"));
+        assertEquals("notFound", ((HashMap<String, Object>) callSite.get("0")).get("receiver"));
+        assertEquals("notFound", ((HashMap<String, Object>) callSite.get("0")).get("type"));
+    }
 }


### PR DESCRIPTION
## Description
Fix NullPointerExeption when generating external CHA, when Instruction is not available. New changes replace absent information with "notFound"

## Motivation and context
After running the OPAL plugin on the entire Maven ecosystem and number of NullPointerException-s very thrown from the getCallSite() method. The cause of it was the absence of type and receiver information. 

## Testing
New unit tests are needed to test branches that include absent type and receiver information. 

## Task list  
- [x] Fix NPE when type and receiver information is not available.
- [x] Test the changes