### PR TITLE
Support for multiple DB connections in the FASTEN server

### DIFF
--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/Main.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/Main.java
@@ -18,6 +18,7 @@
 
 package eu.fasten.analyzer.metadataplugin;
 
+import eu.fasten.core.data.Constants;
 import eu.fasten.server.connectors.PostgresConnector;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -62,7 +63,7 @@ public class Main implements Runnable {
     public void run() {
         var metadataPlugin = new MetadataDatabasePlugin.MetadataDBExtension();
         try {
-            metadataPlugin.setDBConnection(new HashMap<>(Map.of("java",
+            metadataPlugin.setDBConnection(new HashMap<>(Map.of(Constants.mvnForge,
                     PostgresConnector.getDSLContext(dbUrl, dbUser))));
         } catch (IllegalArgumentException | SQLException e) {
             logger.error("Could not connect to the database", e);

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/Main.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/Main.java
@@ -22,6 +22,9 @@ import eu.fasten.server.connectors.PostgresConnector;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.slf4j.Logger;
@@ -59,7 +62,8 @@ public class Main implements Runnable {
     public void run() {
         var metadataPlugin = new MetadataDatabasePlugin.MetadataDBExtension();
         try {
-            metadataPlugin.setDBConnection(PostgresConnector.getDSLContext(dbUrl, dbUser));
+            metadataPlugin.setDBConnection(new HashMap<>(Map.of("java",
+                    PostgresConnector.getDSLContext(dbUrl, dbUser))));
         } catch (IllegalArgumentException | SQLException e) {
             logger.error("Could not connect to the database", e);
             return;

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -76,7 +76,7 @@ public class MetadataDatabasePlugin extends Plugin {
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
-            MetadataDBExtension.dslContext = dslContexts.get("java");
+            MetadataDBExtension.dslContext = dslContexts.get(Constants.mvnForge);
         }
 
         @Override

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePlugin.java
@@ -75,8 +75,8 @@ public class MetadataDatabasePlugin extends Plugin {
         private String outputPath;
 
         @Override
-        public void setDBConnection(DSLContext dslContext) {
-            MetadataDBExtension.dslContext = dslContext;
+        public void setDBConnection(Map<String, DSLContext> dslContexts) {
+            MetadataDBExtension.dslContext = dslContexts.get("java");
         }
 
         @Override

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
@@ -28,9 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.sql.Timestamp;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataDatabasePluginTest {
@@ -42,7 +41,7 @@ public class MetadataDatabasePluginTest {
         var dslContext = Mockito.mock(DSLContext.class);
         metadataDBExtension = new MetadataDatabasePlugin.MetadataDBExtension();
         metadataDBExtension.setTopic("fasten.OPAL.out");
-        metadataDBExtension.setDBConnection(dslContext);
+        metadataDBExtension.setDBConnection(new HashMap<>(Map.of("java", dslContext)));
     }
 
     @Test

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePluginTest.java
@@ -41,7 +41,7 @@ public class MetadataDatabasePluginTest {
         var dslContext = Mockito.mock(DSLContext.class);
         metadataDBExtension = new MetadataDatabasePlugin.MetadataDBExtension();
         metadataDBExtension.setTopic("fasten.OPAL.out");
-        metadataDBExtension.setDBConnection(new HashMap<>(Map.of("java", dslContext)));
+        metadataDBExtension.setDBConnection(new HashMap<>(Map.of(Constants.mvnForge, dslContext)));
     }
 
     @Test

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/Main.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/Main.java
@@ -18,6 +18,7 @@
 
 package eu.fasten.analyzer.pomanalyzer;
 
+import eu.fasten.core.data.Constants;
 import eu.fasten.server.connectors.PostgresConnector;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -73,7 +74,7 @@ public class Main implements Runnable {
     public void run() {
         var pomAnalyzer = new POMAnalyzerPlugin.POMAnalyzer();
         try {
-            pomAnalyzer.setDBConnection(new HashMap<>(Map.of("java",
+            pomAnalyzer.setDBConnection(new HashMap<>(Map.of(Constants.mvnForge,
                     PostgresConnector.getDSLContext(dbUrl, dbUser))));
         } catch (SQLException e) {
             System.err.println("Error connecting to the database:");

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/Main.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/Main.java
@@ -22,6 +22,9 @@ import eu.fasten.server.connectors.PostgresConnector;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import picocli.CommandLine;
@@ -70,7 +73,8 @@ public class Main implements Runnable {
     public void run() {
         var pomAnalyzer = new POMAnalyzerPlugin.POMAnalyzer();
         try {
-            pomAnalyzer.setDBConnection(PostgresConnector.getDSLContext(dbUrl, dbUser));
+            pomAnalyzer.setDBConnection(new HashMap<>(Map.of("java",
+                    PostgresConnector.getDSLContext(dbUrl, dbUser))));
         } catch (SQLException e) {
             System.err.println("Error connecting to the database:");
             e.printStackTrace(System.err);

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -79,7 +79,7 @@ public class POMAnalyzerPlugin extends Plugin {
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
-            POMAnalyzer.dslContext = dslContexts.get("java");
+            POMAnalyzer.dslContext = dslContexts.get(Constants.mvnForge);
         }
 
         @Override

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
@@ -77,8 +78,8 @@ public class POMAnalyzerPlugin extends Plugin {
         }
 
         @Override
-        public void setDBConnection(DSLContext dslContext) {
-            POMAnalyzer.dslContext = dslContext;
+        public void setDBConnection(Map<String, DSLContext> dslContexts) {
+            POMAnalyzer.dslContext = dslContexts.get("java");
         }
 
         @Override

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/Main.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/Main.java
@@ -18,6 +18,7 @@
 
 package eu.fasten.analyzer.restapiplugin;
 
+import eu.fasten.core.data.Constants;
 import eu.fasten.server.connectors.PostgresConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,7 @@ public class Main implements Runnable {
     public void run() {
         var restAPIPlugin = new RestAPIPlugin.RestAPIExtension();
         try {
-            restAPIPlugin.setDBConnection(new HashMap<>(Map.of("java",
+            restAPIPlugin.setDBConnection(new HashMap<>(Map.of(Constants.mvnForge,
                     PostgresConnector.getDSLContext(dbUrl, dbUser))));
         } catch (IllegalArgumentException | SQLException e) {
             logger.error("Could not connect to the database", e);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/Main.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/Main.java
@@ -24,6 +24,8 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 @CommandLine.Command(name = "RestAPIPlugin")
 public class Main implements Runnable {
@@ -50,7 +52,8 @@ public class Main implements Runnable {
     public void run() {
         var restAPIPlugin = new RestAPIPlugin.RestAPIExtension();
         try {
-            restAPIPlugin.setDBConnection(PostgresConnector.getDSLContext(dbUrl, dbUser));
+            restAPIPlugin.setDBConnection(new HashMap<>(Map.of("java",
+                    PostgresConnector.getDSLContext(dbUrl, dbUser))));
         } catch (IllegalArgumentException | SQLException e) {
             logger.error("Could not connect to the database", e);
             return;

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/RestAPIPlugin.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/RestAPIPlugin.java
@@ -19,6 +19,7 @@
 package eu.fasten.analyzer.restapiplugin;
 
 import eu.fasten.analyzer.restapiplugin.server.OpenAPIServer;
+import eu.fasten.core.data.Constants;
 import eu.fasten.core.plugins.DBConnector;
 import io.vertx.core.Vertx;
 import org.jooq.DSLContext;
@@ -46,7 +47,7 @@ public class RestAPIPlugin extends Plugin {
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
-            RestAPIExtension.dslContext = dslContexts.get("java");
+            RestAPIExtension.dslContext = dslContexts.get(Constants.mvnForge);
         }
 
         @Override

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/RestAPIPlugin.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/RestAPIPlugin.java
@@ -28,6 +28,8 @@ import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+
 public class RestAPIPlugin extends Plugin {
 
     public RestAPIPlugin(PluginWrapper wrapper) {
@@ -43,8 +45,8 @@ public class RestAPIPlugin extends Plugin {
         private Vertx vertx;
 
         @Override
-        public void setDBConnection(DSLContext dslContext) {
-            RestAPIExtension.dslContext = dslContext;
+        public void setDBConnection(Map<String, DSLContext> dslContexts) {
+            RestAPIExtension.dslContext = dslContexts.get("java");
         }
 
         @Override

--- a/core/src/main/java/eu/fasten/core/data/Constants.java
+++ b/core/src/main/java/eu/fasten/core/data/Constants.java
@@ -6,6 +6,10 @@ public class Constants {
 
     public static final String mvnForge = "mvn";
 
+    public static final String pyForge = "pypi";
+
+    public static final String cForge = "debian";
+
     public static final String opalGenerator = "OPAL";
 
     public static final int transactionRestartLimit = 3;

--- a/core/src/main/java/eu/fasten/core/plugins/DBConnector.java
+++ b/core/src/main/java/eu/fasten/core/plugins/DBConnector.java
@@ -20,16 +20,17 @@ package eu.fasten.core.plugins;
 
 import org.jooq.DSLContext;
 
+import java.util.Map;
+
 /**
  * A plug-in that needs to get access to a database should implement this interface.
  */
 public interface DBConnector extends FastenPlugin {
 
     /**
-     * This methods sets a DB connection for plug-ins.
+     * This methods sets DB connections for plug-ins.
      *
-     * @param dslContext A DSL context for JOOQ to query the database.
+     * @param dslContexts A set of DSL contexts for JOOQ to query the database.
      */
-    void setDBConnection(DSLContext dslContext);
-
+    void setDBConnection(Map<String, DSLContext> dslContexts);
 }

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -29,17 +29,23 @@ import eu.fasten.server.connectors.PostgresConnector;
 import eu.fasten.server.connectors.RocksDBConnector;
 import eu.fasten.server.plugins.FastenServerPlugin;
 import eu.fasten.server.plugins.kafka.FastenKafkaPlugin;
+
+import java.net.URI;
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.ObjectUtils;
+import org.jooq.DSLContext;
 import org.pf4j.JarPluginManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+
 
 
 @CommandLine.Command(name = "FastenServer", mixinStandardHelpOptions = true)
@@ -96,13 +102,15 @@ public class FastenServer implements Runnable {
 
     @Option(names = {"-d", "--database"},
             paramLabel = "dbURL",
-            description = "Database URL for connection")
-    String dbUrl;
+            description = "Kay-value pairs of Database URLs for connection Example - " +
+                    "java=jdbc:postgresql://postgres@localhost/dbname",
+            split = ",")
+    Map<String, String> dbUrls;
 
-    @Option(names = {"-du", "--user"},
-            paramLabel = "dbUser",
-            description = "Database user name")
-    String dbUser;
+//    @Option(names = {"-du", "--user"},
+//            paramLabel = "dbUser",
+//            description = "Database user name")
+//    String dbUser;
 
     @Option(names = {"-gd", "--graphdb_dir"},
             paramLabel = "dir",
@@ -226,20 +234,36 @@ public class FastenServer implements Runnable {
      */
     private void makeDBConnection(List<DBConnector> dbPlugins) {
         dbPlugins.forEach((p) -> {
-            if (ObjectUtils.allNotNull(dbUrl, dbUser)) {
-                try {
-                    p.setDBConnection(PostgresConnector.getDSLContext(dbUrl, dbUser));
-                    logger.debug("Set DB connection successfully for plug-in {}",
-                            p.getClass().getSimpleName());
-                } catch (SQLException e) {
-                    logger.error("Couldn't set DB connection for plug-in {}\n{}",
-                            p.getClass().getSimpleName(), e.getStackTrace());
-                }
+            if (dbUrls != null) {
+                p.setDBConnection(dbUrls.entrySet().stream().map(e -> new AbstractMap.SimpleEntry<>(e.getKey(),
+                        e.getValue())).collect(Collectors.toMap(AbstractMap.SimpleEntry::toString, e -> {
+                    try {
+                        return getDSLContext(e.getValue());
+                    } catch (SQLException ex) {
+                        logger.error("Couldn't set DB connection for plug-in {}\n{}",
+                                p.getClass().getSimpleName(), ex.getStackTrace());
+                    }
+                    return null;
+                })));
+                logger.debug("Set DB connection successfully for plug-in {}",
+                        p.getClass().getSimpleName());
             } else {
                 logger.error("Couldn't make a DB connection. Make sure that you have "
                         + "provided a valid DB URL, username and password.");
             }
         });
+    }
+
+    /**
+     * Get a DB connection for a given DB URL
+     * @param dbURL JDBC URI
+     * @throws SQLException
+     */
+    private DSLContext getDSLContext(String dbURL) throws SQLException {
+        String cleanURI = dbURL.substring(5);
+        URI uri = URI.create(cleanURI);
+        return PostgresConnector.getDSLContext("jdbc:postgresql://" + uri.getHost() + uri.getPath(),
+                uri.getUserInfo());
     }
 
     /**

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -107,11 +107,6 @@ public class FastenServer implements Runnable {
             split = ",")
     Map<String, String> dbUrls;
 
-//    @Option(names = {"-du", "--user"},
-//            paramLabel = "dbUser",
-//            description = "Database user name")
-//    String dbUser;
-
     @Option(names = {"-gd", "--graphdb_dir"},
             paramLabel = "dir",
             description = "Path to directory with RocksDB database")
@@ -238,15 +233,16 @@ public class FastenServer implements Runnable {
                 p.setDBConnection(dbUrls.entrySet().stream().map(e -> new AbstractMap.SimpleEntry<>(e.getKey(),
                         e.getValue())).collect(Collectors.toMap(AbstractMap.SimpleEntry::toString, e -> {
                     try {
+                        logger.debug("Set {} DB connection successfully for plug-in {}",
+                                e.getKey(), p.getClass().getSimpleName());
                         return getDSLContext(e.getValue());
                     } catch (SQLException ex) {
-                        logger.error("Couldn't set DB connection for plug-in {}\n{}",
-                                p.getClass().getSimpleName(), ex.getStackTrace());
+                        logger.error("Couldn't set {} DB connection for plug-in {}\n{}",
+                                e.getKey(), p.getClass().getSimpleName(), ex.getStackTrace());
                     }
                     return null;
                 })));
-                logger.debug("Set DB connection successfully for plug-in {}",
-                        p.getClass().getSimpleName());
+
             } else {
                 logger.error("Couldn't make a DB connection. Make sure that you have "
                         + "provided a valid DB URL, username and password.");

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -103,7 +103,7 @@ public class FastenServer implements Runnable {
     @Option(names = {"-d", "--database"},
             paramLabel = "dbURL",
             description = "Kay-value pairs of Database URLs for connection Example - " +
-                    "java=jdbc:postgresql://postgres@localhost/dbname",
+                    "mvn=jdbc:postgresql://postgres@localhost/dbname",
             split = ",")
     Map<String, String> dbUrls;
 


### PR DESCRIPTION
## Description
FASTEN server now accepts a set of DB URLs for creating multiple DB connections. For example, to connect to Java and Python DBs, the argument `-d` in the server will be set as follows:
```
-d java=jdbc:postgresql://postgres@localhost/dbname,py=jdbc:postgresql://postgres@localhost/dbname
```
In the plug-in, by using `dslContexts.get("java")`, the connection to the Java DB can be used.
I propose `java`, `py` and `c` for the key names of the list of DBs in CLI and in the code.

## Motivation and context
Plug-ins like QualityAnlyzer and REST API require multiple DB connections as they need to access metadata for different languages.

## Testing
I locally tested the FASTEN server to make sure that it successfully create a DB connection for metadata plug-in and POMAnalyzer. However, we still need to test both plug-ins on our servers to ensure that they work as expected.

## Task list  
- [x] Add the support for multiple DB connections in the FASTEN server
- [x] Change `DBConnector` interface to for accepting a map of DB connections.
- [x] Make the plug-ins that require a DB connection compatible with the new changes.

## Additional context
None
