### PR TITLE
Added PostgresConnector tests

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,6 +22,20 @@
             <artifactId>core</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
+
+        <!-- Integration tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.14.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- For environment variables -->
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/src/test/java/eu/fasten/server/connectors/PostgresConnectorTest.java
+++ b/server/src/test/java/eu/fasten/server/connectors/PostgresConnectorTest.java
@@ -1,0 +1,71 @@
+package eu.fasten.server.connectors;
+
+import eu.fasten.core.data.Constants;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.sql.SQLException;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PostgresConnectorTest {
+
+    protected static final String KB_USERNAME = "testusername";
+    protected static final String KB_PASSWORD = "testpassword";
+
+    @ClassRule
+    public static PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer("postgres:11.1")
+            .withDatabaseName("integration-test-postgres")
+            .withUsername(KB_USERNAME)
+            .withPassword(KB_PASSWORD);
+
+    @BeforeAll
+    static void startPostgresContainer() {
+        postgreSQLContainer.start();
+        postgreSQLContainer.waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*\\n", 1));
+    }
+
+    @Test
+    public void Given_CorrectKbCredentials_When_RestServerConnectsToKb_Then_NoExceptionShouldBeThrown() {
+
+        // Connection to DB should not throw any exceptions
+        assertDoesNotThrow(() ->
+                withEnvironmentVariable(Constants.pgPasswordEnvVariable, KB_PASSWORD).execute(() ->
+                        PostgresConnector.getDSLContext(
+                                postgreSQLContainer.getJdbcUrl(), postgreSQLContainer.getUsername())));
+    }
+
+    @Test
+    public void Given_NoKbPassword_When_RestServerConnectsToKb_Then_IllegalArgumentExceptionShouldBeThrown()
+            throws SQLException {
+
+        assertThrows(IllegalArgumentException.class, () ->
+                PostgresConnector.getDSLContext(
+                        postgreSQLContainer.getJdbcUrl(), postgreSQLContainer.getUsername()));
+    }
+
+    @Test
+    public void Given_WrongKbPassword_When_RestServerConnectsToKb_Then_SQLExceptionShouldBeThrown() {
+
+        final String wrongKbPassword = "wrongpassword";
+
+        assert wrongKbPassword.compareTo(KB_PASSWORD) != 0 :
+                "Using the right KB password during a test that was supposed to be using a wrong one.";
+
+        assertThrows(SQLException.class, () ->
+                withEnvironmentVariable(Constants.pgPasswordEnvVariable, wrongKbPassword).execute(() ->
+                        PostgresConnector.getDSLContext(
+                                postgreSQLContainer.getJdbcUrl(), postgreSQLContainer.getUsername())));
+    }
+
+    @AfterAll
+    static void stopPostgresContainer() {
+        postgreSQLContainer.stop();
+    }
+}


### PR DESCRIPTION
Part of the tests (#89) of the REST API (#80) ended up being tests for the [PostgresConnector](https://github.com/fasten-project/fasten/blob/develop/server/src/main/java/eu/fasten/server/connectors/PostgresConnector.java) class.

Here I'm using [Testcontainers](https://www.testcontainers.org) to fire up a PostgreSQL container and trying to connect to it through that connector class.