### PR TITLE
Minor fixes in format

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -74,7 +74,7 @@ public class OPALPlugin extends Plugin {
             long startTime = System.nanoTime();
             try {
                 // Generate CG and measure construction duration.
-                logger.info("[CG-GENERATION] [UNPROCESSED] [-1] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
+                logger.info("[CG-GENERATION] [UNPROCESSED] [-1i] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
                 this.graph = PartialCallGraph.createExtendedRevisionJavaCallGraph(mavenCoordinate,
                         "", "CHA", kafkaConsumedJson.optLong("date", -1));
                 long endTime = System.nanoTime();
@@ -95,19 +95,19 @@ public class OPALPlugin extends Plugin {
                         + firstLetter + File.separator
                         + artifactId + File.separator + product + ".json";
 
-                logger.info("[CG-GENERATION] [SUCCESS] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
+                logger.info("[CG-GENERATION] [SUCCESS] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
 
             } catch (OPALException | EmptyCallGraphException e) {
                 long endTime = System.nanoTime();
                 long duration = (endTime - startTime) / 1000000; // Compute duration in ms.
 
-                logger.error("[CG-GENERATION] [FAILED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
+                logger.error("[CG-GENERATION] [FAILED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
                 setPluginError(e);
             } catch (MissingArtifactException e) {
                 long endTime = System.nanoTime();
                 long duration = (endTime - startTime) / 1000000; // Compute duration in ms.
 
-                logger.error("[ARTIFACT-DOWNLOAD] [FAILED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
+                logger.error("[ARTIFACT-DOWNLOAD] [FAILED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
                 setPluginError(e);
             }
         }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
@@ -180,12 +180,12 @@ public class MavenCoordinate {
                     found = false;
 
                     long duration = computeDurationInMs(startTime);
-                    logger.warn("[ARTIFACT-DOWNLOAD] [FAILED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
+                    logger.warn("[ARTIFACT-DOWNLOAD] [UNPROCESSED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
                 }
 
                 if (jar.isPresent()) {
                     long duration = computeDurationInMs(startTime);
-                    logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
+                    logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
                     return jar.get();
                 } else if (found && i == repos.size() - 1) {
                     throw new MissingArtifactException("Artifact couldn't be retrieved for repo: " + repos.get(i), null);
@@ -202,11 +202,11 @@ public class MavenCoordinate {
                         found = false;
 
                         long duration = computeDurationInMs(startTime);
-                        logger.warn("[ARTIFACT-DOWNLOAD] [FAILED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
+                        logger.warn("[ARTIFACT-DOWNLOAD] [UNPROCESSED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
                     }
 
                     if (jar.isPresent()) {long duration = computeDurationInMs(startTime);
-                        logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
+                        logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
                         return jar.get();
                     } else if (found && i == repos.size() - 1) {
                         throw new MissingArtifactException("Artifact couldn't be retrieved for repo: " + repos.get(i), null);


### PR DESCRIPTION
## Description
I made two changes in the logging format:
- Integers are appended with "i", e.g. 10i, so that Influx recognizes it as integers. This is done for the `duration` field.
- Changed the `outcome` of a `WARN` MissingArtifactException from 'FAILED' to 'UNPROCESSED'

## Motivation and context
- More advanced queries because InfluxDB stores integers instead of only strings.
- Fixed a bug regarding 'FAILED' artifacts which were actually only just failed for that Maven repo. 

## Testing
--
## Task list  
--

## Additional context
--
