### PR TITLE
Python metadata plugin

### DIFF
--- a/analyzer/metadata-plugin/pom.xml
+++ b/analyzer/metadata-plugin/pom.xml
@@ -85,6 +85,19 @@
                                         <Plugin-License>Apache License 2.0</Plugin-License>
                                     </manifestEntries>
                                 </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>eu.fasten.analyzer.metadataplugin.Main
+                                        </Main-Class>
+                                        <X-Compile-Source-JDK>11</X-Compile-Source-JDK>
+                                        <X-Compile-Target-JDK>11</X-Compile-Target-JDK>
+                                        <Plugin-Class>eu.fasten.analyzer.metadataplugin.MetadataDatabasePythonPlugin</Plugin-Class>
+                                        <Plugin-Id>metadata-plugin-python</Plugin-Id>
+                                        <Plugin-Version>0.1.2</Plugin-Version>
+                                        <Plugin-Description>Metadata Plugin for Python CGs</Plugin-Description>
+                                        <Plugin-License>Apache License 2.0</Plugin-License>
+                                    </manifestEntries>
+                                </transformer>
                             </transformers>
                             <!-- Note that this works when maven is ran in the root directory of the project  -->
                             <outputDirectory>${session.executionRootDirectory}/docker/plugins/</outputDirectory>

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/Main.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/Main.java
@@ -66,6 +66,8 @@ public class Main implements Runnable {
             return new MetadataDatabaseJavaPlugin.MetadataDBJavaExtension();
         else if (language.equals("c"))
             return new MetadataDatabaseCPlugin.MetadataDBCExtension();
+        else if (language.equals("python"))
+            return new MetadataDatabasePythonPlugin.MetadataDBPythonExtension();
         return null;
     }
 

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -200,7 +200,7 @@ public class MetadataDBExtension implements KafkaPlugin, DBConnector {
             return new ExtendedRevisionJavaCallGraph(json);
         } else if (forge.equals(Constants.debianForge)) {
             return new ExtendedRevisionCCallGraph(json);
-        } else if (forge.equals("PyPI")) {
+        } else if (forge.equals(Constants.pypiForge)) {
             return new ExtendedRevisionPythonCallGraph(json);
         }
 

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.metadataplugin;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.ExtendedRevisionJavaCallGraph;
 import eu.fasten.core.data.ExtendedRevisionCCallGraph;
+import eu.fasten.core.data.ExtendedRevisionPythonCallGraph;
 import eu.fasten.core.data.ExtendedRevisionCallGraph;
 import eu.fasten.core.data.Graph;
 import eu.fasten.core.data.graphdb.GidGraph;
