### PR TITLE
Snapshot releases

### DIFF
--- a/.github/workflows/snapshot-releases.yml
+++ b/.github/workflows/snapshot-releases.yml
@@ -1,0 +1,18 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Set version
+        run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }}
+      - name: Publish package
+        run: mvn -B deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>javacg-opal</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>javacg-opal</name>

--- a/analyzer/metadata-plugin/pom.xml
+++ b/analyzer/metadata-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>metadata-plugin</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>metadata-plugin</name>

--- a/analyzer/pom-analyzer/pom.xml
+++ b/analyzer/pom-analyzer/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>pom-analyzer</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>pom-analyzer</name>

--- a/analyzer/repo-cloner-plugin/pom.xml
+++ b/analyzer/repo-cloner-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>eu.fasten.analyzer</groupId>
     <artifactId>repo-cloner-plugin</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>repo-cloner-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,9 @@
 
     <groupId>eu.fasten</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
 
     <description>
         The FASTEN project makes software ecosystems robust, by making package management
@@ -196,6 +197,11 @@
                   </filesets>
                 </configuration>
               </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -232,4 +238,11 @@
         </plugins>
     </reporting>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/fasten-project/fasten</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>eu.fasten</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
 
@@ -120,7 +120,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.8.1</version>
                 <configuration>
                     <generateBackupPoms>false</generateBackupPoms>
                 </configuration>


### PR DESCRIPTION
## Description
Allows for snapshot releases through a GH action. Will first set the version of all components equal to the release tag and then deploy it to GH packages. 

## Motivation and context
We need to use the FASTEN library outside of this repo. 

## Testing
Based on [this post](https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-java-packages-with-maven).

## Task list  
-

## Additional context
-
