### PR TITLE
Improve Vulnerability-Consumer performance with Caching

### DIFF
--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -37,6 +37,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class VulnerabilityConsumer extends Plugin {
 
@@ -154,6 +155,9 @@ public class VulnerabilityConsumer extends Plugin {
             // Find ecosystem of the vulnerability
             var context = v.getPurls().size() > 0 ? getVulnerabilityEcosystem(v) : null;
             if (context == null) return objectMapper.writeValueAsString(v);
+            // Clean first_patched_purls
+            v.setFirstPatchedPurls(v.getFirstPatchedPurls().stream()
+                    .filter(Objects::nonNull).collect(Collectors.toList()));
 
             // Collect packageIds
             var pkgIds = metadataUtility.getPackageIds(context, v);

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -160,10 +160,12 @@ public class VulnerabilityConsumer extends Plugin {
             if (pkgIds.size() == 0) return objectMapper.writeValueAsString(v);
 
             // Get IDs of vulnerable package coordinates
-            var pkgVersionIds = metadataUtility.getPackageVersionIds(v.getPurls(), context, pkgIds);
+            var pkgVersionIds = metadataUtility.getPackageVersionIds(v.getPurls(), context,
+                    pkgIds);
 
             // Get IDs of patched package coordinates
-            var pkgVersionPatchedIds = metadataUtility.getPackageVersionIds(v.getFirstPatchedPurls(), context, pkgIds);
+            var pkgVersionPatchedIds = metadataUtility.getPackageVersionIds(v.getFirstPatchedPurls(),
+                    context, pkgIds);
 
             if (pkgVersionIds.size() == 0) return objectMapper.writeValueAsString(v);
 
@@ -177,7 +179,8 @@ public class VulnerabilityConsumer extends Plugin {
                 for (Vulnerability.Patch p : v.getPatches()) {
                     logger.info("Searching for callables in " + p.getFileName() +
                             " for Package Version ID: " + pkgVersionId);
-                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
+                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId,
+                            context));
                 }
             }
 
@@ -189,13 +192,14 @@ public class VulnerabilityConsumer extends Plugin {
             pkgVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(v, id, context));
 
             for (String uri : fastenUris) {
-                var callableIds = metadataUtility.getCallableIdsForFastenUri(uri, pkgVersionIds, context);
+                var callableIds = metadataUtility.getCallableIdsForFastenUri(uri, pkgVersionIds,
+                        context);
                 // Inject the metadata in the callable row
                 for (Long id : callableIds) {
                     logger.info("Injecting into DB Callable with ID: " + id);
                     if (metadataUtility.injectCallableVulnerability(v, id, context) > 0) {
                         logger.info("Building the full fasten_uri for the injected callable");
-                        fullFastenUris.add(metadataUtility.getCallableInfo(id, context));
+                        fullFastenUris.add(metadataUtility.getFullFastenUri(uri, id));
                     }
                 }
             }

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.vulnerabilityconsumer.db;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.Cache;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.PURLPackage;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.Vulnerability;
 import eu.fasten.core.data.Constants;
@@ -42,6 +43,7 @@ import static eu.fasten.core.utils.FastenUriUtils.generateFullFastenUri;
 public class MetadataUtility {
 
     private ObjectMapper objectMapper = new ObjectMapper();
+    private Cache cache = new Cache();
     private UnaryOperator<String> getBasePurl = s -> s.split("@")[0];
     private final Logger logger = LoggerFactory.getLogger(MetadataUtility.class.getName());
 
@@ -62,9 +64,16 @@ public class MetadataUtility {
                 .distinct().collect(Collectors.toList());
 
         for (String basePurl : uniqueBasePurls) {
-            var pkgId = getPackageId(basePurl, context);
+            // Build the package name from the PURL
+            var pkgName = basePurl.startsWith("pkg:maven") ? basePurl.substring(basePurl.indexOf("/") + 1)
+                    : basePurl.substring(basePurl.lastIndexOf("/"));
+            var coordinateSeparator = basePurl.startsWith("pkg:maven") ? Constants.mvnCoordinateSeparator : "";
+            pkgName = pkgName.replace("/", coordinateSeparator);
+
+            var pkgId = getPackageId(pkgName, context);
             if (pkgId > 0)
                 pkgIds.put(basePurl, pkgId);
+                cache.pkgIdToName.put(pkgId, pkgName);
         }
 
         return pkgIds;
@@ -72,17 +81,22 @@ public class MetadataUtility {
 
     /**
      * Get a list of packageVersion IDs from the PURLs in the vulnerability.
-     *
-     * @param purls   - List of PURLS
+     *  @param purls   - List of PURLS
      * @param context - DSL Context
      * @param pkgIds  - List of package version IDs
      */
-    public List<Long> getPackageVersionIds(List<String> purls, DSLContext context, HashMap<String, Long> pkgIds) {
+    public List<Long> getPackageVersionIds(List<String> purls, DSLContext context,
+                                           HashMap<String, Long> pkgIds) {
         var pkgVersionIds = new ArrayList<Long>();
         for (String purl : purls) {
-            var pkgVersionId = getPackageVersionId(purl, context, pkgIds.get(getBasePurl.apply(purl)));
+            var purlObj = PURLPackage.getObjectFromPurl(purl);
+            var pkgId = pkgIds.get(getBasePurl.apply(purl));
+            var pkgVersionId = getPackageVersionId(purlObj, context, pkgId);
             if (pkgVersionId > 0L) {
                 pkgVersionIds.add(pkgVersionId);
+                // Insert information in cache
+                cache.pkgVsnToName.put(purlObj.getVersion(), cache.pkgIdToName.get(pkgId));
+                cache.pkgVsnIdToVsn.put(pkgVersionId, purlObj.getVersion());
             }
         }
 
@@ -98,7 +112,8 @@ public class MetadataUtility {
      * @param pkgVersionId - Long - ID of the package version
      * @return List of fastenURIs to
      */
-    public HashSet<String> getFastenUrisForPatch(Vulnerability.Patch patch, Long pkgVersionId, DSLContext context) {
+    public HashSet<String> getFastenUrisForPatch(Vulnerability.Patch patch, Long pkgVersionId,
+                                                 DSLContext context) {
         var fastenURIs = new HashSet<String>();
 
         // Get the fileID
@@ -140,19 +155,17 @@ public class MetadataUtility {
     /**
      * Retrieves the package_version_id given the purl of the package version.
      *
-     * @param purl - follows purl specifications
+     * @param purlObj - purl object go bank the information
      * @return negative if it cannot be found
      */
-    public Long getPackageVersionId(String purl, DSLContext context, Long pkgId) {
-        logger.info("Looking for package_version_id of " + purl);
-        PURLPackage packageObject = PURLPackage.getObjectFromPurl(purl);
-
+    public Long getPackageVersionId(PURLPackage purlObj, DSLContext context, Long pkgId) {
+        logger.info("Looking for package_version_id of " + purlObj.getName());
         assert pkgId > 0L;
 
         var pkgVersionRecord = context.select(PackageVersions.PACKAGE_VERSIONS.ID)
                 .from(PackageVersions.PACKAGE_VERSIONS)
                 .where(PackageVersions.PACKAGE_VERSIONS.PACKAGE_ID.equal(pkgId))
-                .and(PackageVersions.PACKAGE_VERSIONS.VERSION.equal(packageObject.getVersion()))
+                .and(PackageVersions.PACKAGE_VERSIONS.VERSION.equal(purlObj.getVersion()))
                 .fetchOne();
         return pkgVersionRecord != null ? pkgVersionRecord.component1() : -1L;
     }
@@ -192,18 +205,14 @@ public class MetadataUtility {
     /**
      * Returns package ID given PURL and CONTEXT (forge).
      *
-     * @param basePurl    - PURL string without version information
+     * @param pkgName - Package name
      * @param context - DSLContext
      * @return -1L if not existing
      */
-    public Long getPackageId(String basePurl, DSLContext context) {
-        var coordinateSeparator = basePurl.startsWith("pkg:maven") ? Constants.mvnCoordinateSeparator : "";
-        basePurl = basePurl.startsWith("pkg:maven") ? basePurl.substring(basePurl.indexOf("/") + 1)
-                : basePurl.substring(basePurl.lastIndexOf("/"));
-        var coordinate = basePurl.replace("/", coordinateSeparator);
+    public Long getPackageId(String pkgName, DSLContext context) {
         var pkgRecord = context.select(Packages.PACKAGES.ID)
                 .from(Packages.PACKAGES)
-                .where(Packages.PACKAGES.PACKAGE_NAME.equal(coordinate))
+                .where(Packages.PACKAGES.PACKAGE_NAME.equal(pkgName))
                 .fetchOne();
         return pkgRecord != null ? pkgRecord.component1() : -1L;
     }
@@ -216,40 +225,34 @@ public class MetadataUtility {
      * @param context       - DSL context
      * @return - List of ids of the callables
      */
-    public List<Long> getCallableIdsForFastenUri(String fastenUri, List<Long> pkgVersionIds, DSLContext context) {
+    public List<Long> getCallableIdsForFastenUri(String fastenUri, List<Long> pkgVersionIds,
+                                                 DSLContext context) {
         // Gets callables IDS with given fasten_uri
-        var callIds = context.select(Callables.CALLABLES.ID)
+        var callInfo = context.select(Callables.CALLABLES.ID, Modules.MODULES.NAMESPACE,
+                Modules.MODULES.PACKAGE_VERSION_ID)
                 .from(Callables.CALLABLES)
                 .join(Modules.MODULES).on(Modules.MODULES.ID.eq(Callables.CALLABLES.MODULE_ID))
                 .where(Callables.CALLABLES.FASTEN_URI.equal(fastenUri))
                 .and(Modules.MODULES.PACKAGE_VERSION_ID.in(pkgVersionIds))
                 .fetch();
 
-        return callIds.stream().map(Record1::component1).collect(Collectors.toList());
+        // Inject info into cache
+        callInfo.forEach(r -> cache.mdlNamespaceToPkgVsn.put(r.value2(), cache.pkgVsnIdToVsn.get(r.value3())));
+        callInfo.forEach(r -> cache.callIdToNamespace.put(r.value1(), r.value2()));
+        return new ArrayList<>(callInfo.map(Record3::value1));
     }
 
     /**
-     * Builds full fasten_uri given the callable ID.
-     * @param id - callable Id
-     * @param context - DSL context
-     * @return full fasten_uri
+     * Builds a full fasten uri using information in the Cache
+     * @param partialFastenUri - partial fasten_uri of the callable
+     * @param callId - callable ID - Long
+     * @return String - full_fasten_uri
      */
-    public String getCallableInfo(Long id, DSLContext context) {
-        var callInfo = context.select(Callables.CALLABLES.FASTEN_URI, Modules.MODULES.NAMESPACE,
-                PackageVersions.PACKAGE_VERSIONS.VERSION, Packages.PACKAGES.PACKAGE_NAME)
-                .from(Callables.CALLABLES)
-                .join(Modules.MODULES).on(Callables.CALLABLES.MODULE_ID.eq(Modules.MODULES.ID))
-                .join(PackageVersions.PACKAGE_VERSIONS).on(Modules.MODULES.PACKAGE_VERSION_ID.eq(PackageVersions.PACKAGE_VERSIONS.ID))
-                .join(Packages.PACKAGES).on(PackageVersions.PACKAGE_VERSIONS.PACKAGE_ID.eq(Packages.PACKAGES.ID))
-                .where(Callables.CALLABLES.ID.eq(id))
-                .fetchOne();
-
-        var partialFastenUri = callInfo.component1();
-        var namespace = callInfo.component2();
-        var pkgVersion = callInfo.component3();
-        var pkgName = callInfo.component4();
-
-        return generateFullFastenUri(pkgName, pkgVersion, namespace, partialFastenUri);
+    public String getFullFastenUri(String partialFastenUri, Long callId) {
+        var moduleNamespace = cache.callIdToNamespace.get(callId);
+        var pkgVersion = cache.mdlNamespaceToPkgVsn.get(moduleNamespace);
+        var pkgName = cache.pkgVsnToName.get(pkgVersion);
+        return generateFullFastenUri(pkgName, pkgVersion, moduleNamespace, partialFastenUri);
     }
 
     //////////////////////////
@@ -334,6 +337,11 @@ public class MetadataUtility {
     //////////////////////////
     //    DATABASE PURGE    //
     //////////////////////////
+
+    /**
+     *  Purges all vulnerability information from the DB.
+     * @param contexts - DSL contexts to be purged
+     */
     public void purgeFromDB(Map<String, DSLContext> contexts) {
         // Purge each of the DBs
         for (String ecosystem : contexts.keySet()) {

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
@@ -228,8 +228,7 @@ public class MetadataUtility {
     public List<Long> getCallableIdsForFastenUri(String fastenUri, List<Long> pkgVersionIds,
                                                  DSLContext context) {
         // Gets callables IDS with given fasten_uri
-        var callInfo = context.select(Callables.CALLABLES.ID, Modules.MODULES.NAMESPACE,
-                Modules.MODULES.PACKAGE_VERSION_ID)
+        var callInfo = context.select(Callables.CALLABLES.ID, Modules.MODULES.PACKAGE_VERSION_ID)
                 .from(Callables.CALLABLES)
                 .join(Modules.MODULES).on(Modules.MODULES.ID.eq(Callables.CALLABLES.MODULE_ID))
                 .where(Callables.CALLABLES.FASTEN_URI.equal(fastenUri))
@@ -237,9 +236,8 @@ public class MetadataUtility {
                 .fetch();
 
         // Inject info into cache
-        callInfo.forEach(r -> cache.mdlNamespaceToPkgVsn.put(r.value2(), cache.pkgVsnIdToVsn.get(r.value3())));
-        callInfo.forEach(r -> cache.callIdToNamespace.put(r.value1(), r.value2()));
-        return new ArrayList<>(callInfo.map(Record3::value1));
+        callInfo.forEach(r -> cache.callIdToPkgVsn.put(r.value1(), cache.pkgVsnIdToVsn.get(r.value2())));
+        return new ArrayList<>(callInfo.map(Record2::value1));
     }
 
     /**
@@ -249,10 +247,9 @@ public class MetadataUtility {
      * @return String - full_fasten_uri
      */
     public String getFullFastenUri(String partialFastenUri, Long callId) {
-        var moduleNamespace = cache.callIdToNamespace.get(callId);
-        var pkgVersion = cache.mdlNamespaceToPkgVsn.get(moduleNamespace);
+        var pkgVersion = cache.callIdToPkgVsn.get(callId);
         var pkgName = cache.pkgVsnToName.get(pkgVersion);
-        return generateFullFastenUri(pkgName, pkgVersion, moduleNamespace, partialFastenUri);
+        return generateFullFastenUri(pkgName, pkgVersion, partialFastenUri);
     }
 
     //////////////////////////

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Cache.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Cache.java
@@ -21,12 +21,13 @@ package eu.fasten.analyzer.vulnerabilityconsumer.utils;
 import java.util.HashMap;
 
 public class Cache {
+    // Necessary
     // pkg_version --> pkg_name
     public HashMap<String, String> pkgVsnToName = new HashMap<>();
-    // namespace --> pkg_version
-    public HashMap<String, String> mdlNamespaceToPkgVsn = new HashMap<>();
-    // callable_id --> namespace
-    public HashMap<Long, String> callIdToNamespace = new HashMap<>();
+    // callable_id --> pkg_version
+    public HashMap<Long, String> callIdToPkgVsn = new HashMap<>();
+
+    // Extra
     // pkg_id --> pkg_name
     public HashMap<Long, String> pkgIdToName = new HashMap<>();
     // pkg_version_id --> pkg_vsn

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Cache.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Cache.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.analyzer.vulnerabilityconsumer.utils;
+
+import java.util.HashMap;
+
+public class Cache {
+    // pkg_version --> pkg_name
+    public HashMap<String, String> pkgVsnToName = new HashMap<>();
+    // namespace --> pkg_version
+    public HashMap<String, String> mdlNamespaceToPkgVsn = new HashMap<>();
+    // callable_id --> namespace
+    public HashMap<Long, String> callIdToNamespace = new HashMap<>();
+    // pkg_id --> pkg_name
+    public HashMap<Long, String> pkgIdToName = new HashMap<>();
+    // pkg_version_id --> pkg_vsn
+    public HashMap<Long, String> pkgVsnIdToVsn = new HashMap<>();
+
+    public Cache() {
+    }
+}

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
@@ -123,6 +123,7 @@ public class Vulnerability {
         return id;
     }
 
+    @JsonProperty("vulnerable_purls")
     public List<String> getPurls() {
         return purls;
     }
@@ -173,7 +174,7 @@ public class Vulnerability {
         return patches;
     }
 
-    @JsonProperty("callable_uris")
+    @JsonProperty("vulnerable_fasten_uris")
     public HashSet<String> getFastenUris() {
         return fastenUris;
     }

--- a/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
+++ b/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
@@ -113,7 +113,7 @@ public class VulnerabilityConsumerTest {
         doNothing().when(metadataUtility).injectPackageVersionVulnerability(Mockito.any(Vulnerability.class), Mockito.anyLong(), Mockito.any(DSLContext.class));
         when(metadataUtility.getCallableIdsForFastenUri(fasten_uri, pkgVersionIds, context)).thenReturn(Arrays.asList(42L));
         when(metadataUtility.injectCallableVulnerability(Mockito.any(Vulnerability.class), Mockito.anyLong(), Mockito.any(DSLContext.class))).thenReturn(1);
-        when(metadataUtility.getCallableInfo(1L, context)).thenReturn("full_fasten_uri");
+        when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
         vulnerabilityConsumerExtension.injectVulnerabilityIntoDB(v, metadataUtility);
@@ -127,7 +127,7 @@ public class VulnerabilityConsumerTest {
         // VERIFY injection
         Mockito.verify(metadataUtility).injectPackageVersionVulnerability(v, 1L, context);
         Mockito.verify(metadataUtility).injectCallableVulnerability(v, 42L, context);
-        Mockito.verify(metadataUtility).getCallableInfo(42L, context);
+        Mockito.verify(metadataUtility).getFullFastenUri(fasten_uri, 42L);
     }
 
     @Test


### PR DESCRIPTION
## Description
Avoids a very costly `getCallableInfo` query by caching previous results to build the `full_fasten_uri` of each callable. 

## Motivation and context
The injection of vulnerabilities is extremely slow due to the `getCallableInfo` query, which joins 4 different tables together. Using Caching, we can avoid this heavy operation.

## Testing
Ran locally and accommodated changes in unit tests.

## Task list  
- [x] Implemented Caching
- [x] Tested locally
- [x] Tested on monster

## Additional context
n/a