### PR TITLE
Fix stitching-merging wording and option validation

### DIFF
--- a/analyzer/javacg-opal/README.md
+++ b/analyzer/javacg-opal/README.md
@@ -3,28 +3,28 @@
 </p>
 <br/>
 <p align="center">
-    <a href="https://github.com/fasten-project/fasten/actions" alt="GitHub Workflow Status">
-        <img src="https://img.shields.io/github/workflow/status/fasten-project/fasten/Java%20CI?logo=GitHub%20Actions&logoColor=white&style=for-the-badge" /></a>
+    <a href="https://github.com/fasten-project/fasten/actions">
+        <img src="https://img.shields.io/github/workflow/status/fasten-project/fasten/Java%20CI?logo=GitHub%20Actions&logoColor=white&style=for-the-badge" alt="GitHub Workflow Status"/></a>
     <!-- Here should be a link to Maven repo and version should be pulled from there. -->
-    <a href="https://github.com/fasten-project/fasten/" alt="GitHub Workflow Status">
-                <img src="https://img.shields.io/maven-central/v/fasten/opal?label=version&logo=Apache%20Maven&style=for-the-badge" /></a>
+    <a href="https://github.com/fasten-project/fasten/">
+                <img src="https://img.shields.io/maven-central/v/fasten/opal?label=version&logo=Apache%20Maven&style=for-the-badge" alt="GitHub Workflow Status" /></a>
 </p>
 <br/>
 
 The FASTEN OPAL is a tool for generating call graphs in FASTEN format using [OPAL](https://www.opal-project.de/) call graph generator version '3.0.0'. This tool can also merge the resulted call graphs with their dependencies. The OPAL can be used as a standalone tool for generating call graphs for libraries and application and as a part of the FASTEN server.
 
 ## Arguments
-- `-a` `--artifact` Artifact, maven coordinate, or a file path
+- `-a` `--artifact` Artifact, Maven coordinate, or a file path
 - `-d` `--dependencies` Dependencies: coordinates or files
 - `-g` `--generate` Generate call graph for the artifact
     - `-ga` `--genAlgorithm` Algorithm for generating a call graph {RTA,CHA,AllocationSiteBasedPointsTo,TypeBasedPointsTo}
 - `-h` `--help` Show this help message and exit.
-- `-m` `--mode` Input of algorithms are {FILE or COORD}
+- `-i` `--input-type` Input of algorithms are {FILE or COORD}
+- `-m` `--merge` Merge artifact CG to dependencies
     - `-ma` `--mergeAlgorithm` Algorithm for merging call graphs {RA, CHA}
 - `-n` `--main` Main class of artifact (Used for analyzing applications. Omit for libraries)
 - `-o` `--output` Output directory path
 - `-r` A list of Maven repositories to look for the artifact in
-- `-s` `--stitch` Stitch artifact CG to dependencies
 - `-t` `--timestamp` Release timestamp
 - `-V` `--version` Print version information and exit.
 
@@ -32,18 +32,18 @@ The FASTEN OPAL is a tool for generating call graphs in FASTEN format using [OPA
 
 #### Generate a call graph for an artifact
 ```shell script
--a groupId:artifactId:version -g -ga CHA -m COORD -r https://repo.maven.apache.org/maven2/ -o /some/path/to/result/file.json
+-a groupId:artifactId:version -g -ga CHA -i COORD -r https://repo.maven.apache.org/maven2/ -o /some/path/to/result/file.json
 ```
 
 #### Generate a call graph for a file
 Can be used for all core Maven archived projects (jar, war, zip) as well as class files.
 ```shell script
--a /path/to/file.jar -g -ga CHA -m FILE -o /some/path/to/result/file.json
+-a /path/to/file.jar -g -ga CHA -i FILE -o /some/path/to/result/file.json
 ```
 
 #### Merge a call graph for an artifact with its dependencies call graphs
 ```shell script
--a abbot:costello:1.4.0 -d abbot:abbot:1.4.0 -m COORD -ma CHA -o /some/path/to/result/file.json
+-a abbot:costello:1.4.0 -d abbot:abbot:1.4.0 -m -ma CHA -i COORD -o /some/path/to/result/file.json
 ```
 
 ## Docker
@@ -68,10 +68,10 @@ docker run -it docker.pkg.github.com/fasten-project/fasten/fasten.opal.plugin -a
 
 The FASTEN software package management efficiency relies on an open community contributing to open technologies. Related research projects, R&D engineers, early users and open source contributors are welcome to join the [FASTEN community](https://www.fasten-project.eu/view/Main/Community), to try the tools, to participate in physical and remote worshops and to share our efforts using the project [community page](https://www.fasten-project.eu/view/Main/Community) and the social media buttons below.  
 <p>
-    <a href="http://www.twitter.com/FastenProject" alt="Fasten Twitter">
-        <img src="https://img.shields.io/badge/%20-Twitter-%231DA1F2?logo=Twitter&style=for-the-badge&logoColor=white" /></a>
-    <a href="http://www.slideshare.net/FastenProject" alt="GitHub Workflow Status">
-                <img src="https://img.shields.io/badge/%20-SlideShare-%230077B5?logo=slideshare&style=for-the-badge&logoColor=white" /></a>
-    <a href="http://www.linkedin.com/groups?gid=12172959" alt="Gitter">
-            <img src="https://img.shields.io/badge/%20-LinkedIn-%232867B2?logo=linkedin&style=for-the-badge&logoColor=white" /></a>
+    <a href="http://www.twitter.com/FastenProject">
+        <img src="https://img.shields.io/badge/%20-Twitter-%231DA1F2?logo=Twitter&style=for-the-badge&logoColor=white"  alt="Fasten Twitter" /></a>
+    <a href="http://www.slideshare.net/FastenProject">
+                <img src="https://img.shields.io/badge/%20-SlideShare-%230077B5?logo=slideshare&style=for-the-badge&logoColor=white" alt="GitHub Workflow Status" /></a>
+    <a href="http://www.linkedin.com/groups?gid=12172959">
+            <img src="https://img.shields.io/badge/%20-LinkedIn-%232867B2?logo=linkedin&style=for-the-badge&logoColor=white" alt="Gitter" /></a>
 </p>

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
@@ -66,10 +66,10 @@ public class Main implements Runnable {
     static class Computations {
         @CommandLine.Option(names = {"-a", "--artifact"},
                 paramLabel = "ARTIFACT",
-                description = "Artifact, maven coordinate or file path")
+                description = "Artifact, Maven coordinate or file path")
         String artifact;
 
-        @CommandLine.Option(names = {"-m", "--mode"},
+        @CommandLine.Option(names = {"-i", "--input-type"},
                 paramLabel = "MODE",
                 description = "Input of algorithms are {FILE or COORD}",
                 defaultValue = "FILE")
@@ -86,7 +86,7 @@ public class Main implements Runnable {
                 defaultValue = "CHA")
         String genAlgorithm;
 
-        @CommandLine.ArgGroup()
+        @CommandLine.ArgGroup(multiplicity = "1")
         Tools tools;
 
         @CommandLine.Option(names = {"-t", "--timestamp"},
@@ -118,9 +118,10 @@ public class Main implements Runnable {
                 defaultValue = "CHA")
         String mergeAlgorithm;
 
-        @CommandLine.Option(names = {"-s", "--stitch"},
-                paramLabel = "STITCH",
-                description = "Stitch artifact CG to dependencies")
+        @CommandLine.Option(names = {"-m", "--merge"},
+                paramLabel = "MERGE",
+                description = "Merge artifact CG to dependencies",
+                required = true)
         boolean doMerge;
 
         @CommandLine.Option(names = {"-d", "--dependencies"},

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
@@ -59,7 +59,7 @@ public class Main implements Runnable {
     List<String> repos;
 
     static class Commands {
-        @CommandLine.ArgGroup(exclusive = false)
+        @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
         Computations computations;
     }
 


### PR DESCRIPTION
## Description
- Rename option `-s` and `--stitch` to `-m` and `--merge` and refer to operation as merging instead of stitching to use coherent wording across the project. Note that `-m` was previously used to specify the mode (file or coord). Also `-m` and `-ma` combination is coherent with `-g` and `-ga` combination.
- Rename option `-m` and `--mode` to `-i` and `--input-type` in order to be able to use `-m` for merging.
- Force at least one operation (generate or merge) to be specified.
- Make merge option mandatory if `-ma` or `-d` is provided.
- Update README.md content according to option modification.
- Add missing `-m` option in the merging example (was missing `-s` option before this update).

## Motivation and context
A mix of two different wording (stitching and merging) was confusing for new users.
Also making this option to do merging required if `-ma` and/or `-d` are provided help to avoid the scenario where the generator will do nothing.

## Testing
I did some manual testing with various combination including: generate and merge operations, display of help, some invalid command usages, etc.