@@ -199,6 +200,8 @@ public class MetadataDBExtension implements KafkaPlugin, DBConnector {
             return new ExtendedRevisionJavaCallGraph(json);
         } else if (forge.equals(Constants.debianForge)) {
             return new ExtendedRevisionCCallGraph(json);
+        } else if (forge.equals("PyPI")) {
+            return new ExtendedRevisionPythonCallGraph(json);
         }
 
         return null;

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPlugin.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.analyzer.metadataplugin;
+
+import eu.fasten.core.data.PythonScope;
+import eu.fasten.core.data.PythonNode;
+import eu.fasten.core.data.PythonType;
+import eu.fasten.core.data.Constants;
+import eu.fasten.core.data.ExtendedRevisionPythonCallGraph;
+import eu.fasten.core.data.ExtendedRevisionCallGraph;
+import eu.fasten.core.data.Graph;
+import eu.fasten.core.data.graphdb.GidGraph;
+import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.data.metadatadb.codegen.tables.records.CallablesRecord;
+import eu.fasten.core.data.metadatadb.codegen.tables.records.EdgesRecord;
+import eu.fasten.core.data.metadatadb.codegen.udt.records.ReceiverRecord;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.json.JSONObject;
+import org.pf4j.Extension;
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MetadataDatabasePythonPlugin extends Plugin {
+    public MetadataDatabasePythonPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+
+    @Extension
+    public static class MetadataDBPythonExtension extends MetadataDBExtension {
+        private static DSLContext dslContext;
+
+        @Override
+        public void setDBConnection(DSLContext dslContext) {
+            MetadataDBPythonExtension.dslContext = dslContext;
+        }
+
+        @Override
+        public DSLContext getDBConnection() {
+            return MetadataDBPythonExtension.dslContext;
+        }
+
+        public ArrayList<CallablesRecord> insertDataExtractCallables(ExtendedRevisionCallGraph callgraph, MetadataDao metadataDao, long packageVersionId) {
+            ExtendedRevisionPythonCallGraph pythonCallGraph = (ExtendedRevisionPythonCallGraph) callgraph;
+
+            var callables = new ArrayList<CallablesRecord>();
+            var cha = pythonCallGraph.getClassHierarchy();
+            var internals = cha.get(PythonScope.internal);
+            // Insert all modules, files, module contents and extract callables from internal types
+            for (var entry : internals.entrySet()) {
+                var type = entry.getValue();
+                var moduleName = entry.getKey();
+
+                var moduleId = metadataDao.insertModule(packageVersionId, moduleName,
+                                                        null, new JSONObject());
+                var fileId = metadataDao.insertFile(packageVersionId, type.getSourceFileName());
+                metadataDao.insertModuleContent(moduleId, fileId);
+                callables.addAll(extractCallablesFromType(type, moduleId, true));
+            }
+
+            var externals = cha.get(PythonScope.external);
+            // Extract all external callables
+            for (var entry : externals.entrySet()) {
+                var type = entry.getValue();
+                callables.addAll(extractCallablesFromType(type, -1L, false));
+            }
+
+            return callables;
+        }
+
+        private List<CallablesRecord> extractCallablesFromType(PythonType type,
+                                                               long moduleId, boolean isInternal) {
+            // Extracts a list of all callable records and their metadata from the type
+            var callables = new ArrayList<CallablesRecord>(type.getMethods().size());
+
+            for (var methodEntry : type.getMethods().entrySet()) {
+                // Get Local ID
+                var localId = (long) methodEntry.getKey();
+
+                // Get FASTEN URI
+                var uri = methodEntry.getValue().getUri().toString();
+
+                // Collect metadata
+                var callableMetadata = new JSONObject(methodEntry.getValue().getMetadata());
+                Integer firstLine = null;
+                if (callableMetadata.has("first")
+                        && !(callableMetadata.get("first") instanceof String)) {
+                    firstLine = callableMetadata.getInt("first");
+                    callableMetadata.remove("first");
+                }
+                Integer lastLine = null;
+                if (callableMetadata.has("last")
+                        && !(callableMetadata.get("last") instanceof String)) {
+                    lastLine = callableMetadata.getInt("last");
+                    callableMetadata.remove("last");
+                }
+
+                // Add a record to the list
+                callables.add(new CallablesRecord(localId, moduleId, uri, isInternal, null,
+                        firstLine, lastLine, JSONB.valueOf(callableMetadata.toString())));
+            }
+            return callables;
+        }
+
+        protected List<EdgesRecord> insertEdges(Graph graph,
+                                 Long2LongOpenHashMap lidToGidMap, MetadataDao metadataDao) {
+            final var numEdges = graph.getInternalCalls().size() + graph.getExternalCalls().size();
+
+            // Map of all edges (internal and external)
+            var graphCalls = graph.getInternalCalls();
+            graphCalls.putAll(graph.getExternalCalls());
+
+            var edges = new ArrayList<EdgesRecord>(numEdges);
+            for (var edgeEntry : graphCalls.entrySet()) {
+
+                // Get Global ID of the source callable
+                var source = lidToGidMap.get((long) edgeEntry.getKey().get(0));
+                // Get Global ID of the target callable
+                var target = lidToGidMap.get((long) edgeEntry.getKey().get(1));
+
+                // Create receivers
+                var receivers = new ReceiverRecord[0];
+
+                // Add edge record to the list of records
+                edges.add(new EdgesRecord(source, target, receivers, JSONB.valueOf("{}")));
+            }
+
+            // Batch insert all edges
+            final var edgesIterator = edges.iterator();
+            while (edgesIterator.hasNext()) {
+                var edgesBatch = new ArrayList<EdgesRecord>(Constants.insertionBatchSize);
+                while (edgesIterator.hasNext()
+                        && edgesBatch.size() < Constants.insertionBatchSize) {
+                    edgesBatch.add(edgesIterator.next());
+                }
+                metadataDao.batchInsertEdges(edgesBatch);
+            }
+            return edges;
+        }
+    }
+}

