### PR TITLE
Added analysis phase to the License and Compliance plugin

### DIFF
--- a/analyzer/compliance-analyzer/dummyKafkaTopic.json
+++ b/analyzer/compliance-analyzer/dummyKafkaTopic.json
@@ -1,20 +1,20 @@
 {
   "input": {
-    "artifactId": "junit",
-    "groupId": "junit",
-    "version": "4.12",
+    "artifactId": "javacv",
+    "groupId": "javacv",
+    "version": "1.5.4",
     "dependendencyData": {
     },
     "commitTag": ""
   },
   "plugin_version": "0.0.1",
   "payload": {
-    "artifactId": "junit",
-    "groupId": "junit",
-    "version": "4.12",
-    "repoUrl": "http://github.com/junit-team/junit",
-    "repoPath": "/j/junit/junit"
+    "artifactId": "javacv",
+    "groupId": "javacv",
+    "version": "1.5.4",
+    "repoUrl": "https://github.com/bytedeco/javacv",
+    "repoPath": "/j/javacv/javacv"
   },
-  "created_at": 1594820036478,
+  "created_at": 1600851029,
   "plugin_name": "RepoCloner"
 }

--- a/analyzer/compliance-analyzer/src/main/java/eu/fasten/analyzer/complianceanalyzer/ComplianceAnalyzerPlugin.java
+++ b/analyzer/compliance-analyzer/src/main/java/eu/fasten/analyzer/complianceanalyzer/ComplianceAnalyzerPlugin.java
@@ -68,6 +68,11 @@ public class ComplianceAnalyzerPlugin extends Plugin {
          */
         protected final String clusterCredentialsFilePath;
 
+        /**
+         * Placeholder for the repository URL in the Kubernetes Job file
+         */
+        protected final String repositoryUrlPlaceholder = "REPOSITORY_URL";
+
         public CompliancePluginExtension() {
             this.clusterCredentialsFilePath = System.getProperty(CLUSTER_CREDENTIALS_ENV);
         }
@@ -159,7 +164,7 @@ public class ComplianceAnalyzerPlugin extends Plugin {
                 Path jobFileSystemPath = Paths.get(jobFileFullPath);
                 Charset jobFileCharset = StandardCharsets.UTF_8;
                 String jobFileContent = Files.readString(jobFileSystemPath, jobFileCharset);
-                jobFileContent = jobFileContent.replaceAll("url", repoUrl);
+                jobFileContent = jobFileContent.replaceAll(repositoryUrlPlaceholder, repoUrl);
                 Files.write(jobFileSystemPath, jobFileContent.getBytes(jobFileCharset));
 
                 // Deploying the QMSTR Job

--- a/analyzer/compliance-analyzer/src/main/resources/docker/job.yaml
+++ b/analyzer/compliance-analyzer/src/main/resources/docker/job.yaml
@@ -12,9 +12,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: qmstr-master
-          image: endocodeci/qmstr-master:sha-4678e1d
-          command: [ "/usr/local/bin/qmstr-master" ]
-          args: [ "--config", "/home/qmstr/config/qmstr.yaml" ]
+          image: endocodeci/qmstr-master:sha-086f323
+          command: [ "sh", "-c", "sleep 40 && /usr/local/bin/qmstr-master --config /home/qmstr/config/qmstr.yaml" ]
           ports:
             - containerPort: 50051
           env:
@@ -28,18 +27,15 @@ spec:
         - name: dgraph
           image: dgraph/standalone:latest
         - name: qmstr-client
-          image: endocodeci/qmstr-client-mvn:sha-6d95b9e # generic "project" directory
-          command: [ "sh", "./entrypoint.sh" ]
-          ports:
-            - containerPort: 8000
-              name: http-ratel
-            - containerPort: 8080
-              name: http-alpha
+          image: endocodeci/qmstr-client-mvn:sha-086f323
+          command: [ "sh", "-c", "sleep 60 && mvn package -Dmaven.test.skip=true && qmstrctl analyze --verbose" ]
           env:
             - name: QMSTRADDRENV
               value: "localhost:50051"
             - name: BUILDROOT
               value: /var/qmstr/buildroot
+            - name: QMSTR_MASTER
+              value: "localhost:50051"
           volumeMounts:
             - name: buildroot-volume
               mountPath: /var/qmstr/buildroot
@@ -56,13 +52,13 @@ spec:
             - "git"
             - "clone"
           args:
-            - "url"
+            - REPOSITORY_URL
             - "/home/git/buildroot/project"
           volumeMounts:
             - name: buildroot-volume
               mountPath: /home/git/buildroot
         - name: pom-patch
-          image: endocodeci/pom-patch:sha-4678e1d
+          image: endocodeci/pom-patch:sha-086f323
           command: [ "python", "insert-build-plugin.py", "qmstr-maven-plugin.xml" ]
           volumeMounts:
             - name: buildroot-volume

--- a/analyzer/compliance-analyzer/src/main/resources/docker/master-config.yaml
+++ b/analyzer/compliance-analyzer/src/main/resources/docker/master-config.yaml
@@ -10,5 +10,12 @@ data:
       metadata:
         message: "Hello World!"
       server:
-        dbAddress: "dgraph:9000"
+        dbAddress: "dgraph:9080"
+        rpcAddress: "localhost:50051" # master address
       analysis:
+        - analyzer: scancode-analyzer
+          name: "Scancode Analyzer"
+          config:
+            workdir: "/var/qmstr/buildroot"
+            resultfile: "/var/qmstr/buildroot/scancode.json"
+    #       cached: "true"

--- a/analyzer/compliance-analyzer/src/main/resources/docker/service.yaml
+++ b/analyzer/compliance-analyzer/src/main/resources/docker/service.yaml
@@ -15,3 +15,6 @@ spec:
     - name: http-ratel
       port: 8000
       targetPort: 8000
+    - name: grpc-alpha
+      port: 9080
+      targetPort: 9080


### PR DESCRIPTION
## Description
The License and Compliance plugin now also analyzes Maven projects using [scancode](https://github.com/nexB/scancode-toolkit).\
As a result of this phase, our graph database is augmented with licence and compliance information.

<p align="center">
        <img src="https://github.com/endocode/qmstr/blob/feature/self-contained-modules/deploy/img/graph.png?raw=true" alt="Generated Build Graph example"/>
</p>

The left part of the graph consists in the usual build graph, having in this case a single (Java) package node in green as the central node. License and compliance information is on the right, having the analyzer node in pink right in the middle.

## Motivation and context
It's part of #48, deliverable 4.2 "_Detection of license obligations and metadata and application to the call graphs_".

## Testing
It's running in the cloud and I've tried several Maven projects. Obviously the bigger the project, the longer the analysis phase. For this matter I had to change the repository URL in our [`dummyKafkaTopic.json`](https://github.com/marcomicera/fasten/blob/endocode/compliancePlugin/analyzer/compliance-analyzer/dummyKafkaTopic.json) from http://github.com/junit-team/junit to https://github.com/bytedeco/javacv: appartenly [junit](http://github.com/junit-team/junit) is so big that we would need scale up our dev cluster. It's something that I will definitely do in the future.

## Additional context
Please note that the base branch of this PR is actually in the process of being merged into [`develop`](https://github.com/fasten-project/fasten/pull/48) in #48.