### PR TITLE
Add GitHub Super Linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,24 @@
+name: Lint Code Base
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: develop
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

GitHub introduced GitHub Super Linter: one linter to rule them all. See <https://github.blog/2020-06-18-introducing-github-super-linter-one-linter-to-rule-them-all/> for details. Since I am a huge fan of linting (especially [markdown-lint](https://github.com/igorshubovych/markdownlint-cli#readme)) and I was seeing that "checkstyle" is already in place, I thought, this could be helpful.

## Motivation and context

Having linting issues reported in a clear way increases the likelihood that linting issues are addressed during submission of a pull request.

I did not touch the maven build file since I am not sure whether you really like this new trendy GitHub tool.

Alternatively, it is also possible that the PR is directly commented ([reviewdog](https://github.com/reviewdog/reviewdog)), but this causes much noise at unfinished PR. The alternative to that is [PR annotation](https://github.com/staabm/annotate-pull-request-from-checkstyle), but this fails if an external contributor is contributing something due to token issues. Thus, I tink, the GitHub super linter is a good thing.