--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPluginTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPluginTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.analyzer.metadataplugin;
+
+import eu.fasten.core.data.Constants;
+import eu.fasten.core.data.ExtendedRevisionPythonCallGraph;
+import eu.fasten.core.data.metadatadb.MetadataDao;
+import org.jooq.DSLContext;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MetadataDatabasePythonPluginTest {
+
+    private MetadataDatabasePythonPlugin.MetadataDBPythonExtension metadataDBExtension;
+
+    @BeforeEach
+    public void setUp() {
+        var dslContext = Mockito.mock(DSLContext.class);
+        metadataDBExtension = new MetadataDatabasePythonPlugin.MetadataDBPythonExtension();
+        metadataDBExtension.setTopic("fasten.pypi.cg");
+        metadataDBExtension.setDBConnection(dslContext);
+    }
+
+    @Test
+    public void consumeJsonErrorTest() {
+        metadataDBExtension.consume("{\"payload\":{\"foo\":\"bar\"}}");
+        assertNotNull(metadataDBExtension.getPluginError());
+    }
+
+   @Test
+    public void saveToDatabaseTest() {
+        var metadataDao = Mockito.mock(MetadataDao.class);
+        var json = new JSONObject("{\n" +
+           "     \"product\": \"foo\",\n" +
+           "     \"forge\": \"PyPI\",\n" +
+           "     \"nodes\": 3,\n" +
+           "     \"generator\": \"PyCG\",\n" +
+           "     \"depset\": [],\n" +
+           "     \"version\": \"3.10.0.7\",\n" +
+           "     \"modules\": {\n" +
+           "         \"internal\": {\n" +
+           "             \"/module.name/\": {\n" +
+           "                 \"sourceFile\": \"module/name.py\",\n" +
+           "                 \"namespaces\": {\n" +
+           "                     \"0\": {\n" +
+           "                         \"namespace\": \"/module.name/\",\n" +
+           "                         \"metadata\": {\n" +
+           "                             \"first\": 1\n" +
+           "                         }\n" +
+           "                     },\n" +
+           "                     \"1\": {\n" +
+           "                         \"namespace\": \"/module.name/Cls\",\n" +
+           "                         \"metadata\": {\n" +
+           "                             \"first\": 4,\n" +
+           "                             \"superClasses\": [\"/other.module/Parent\", \"//external//external.package.SomeClass\"]\n" +
+           "                         }\n" +
+           "                     },\n" +
+           "                 }\n" +
+           "             }\n" +
+           "         },\n" +
+           "         \"external\": {\n" +
+           "             \"external\": {\n" +
+           "                 \"sourceFile\": \"\",\n" +
+           "                 \"namespaces\": {\n" +
+           "                     \"2\": {\n" +
+           "                         \"namespace\": \"//external//external.package.method\",\n" +
+           "                         \"metadata\": {}\n" +
+           "                     }\n" +
+           "                 }\n" +
+           "             }\n" +
+           "         }\n" +
+           "     },\n" +
+           "     \"graph\": {\n" +
+           "         \"internalCalls\": [\n" +
+           "             [\"0\", \"1\"],\n" +
+           "         ],\n" +
+           "         \"externalCalls\": [\n" +
+           "             [\"1\", \"2\"]\n" +
+           "         ],\n" +
+           "         \"resolvedCalls\": []\n" +
+           "     },\n" +
+           "     \"timestamp\": 123\n" +
+           " }\n");
+        long packageId = 8;
+        Mockito.when(metadataDao.insertPackage(json.getString("product"), Constants.pypiForge)).thenReturn(packageId);
+        long packageVersionId = 42;
+        Mockito.when(metadataDao.insertPackageVersion(Mockito.eq(packageId), Mockito.eq(json.getString("generator")),
+                Mockito.eq(json.getString("version")), Mockito.eq(null), Mockito.eq(new Timestamp(json.getLong("timestamp") * 1000)), Mockito.any(JSONObject.class))).thenReturn(packageVersionId);
+        long fileId = 4;
+        Mockito.when(metadataDao.insertFile(packageVersionId, "module/name.py")).thenReturn(fileId);
+        Mockito.when(metadataDao.insertCallablesSeparately(Mockito.anyList(), Mockito.anyInt())).thenReturn(List.of(64L, 65L, 66L));
+        long internalModuleId = 17;
+        Mockito.when(metadataDao.insertModule(Mockito.eq(packageVersionId), Mockito.eq("/module.name/"), Mockito.eq(null),
+                Mockito.any(JSONObject.class))).thenReturn(internalModuleId);
+
+        long id = metadataDBExtension.saveToDatabase(new ExtendedRevisionPythonCallGraph(json), metadataDao);
+        assertEquals(packageVersionId, id);
+        Mockito.verify(metadataDao).insertPackage(json.getString("product"), Constants.pypiForge);
+        Mockito.verify(metadataDao).insertPackageVersion(Mockito.eq(packageId), Mockito.eq(json.getString("generator")),
+                Mockito.eq(json.getString("version")), Mockito.eq(null), Mockito.eq(new Timestamp(json.getLong("timestamp") * 1000)), Mockito.any(JSONObject.class));
+        Mockito.verify(metadataDao).insertFile(packageVersionId, "module/name.py");
+        Mockito.verify(metadataDao).insertCallablesSeparately(Mockito.anyList(), Mockito.anyInt());
+        Mockito.verify(metadataDao).batchInsertEdges(Mockito.anyList());
+        Mockito.verify(metadataDao).insertModule(Mockito.eq(packageVersionId), Mockito.eq("/module.name/"), Mockito.eq(null), Mockito.any(JSONObject.class));
+    }
+
+    @Test
+    public void saveToDatabaseEmptyJsonTest() {
+        var metadataDao = Mockito.mock(MetadataDao.class);
+        var json = new JSONObject();
+        assertThrows(JSONException.class, () -> metadataDBExtension
+                .saveToDatabase(new ExtendedRevisionPythonCallGraph(json), metadataDao));
+    }
+
+    @Test
+    public void consumerTopicsTest() {
+        var topics = Optional.of(Collections.singletonList("fasten.pypi.cg"));
+        assertEquals(topics, metadataDBExtension.consumeTopic());
+    }
+
+    @Test
+    public void consumerTopicChangeTest() {
+        var topics1 = Optional.of(Collections.singletonList("fasten.pypi.cg"));
+        assertEquals(topics1, metadataDBExtension.consumeTopic());
+        var differentTopic = "DifferentKafkaTopic";
+        var topics2 = Optional.of(Collections.singletonList(differentTopic));
+        metadataDBExtension.setTopic(differentTopic);
+        assertEquals(topics2, metadataDBExtension.consumeTopic());
+    }
+
+    @Test
+    public void nameTest() {
+        var name = "Metadata plugin";
+        assertEquals(name, metadataDBExtension.name());
+    }
+
+    @Test
+    public void descriptionTest() {
+        var description = "Metadata plugin. "
+                + "Consumes ExtendedRevisionCallgraph-formatted JSON objects from Kafka topic"
+                + " and populates metadata database with consumed data"
+                + " and writes graph of GIDs of callgraph to another Kafka topic.";
+        assertEquals(description, metadataDBExtension.description());
+    }
+}

