### PR TITLE
[WIP] Better configuration values for the Kafka consumers.

### DIFF
--- a/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
+++ b/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
@@ -50,8 +50,9 @@ public class KafkaConnector {
 
         // Gives more time to the consumer for processing the records so
         // that the broker will NOT kill the consumer.
-        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "200000");
-        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "700000");
+        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "3000");
+        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000");
+        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "700000");
 
         return properties;
     }

--- a/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
+++ b/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
@@ -52,7 +52,7 @@ public class KafkaConnector {
         // that the broker will NOT kill the consumer.
         properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "3000");
         properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000");
-        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "700000");
+        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
 
         return properties;
     }


### PR DESCRIPTION
## Description
Improved configuration settings for Kafka consumers. The following configuration is changed:
- `session.timeout.ms`: is set to 10 seconds. The Kafka broker will know that a consumer is dead if it hasn't had heartbeats for the amount of time specified by this config.
- `heartbeat.interval.ms`: is set to 3 seconds. Hearbeats are used to trigger the rebalance protocol. Setting this too high will cause consumers being aware of rebalancing too slowly.
- `max.poll.interval.ms`: is set to 700 seconds. This should be the maximum time to process a single Kafka record. 


## Motivation and context
Current configuration values were wrong and caused some undesired behaviour. Rebalancing of Kafka, when consumer joined or left the group, took too long. Proposed values are based on [this](https://stackoverflow.com/a/43992308) and [this](https://medium.com/streamthoughts/apache-kafka-rebalance-protocol-or-the-magic-behind-your-streams-applications-e94baf68e4f2#:~:text=During%20the%20entire%20rebalancing%20process,lag%20can%20become%20an%20issue.) resource. 

## Testing
x

## Task list  
- [ ] Do a simple test run to see if proposed configuration works.

## Additional context
x
