### PR TITLE
Fix bug in makeDBConnection

### DIFF
--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -231,7 +231,7 @@ public class FastenServer implements Runnable {
         dbPlugins.forEach((p) -> {
             if (dbUrls != null) {
                 p.setDBConnection(dbUrls.entrySet().stream().map(e -> new AbstractMap.SimpleEntry<>(e.getKey(),
-                        e.getValue())).collect(Collectors.toMap(AbstractMap.SimpleEntry::toString, e -> {
+                        e.getValue())).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, e -> {
                     try {
                         logger.debug("Set {} DB connection successfully for plug-in {}",
                                 e.getKey(), p.getClass().getSimpleName());


### PR DESCRIPTION
The stream was producing a map that had a string composed of forge=uri
as a key. In the map we want to have forge as the key to be able to
select the connection based on the forge.

@mir-am @MihhailSokolov Please verify that all the plug-ins that use the databases have the same logic to connect to the databases.