--- a/core/src/main/java/eu/fasten/core/data/Constants.java
+++ b/core/src/main/java/eu/fasten/core/data/Constants.java
@@ -8,6 +8,8 @@ public class Constants {
 
     public static final String debianForge = "debian";
 
+    public static final String pypiForge = "PyPI";
+
     public static final String opalGenerator = "OPAL";
 
     public static final int transactionRestartLimit = 3;

--- a/core/src/main/java/eu/fasten/core/data/ExtendedBuilderPython.java
+++ b/core/src/main/java/eu/fasten/core/data/ExtendedBuilderPython.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.core.data;
+
+import java.util.Map;
+
+/**
+ * Builder for {@link ExtendedRevisionPythonCallGraph}.
+ */
+public final class ExtendedBuilderPython extends ExtendedBuilder<Map<PythonScope, Map<String, PythonType>>> {
+    public ExtendedBuilderPython nodeCount(final int nodeCount) {
+        this.nodeCount = nodeCount;
+        return this;
+    }
+
+    public ExtendedBuilderPython forge(final String forge) {
+        this.forge = forge;
+        return this;
+    }
+
+    public ExtendedBuilderPython product(final String product) {
+        this.product = product;
+        return this;
+    }
+
+    public ExtendedBuilderPython version(final String version) {
+        this.version = version;
+        return this;
+    }
+
+    public ExtendedBuilderPython cgGenerator(final String cgGenerator) {
+        this.cgGenerator = cgGenerator;
+        return this;
+    }
+
+    public ExtendedBuilderPython timestamp(final long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public ExtendedBuilderPython graph(final Graph graph) {
+        this.graph = graph;
+        return this;
+    }
+
+    public ExtendedBuilderPython classHierarchy(final Map<PythonScope, Map<String, PythonType>> cha) {
+        this.classHierarchy = cha;
+        return this;
+    }
+
+    public ExtendedRevisionPythonCallGraph build() {
+        return new ExtendedRevisionPythonCallGraph(this);
+    }
+}

--- a/core/src/main/java/eu/fasten/core/data/ExtendedRevisionPythonCallGraph.java
+++ b/core/src/main/java/eu/fasten/core/data/ExtendedRevisionPythonCallGraph.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.core.data;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+//Map<PythonScope, Map<String, PythonType>>
+public class ExtendedRevisionPythonCallGraph extends ExtendedRevisionCallGraph<Map<PythonScope, Map<String, PythonType>>> {
+    static {
+        classHierarchyJSONKey = "modules";
+    }
+
+    /**
+     * Creates {@link ExtendedRevisionPythonCallGraph} with the given builder.
+     *
+     * @param builder builder for {@link ExtendedRevisionCCallGraph}
+     */
+    public ExtendedRevisionPythonCallGraph(final ExtendedBuilder<Map<PythonScope, Map<String, PythonType>>> builder) {
+        super(builder);
+    }
+
+    /**
+     * Creates {@link ExtendedRevisionPythonCallGraph} with the given data.
+     *
+     * @param forge          the forge.
+     * @param product        the product.
+     * @param version        the version.
+     * @param timestamp      the timestamp (in seconds from UNIX epoch); optional: if not present,
+     *                       it is set to -1.
+     * @param nodeCount      number of nodes
+     * @param cgGenerator    The name of call graph generator that generated this call graph.
+     * @param classHierarchy class hierarchy of this revision including all classes of the revision
+     *                       <code> Map<{@link FastenURI}, {@link Type}> </code>
+     * @param graph          the call graph (no control is done on the graph) {@link Graph}
+     */
+    public ExtendedRevisionPythonCallGraph(final String forge, final String product, final String version,
+                                     final long timestamp, int nodeCount, final String cgGenerator,
+                                     final Map<PythonScope, Map<String, PythonType>>classHierarchy,
+                                     final Graph graph) {
+        super(forge, product, version, timestamp, nodeCount, cgGenerator, classHierarchy, graph);
+    }
+
+    /**
+     * Creates {@link ExtendedRevisionCallGraph} for the given JSONObject.
+     *
+     * @param json JSONObject of a revision call graph.
+     */
+    public ExtendedRevisionPythonCallGraph(final JSONObject json) throws JSONException {
+        super(json);
+    }
+
+    /**
+     * Creates builder to build {@link ExtendedRevisionCCallGraph}.
+     *
+     * @return created builder
+     */
+    public static ExtendedBuilderPython extendedBuilder() {
+        return new ExtendedBuilderPython();
+    }
+
+    /**
+     * Creates a class hierarchy for the given JSONObject.
+     *
+     * @param cha JSONObject of a cha.
+     */
+    public Map<PythonScope, Map<String, PythonType>> getCHAFromJSON(final JSONObject cha) {
+        final Map<PythonScope, Map<String, PythonType>> methods = new HashMap<>();
+
+        final var internal = cha.getJSONObject("internal");
+        final var external = cha.getJSONObject("external");
+
+        methods.put(PythonScope.internal, parseModules(internal));
+        methods.put(PythonScope.external, parseModules(external));
+
+        return methods;
+    }
+
+    /**
+     * Helper method to parse modules.
+     *
+     * @param json JSONObject that contains methods.
+     */
+    public static Map<String, PythonType> parseModules(final JSONObject json) {
+        final Map<String, PythonType> modules = new HashMap<>();
+
+        for (final var module : json.keySet()) {
+            final var typeJson = json.getJSONObject(module);
+            final var type = new PythonType(typeJson);
+            modules.put(module, type);
+        }
+        return modules;
+    }
+
+    /**
+     * Returns the map of all the methods of this object.
+     *
+     * @return a Map of method ids and their corresponding {@link FastenURI}
+     */
+    @Override
+    public Map<Integer, PythonNode> mapOfAllMethods() {
+        Map<Integer, PythonNode> result = new HashMap<>();
+        for (final var aClass : this.getClassHierarchy().get(PythonScope.internal).entrySet()) {
+            result.putAll(aClass.getValue().getMethods());
+        }
+        for (final var aClass : this.getClassHierarchy().get(PythonScope.external).entrySet()) {
+            result.putAll(aClass.getValue().getMethods());
+        }
+        return result;
+    }
+
+    /**
+     * Produces the JSON representation of class hierarchy.
+     *
+     * @param cha class hierarchy
+     * @return the JSON representation
+     */
+    public JSONObject classHierarchyToJSON(final Map<PythonScope, Map<String, PythonType>> cha) {
+        final var result = new JSONObject();
+
+        final var internal = methodsToJSON(cha.get(PythonScope.internal));
+        final var external = methodsToJSON(cha.get(PythonScope.external));
+
+        result.put("internal", internal);
+        result.put("external", external);
+
+        return result;
+    }
+
+    /**
+     * Produces the JSON of methods
+     *
+     * @param types the python types
+     */
+    public static JSONObject methodsToJSON(final Map<String, PythonType> types) {
+        final var result = new JSONObject();
+        for (final var type : types.entrySet()) {
+            result.put(type.getKey(), type.getValue().toJSON());
+        }
+        return result;
+    }
+
+    /**
+     * Returns a string representation of the revision.
+     *
+     * @return String representation of the revision.
+     */
+    public String getRevisionName() {
+        return this.product + "_" + this.version;
+    }
+}

--- a/core/src/main/java/eu/fasten/core/data/PythonNode.java
+++ b/core/src/main/java/eu/fasten/core/data/PythonNode.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.core.data;
+
+import java.util.Map;
+import java.util.List;
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+public class PythonNode extends Node {
+    /**
+     * Creates {@link PythonNode} from a FastenURI and metadata.
+     *
+     * @param uri      FastenURI corresponding to this PythonNode
+     * @param metadata metadata associated with this PythonNode
+     */
+    public PythonNode(final FastenURI uri, final Map<String, Object> metadata) {
+        super(uri, metadata);
+    }
+}

--- a/core/src/main/java/eu/fasten/core/data/PythonScope.java
+++ b/core/src/main/java/eu/fasten/core/data/PythonScope.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.core.data;
+
+/**
+ * Scope of Python modules.
+ */
+public enum PythonScope {
+    internal,
+    external
+}

--- a/core/src/main/java/eu/fasten/core/data/PythonType.java
+++ b/core/src/main/java/eu/fasten/core/data/PythonType.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.core.data;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.json.JSONObject;
+
+public class PythonType {
+
+    /**
+     * The source file name of this type.
+     */
+    private final String sourceFileName;
+
+    /**
+     * methods of this type and their unique ids.
+     */
+    private final BiMap<Integer, PythonNode> methods;
+
+    /**
+     * Creates {@link PythonType} for the given data.
+     *
+     * @param sourceFile      the name of this type's source file
+     * @param methods      a map of methods in this type indexed by their ids.
+     */
+    public PythonType(final String sourceFile, final BiMap<Integer, PythonNode> methods) {
+        this.sourceFileName = sourceFile;
+        this.methods = methods;
+    }
+
+    /**
+     * Creates {@link PythonType} for the given JSONObject.
+     *
+     * @param type JSONObject of a type including its source file name and map of namespaces
+     */
+    public PythonType(final JSONObject type) {
+        this.sourceFileName = type.getString("sourceFile");
+
+        final var methodsJson = type.getJSONObject("namespaces");
+        this.methods = HashBiMap.create();
+        for (final var methodKey : methodsJson.keySet()) {
+            final var nodeJson = methodsJson.getJSONObject(methodKey);
+            this.methods.put(Integer.parseInt(methodKey),
+                    new PythonNode(FastenPythonURI.create(nodeJson.getString("namespace")), nodeJson.getJSONObject("metadata").toMap()));
+        }
+    }
+
+    public String getSourceFileName() {
+        return sourceFileName;
+    }
+
+    public Map<Integer, PythonNode> getMethods() {
+        return this.methods;
+    }
+
+    /**
+     * Converts all the values of a given Map to String.
+     *
+     * @param map map of id-s and corresponding JavaNodes
+     */
+    public static Map<Integer, JSONObject> toMapOfString(final Map<Integer, PythonNode> map) {
+        final Map<Integer, JSONObject> methods = new HashMap<>();
+        for (final var entry : map.entrySet()) {
+            final JSONObject node = new JSONObject();
+            node.put("namespace", entry.getValue().getUri());
+            node.put("metadata", new JSONObject(entry.getValue().getMetadata()));
+            methods.put(entry.getKey(), node);
+        }
+        return methods;
+    }
+
+    /**
+     * Converts this {@link PythonType} object to its JSON representation.
+     *
+     * @return the corresponding JSON representation.
+     */
+    public JSONObject toJSON() {
+        final var result = new JSONObject();
+
+        result.put("sourceFile", this.sourceFileName);
+        result.put("namespaces", toMapOfString(this.methods));
+
+        return result;
+    }
+}

--- a/core/src/test/java/eu/fasten/core/data/ExtendedRevisionPythonCallGraphTest.java
+++ b/core/src/test/java/eu/fasten/core/data/ExtendedRevisionPythonCallGraphTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.core.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Objects;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ExtendedRevisionPythonCallGraphTest {
+
+    private static ExtendedRevisionPythonCallGraph graph;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        var file = new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
+                .getResource("extended-revision-call-graph/testPythonRCG.json"))
+                .getFile());
+
+        JSONTokener tokener = new JSONTokener(new FileReader(file));
+
+        graph = new ExtendedRevisionPythonCallGraph(new JSONObject(tokener));
+    }
+
+    @Test
+    void getNodeCount() {
+        assertEquals(5, graph.getNodeCount());
+    }
+
+    @Test
+    void toJSON() throws FileNotFoundException {
+        var file = new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
+                .getResource("extended-revision-call-graph/testPythonRCG.json"))
+                .getFile());
+
+        JSONTokener tokener = new JSONTokener(new FileReader(file));
+
+        JSONObject jsonGraph = new JSONObject(tokener);
+
+        System.out.println("HAAHAHAHAHAAAHAHAH " + jsonGraph.toString());
+
+        assertEquals(jsonGraph.getJSONObject("modules").getJSONObject("internal").toString(),
+                graph.toJSON().getJSONObject("modules").getJSONObject("internal").toString());
+
+        assertEquals(jsonGraph.getJSONObject("modules").getJSONObject("external").toString(),
+                graph.toJSON().getJSONObject("modules").getJSONObject("external").toString());
+
+        assertEquals(jsonGraph.getJSONObject("graph").toMap(),
+                graph.toJSON().getJSONObject("graph").toMap());
+    }
+
+    @Test
+    void toJSONFromCHA() {
+        assertEquals(graph.classHierarchyToJSON(graph.getClassHierarchy()).toString(),
+                graph.toJSON().getJSONObject("modules").toString());
+    }
+
+    @Test
+    void mapOfAllMethods() {
+        var methodsMap = graph.mapOfAllMethods();
+
+        assertEquals(5, methodsMap.size());
+
+        assertEquals("/module.name/",
+                methodsMap.get(0).getUri().toString());
+        assertEquals("/module.name/Cls",
+                methodsMap.get(1).getUri().toString());
+        assertEquals("/module.name/Cls.func()",
+                methodsMap.get(2).getUri().toString());
+        assertEquals("/other.module/",
+                methodsMap.get(3).getUri().toString());
+        assertEquals("//external//external.package.method",
+                methodsMap.get(4).getUri().toString());
+    }
+
+    @Test
+    void isCallGraphEmptyEmptyInternal() throws IOException {
+        var file = new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
+                .getResource("extended-revision-call-graph/testPythonRCGEmptyInternal.json"))
+                .getFile());
+
+        JSONTokener tokener = new JSONTokener(new FileReader(file));
+
+        var cg = new ExtendedRevisionPythonCallGraph(new JSONObject(tokener));
+
+        assertFalse(cg.isCallGraphEmpty());
+    }
+
+    @Test
+    void isCallGraphEmptyEmptyExternal() throws IOException {
+        var file = new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
+                .getResource("extended-revision-call-graph/testPythonRCGEmptyExternal.json"))
+                .getFile());
+
+        JSONTokener tokener = new JSONTokener(new FileReader(file));
+
+        var cg = new ExtendedRevisionPythonCallGraph(new JSONObject(tokener));
+
+        assertFalse(cg.isCallGraphEmpty());
+    }
+
+    @Test
+    void isCallGraphEmptyEmptyAll() throws IOException {
+        var file = new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
+                .getResource("extended-revision-call-graph/testPythonRCGEmptyAll.json"))
+                .getFile());
+
+        JSONTokener tokener = new JSONTokener(new FileReader(file));
+
+        var cg = new ExtendedRevisionPythonCallGraph(new JSONObject(tokener));
+
+        assertTrue(cg.isCallGraphEmpty());
+    }
+
+    @Test
+    void isCallGraphEmptyAllExist() {
+        assertFalse(graph.isCallGraphEmpty());
+    }
+
+    @Test
+    void getCgGenerator() {
+        assertEquals("PyCG", graph.getCgGenerator());
+    }
+}

