### PR TITLE
New callables insertion strategy

### DIFF
--- a/analyzer/metadata-plugin/pom.xml
+++ b/analyzer/metadata-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>metadata-plugin</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>metadata-plugin</name>
@@ -67,7 +67,7 @@
                                         <X-Compile-Target-JDK>11</X-Compile-Target-JDK>
                                         <Plugin-Class>eu.fasten.analyzer.metadataplugin.MetadataDatabasePlugin</Plugin-Class>
                                         <Plugin-Id>metadata-plugin</Plugin-Id>
-                                        <Plugin-Version>0.0.1</Plugin-Version>
+                                        <Plugin-Version>0.1.1</Plugin-Version>
                                         <Plugin-Description>Metadata Plugin</Plugin-Description>
                                         <Plugin-License>Apache License 2.0</Plugin-License>
                                     </manifestEntries>

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -470,18 +470,8 @@ public class MetadataDatabasePlugin extends Plugin {
                             null, JSONB.valueOf(callableMetadata.toString())));
                 }
             }
-            final int edgesBatchSize = 4096;
-            final int callablesBatchSize = 512;
             var callablesIds = new LongArrayList(callables.size());
-            final var callablesIterator = callables.iterator();
-            while (callablesIterator.hasNext()) {
-                var callablesBatch = new ArrayList<CallablesRecord>(callablesBatchSize);
-                while (callablesIterator.hasNext() && callablesBatch.size() < callablesBatchSize) {
-                    callablesBatch.add(callablesIterator.next());
-                }
-                var ids = metadataDao.batchInsertCallables(callablesBatch);
-                callablesIds.addAll(ids);
-            }
+            callablesIds.addAll(metadataDao.insertCallablesSeparately(callables, numInternal));
             var lidToGidMap = new Long2LongOpenHashMap();
             for (int i = 0; i < callables.size(); i++) {
                 lidToGidMap.put(callables.get(i).getId().longValue(), callablesIds.getLong(i));
@@ -510,6 +500,7 @@ public class MetadataDatabasePlugin extends Plugin {
                 edges.add(new EdgesRecord(globalSource, globalTarget,
                         JSONB.valueOf(metadata.toString())));
             }
+            final int edgesBatchSize = 4096;
             final var edgesIterator = edges.iterator();
             while (edgesIterator.hasNext()) {
                 var edgesBatch = new ArrayList<EdgesRecord>(edgesBatchSize);

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -541,7 +541,7 @@ public class MetadataDatabasePlugin extends Plugin {
 
         @Override
         public String version() {
-            return "0.1.0";
+            return "0.1.1";
         }
 
         @Override

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
@@ -138,7 +138,7 @@ public class MetadataDatabasePluginTest {
                 externalModuleMetadata)).thenReturn(externalModuleId);
         long fileId1 = 3;
         Mockito.when(metadataDao.insertFile(packageVersionId, "", null, null, null)).thenReturn(fileId1);
-        Mockito.when(metadataDao.batchInsertCallables(Mockito.anyList())).thenReturn(List.of(64L, 65L));
+        Mockito.when(metadataDao.insertCallablesSeparately(Mockito.anyList(), Mockito.anyInt())).thenReturn(List.of(64L, 65L));
         long internalModuleId = 17;
         var internalModuleMetadata = new JSONObject("{" +
                 "\"access\": \"public\"," +

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -34,6 +34,8 @@ import eu.fasten.core.data.metadatadb.codegen.tables.records.CallablesRecord;
 import eu.fasten.core.data.metadatadb.codegen.tables.records.EdgesRecord;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
@@ -136,7 +138,7 @@ public class MetadataDao {
                         PackageVersions.PACKAGE_VERSIONS.as("excluded").CREATED_AT)
                 .set(PackageVersions.PACKAGE_VERSIONS.METADATA,
                         JsonbDSL.concat(PackageVersions.PACKAGE_VERSIONS.METADATA,
-                        PackageVersions.PACKAGE_VERSIONS.as("excluded").METADATA))
+                                PackageVersions.PACKAGE_VERSIONS.as("excluded").METADATA))
                 .returning(PackageVersions.PACKAGE_VERSIONS.ID).fetchOne();
         return resultRecord.getValue(PackageVersions.PACKAGE_VERSIONS.ID);
     }
@@ -293,7 +295,7 @@ public class MetadataDao {
                         BinaryModules.BINARY_MODULES.as("excluded").CREATED_AT)
                 .set(BinaryModules.BINARY_MODULES.METADATA,
                         JsonbDSL.concat(BinaryModules.BINARY_MODULES.METADATA,
-                        BinaryModules.BINARY_MODULES.as("excluded").METADATA))
+                                BinaryModules.BINARY_MODULES.as("excluded").METADATA))
                 .returning(BinaryModules.BINARY_MODULES.ID).fetchOne();
         return resultRecord.getValue(BinaryModules.BINARY_MODULES.ID);
     }
@@ -602,5 +604,86 @@ public class MetadataDao {
                         Callables.CALLABLES.as("excluded").METADATA))
                 .returning(Callables.CALLABLES.ID).fetch();
         return result.getValues(Callables.CALLABLES.ID);
+    }
+
+    /**
+     * Inserts all the callables from the CG.
+     * First batch inserts all internal callables,
+     * then retrieves IDs of all external callables that are already in the database,
+     * and then batch inserts all new external callables.
+     *
+     * @param callables   List of callables. NB! First all internal callables and then all external.
+     * @param numInternal Number of internal callables in the callables list
+     * @return List of IDs of inserted callables from the database.
+     */
+    public List<Long> insertCallablesSeparately(List<CallablesRecord> callables, int numInternal) {
+        var ids = new ArrayList<Long>(callables.size());
+        var internalCallables = new ArrayList<CallablesRecord>(numInternal);
+        var externalCallables = new ArrayList<CallablesRecord>(callables.size() - numInternal);
+        for (int i = 0; i < callables.size(); i++) {
+            if (i < numInternal) {
+                internalCallables.add(callables.get(i));
+            } else {
+                externalCallables.add(callables.get(i));
+            }
+        }
+        // Batch insert internal callables
+        final var batchSize = 4096;
+        final var callablesIterator = internalCallables.iterator();
+        while (callablesIterator.hasNext()) {
+            var callablesBatch = new ArrayList<CallablesRecord>(batchSize);
+            while (callablesIterator.hasNext() && callablesBatch.size() < batchSize) {
+                callablesBatch.add(callablesIterator.next());
+            }
+            var callablesIds = this.batchInsertCallables(callablesBatch);
+            ids.addAll(callablesIds);
+        }
+
+        // Get IDs of external callables that are already in the database
+        var urisCondition = Callables.CALLABLES.FASTEN_URI
+                .eq(externalCallables.get(0).getFastenUri());
+        for (int i = 1; i < externalCallables.size(); i++) {
+            urisCondition = urisCondition
+                    .or(Callables.CALLABLES.FASTEN_URI.eq(externalCallables.get(i).getFastenUri()));
+        }
+        var result = context
+                .select(Callables.CALLABLES.ID, Callables.CALLABLES.FASTEN_URI)
+                .from(Callables.CALLABLES)
+                .where(Callables.CALLABLES.MODULE_ID.eq(-1L))
+                .and(Callables.CALLABLES.IS_INTERNAL_CALL.eq(false))
+                .and(urisCondition)
+                .fetch();
+        var uriMap = new HashMap<String, Long>(result.size());
+        for (var tuple : result) {
+            uriMap.put(tuple.value2(), tuple.value1());
+        }
+
+        // Batch insert external callables which are not in the database yet
+        var newExternalCallables = new ArrayList<CallablesRecord>(
+                externalCallables.size() - uriMap.size()
+        );
+        for (var callable : externalCallables) {
+            if (!uriMap.containsKey(callable.getFastenUri())) {
+                newExternalCallables.add(callable);
+            }
+        }
+        final var newExternalCallablesIterator = newExternalCallables.iterator();
+        while (newExternalCallablesIterator.hasNext()) {
+            var callablesBatch = new ArrayList<CallablesRecord>(batchSize);
+            while (newExternalCallablesIterator.hasNext() && callablesBatch.size() < batchSize) {
+                callablesBatch.add(newExternalCallablesIterator.next());
+            }
+            var callablesIds = this.batchInsertCallables(callablesBatch);
+            for (int i = 0; i < callablesBatch.size(); i++) {
+                uriMap.put(callablesBatch.get(i).getFastenUri(), callablesIds.get(i));
+            }
+        }
+
+        // Add external IDs to the result in the correct order
+        for (var externalCallable : externalCallables) {
+            ids.add(uriMap.get(externalCallable.getFastenUri()));
+        }
+
+        return ids;
     }
 }


### PR DESCRIPTION
## Description
This PR changes the way that the callables of the new format CGs are inserted in the database in order to optimize the performance of insertion.
Previously,  all callables were inserted together and since a lot of external callables are already in the database, the performance of the PostgreSQL insertion was very low because conflicts on constraints caused a lot of deadlocks.
Now, internal callables are inserted with batch insert as before, then `select` is performed to retrieve IDs of the external callables that are already in the database and are in the CG, and then external callables which weren't in the database are inserted with the batch insert.

## Motivation and context
This PR should improve the performance of the metadata plugin.

## Testing
Used regression testing to make sure that overall functionality did not change and tested on a small CG to compare the results with the current metadata plugin on the `develop` branch.

## Task list  
- [X] Implement the new callables insertion strategy