--- a/core/src/test/resources/extended-revision-call-graph/testPythonRCG.json
+++ b/core/src/test/resources/extended-revision-call-graph/testPythonRCG.json
@@ -1,0 +1,76 @@
+{
+    "product": "foo",
+    "forge": "PyPI",
+    "nodes": 5,
+    "generator": "PyCG",
+    "depset": [
+        {"product": "a", "forge": "PyPI", "constraints": ["[1.2..1.5]","[2.3..]"]},
+        {"product": "b", "forge": "PyPI", "constraints": ["[2.0.1]"]}
+    ],
+    "version": "3.10.0.7",
+    "modules": {
+        "internal": {
+            "/module.name/": {
+                "sourceFile": "module/name.py",
+                "namespaces": {
+                    "0": {
+                        "namespace": "/module.name/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    },
+                    "1": {
+                        "namespace": "/module.name/Cls",
+                        "metadata": {
+                            "first": 4,
+                            "last": 11,
+                            "superClasses": ["/other.module/Parent", "//external//external.package.SomeClass"]
+                        }
+                    },
+                    "2": {
+                        "namespace": "/module.name/Cls.func()",
+                        "metadata": {
+                            "first": 9,
+                            "last": 11
+                        }
+                    }
+                }
+            },
+            "/other.module/": {
+                "sourceFile": "other/module.py",
+                "namespaces": {
+                    "3": {
+                        "namespace": "/other.module/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    }
+                }
+            }
+        },
+        "external": {
+            "external": {
+                "sourceFile": "",
+                "namespaces": {
+                    "4": {
+                        "namespace": "//external//external.package.method",
+                        "metadata": {}
+                    }
+                }
+            }
+        }
+    },
+    "graph": {
+        "internalCalls": [
+            ["0", "1", {}],
+            ["0", "2", {}]
+        ],
+        "externalCalls": [
+            ["2", "4", {}]
+        ],
+        "resolvedCalls": []
+    },
+    "timestamp": 123
+}

--- a/core/src/test/resources/extended-revision-call-graph/testPythonRCGEmptyAll.json
+++ b/core/src/test/resources/extended-revision-call-graph/testPythonRCGEmptyAll.json
@@ -1,0 +1,71 @@
+{
+    "product": "foo",
+    "forge": "PyPI",
+    "nodes": 5,
+    "generator": "PyCG",
+    "depset": [
+        {"product": "a", "forge": "PyPI", "constraints": ["[1.2..1.5]","[2.3..]"]},
+        {"product": "b", "forge": "PyPI", "constraints": ["[2.0.1]"]}
+    ],
+    "version": "3.10.0.7",
+    "modules": {
+        "internal": {
+            "/module.name/": {
+                "sourceFile": "module/name.py",
+                "namespaces": {
+                    "0": {
+                        "namespace": "/module.name/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    },
+                    "1": {
+                        "namespace": "/module.name/Cls",
+                        "metadata": {
+                            "first": 4,
+                            "last": 11,
+                            "superClasses": ["/other.module/Parent", "//external//external.package.SomeClass"]
+                        }
+                    },
+                    "2": {
+                        "namespace": "/module.name/Cls.func()",
+                        "metadata": {
+                            "first": 9,
+                            "last": 11
+                        }
+                    }
+                }
+            },
+            "/other.module/": {
+                "sourceFile": "other/module.py",
+                "namespaces": {
+                    "3": {
+                        "namespace": "/other.module/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    }
+                }
+            }
+        },
+        "external": {
+            "external": {
+                "sourceFile": "",
+                "namespaces": {
+                    "4": {
+                        "namespace": "//external//external.package.method",
+                        "metadata": {}
+                    }
+                }
+            }
+        }
+    },
+    "graph": {
+        "internalCalls": [],
+        "externalCalls": [],
+        "resolvedCalls": []
+    },
+    "timestamp": 123
+}

--- a/core/src/test/resources/extended-revision-call-graph/testPythonRCGEmptyExternal.json
+++ b/core/src/test/resources/extended-revision-call-graph/testPythonRCGEmptyExternal.json
@@ -1,0 +1,74 @@
+{
+    "product": "foo",
+    "forge": "PyPI",
+    "nodes": 5,
+    "generator": "PyCG",
+    "depset": [
+        {"product": "a", "forge": "PyPI", "constraints": ["[1.2..1.5]","[2.3..]"]},
+        {"product": "b", "forge": "PyPI", "constraints": ["[2.0.1]"]}
+    ],
+    "version": "3.10.0.7",
+    "modules": {
+        "internal": {
+            "/module.name/": {
+                "sourceFile": "module/name.py",
+                "namespaces": {
+                    "0": {
+                        "namespace": "/module.name/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    },
+                    "1": {
+                        "namespace": "/module.name/Cls",
+                        "metadata": {
+                            "first": 4,
+                            "last": 11,
+                            "superClasses": ["/other.module/Parent", "//external//external.package.SomeClass"]
+                        }
+                    },
+                    "2": {
+                        "namespace": "/module.name/Cls.func()",
+                        "metadata": {
+                            "first": 9,
+                            "last": 11
+                        }
+                    }
+                }
+            },
+            "/other.module/": {
+                "sourceFile": "other/module.py",
+                "namespaces": {
+                    "3": {
+                        "namespace": "/other.module/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    }
+                }
+            }
+        },
+        "external": {
+            "external": {
+                "sourceFile": "",
+                "namespaces": {
+                    "4": {
+                        "namespace": "//external//external.package.method",
+                        "metadata": {}
+                    }
+                }
+            }
+        }
+    },
+    "graph": {
+        "internalCalls": [
+            ["0", "1", {}],
+            ["0", "2", {}]
+        ],
+        "externalCalls": [],
+        "resolvedCalls": []
+    },
+    "timestamp": 123
+}

--- a/core/src/test/resources/extended-revision-call-graph/testPythonRCGEmptyInternal.json
+++ b/core/src/test/resources/extended-revision-call-graph/testPythonRCGEmptyInternal.json
@@ -1,0 +1,73 @@
+{
+    "product": "foo",
+    "forge": "PyPI",
+    "nodes": 5,
+    "generator": "PyCG",
+    "depset": [
+        {"product": "a", "forge": "PyPI", "constraints": ["[1.2..1.5]","[2.3..]"]},
+        {"product": "b", "forge": "PyPI", "constraints": ["[2.0.1]"]}
+    ],
+    "version": "3.10.0.7",
+    "modules": {
+        "internal": {
+            "/module.name/": {
+                "sourceFile": "module/name.py",
+                "namespaces": {
+                    "0": {
+                        "namespace": "/module.name/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    },
+                    "1": {
+                        "namespace": "/module.name/Cls",
+                        "metadata": {
+                            "first": 4,
+                            "last": 11,
+                            "superClasses": ["/other.module/Parent", "//external//external.package.SomeClass"]
+                        }
+                    },
+                    "2": {
+                        "namespace": "/module.name/Cls.func()",
+                        "metadata": {
+                            "first": 9,
+                            "last": 11
+                        }
+                    }
+                }
+            },
+            "/other.module/": {
+                "sourceFile": "other/module.py",
+                "namespaces": {
+                    "3": {
+                        "namespace": "/other.module/",
+                        "metadata": {
+                            "first": 1,
+                            "last": 12
+                        }
+                    }
+                }
+            }
+        },
+        "external": {
+            "external": {
+                "sourceFile": "",
+                "namespaces": {
+                    "4": {
+                        "namespace": "//external//external.package.method",
+                        "metadata": {}
+                    }
+                }
+            }
+        }
+    },
+    "graph": {
+        "internalCalls": [],
+        "externalCalls": [
+            ["2", "4", {}]
+        ],
+        "resolvedCalls": []
+    },
+    "timestamp": 123
+}

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -135,8 +135,7 @@ public class FastenServer implements Runnable {
 
         // Stop plugins that are not passed as parameters.
         jarPluginManager.getPlugins().stream()
-                .filter(x -> !plugins.contains(jarPluginManager
-                        .getExtensions(x.getPluginId()).get(0).getClass().getSimpleName()))
+                .filter(x -> !jarPluginManager.getExtensions(x.getPluginId()).stream().anyMatch(e -> plugins.contains(e.getClass().getSimpleName())))
                 .forEach(x -> {
                     jarPluginManager.stopPlugin(x.getPluginId());
                     jarPluginManager.unloadPlugin(x.getPluginId());


### PR DESCRIPTION
## Description
Introduce metadata plugin for inserting Python call graphs into the metadata database.
This pull request is based on #91 , and therefore it should be merged after it.

## Motivation and context
This is Python specific code which is very similar to the ones implemented for Java and C.

## Testing
1. Unit tests
2. Local tests on my machine (OS x) using a kafka topic which stored either the call graphs themselves or a path to the call graph.
3. Repeated the same tests on the monster server.

## Additional context
Based on #91 .
