### PR TITLE
Fixing missing graphDB nodes

### DIFF
--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -33,6 +33,8 @@ import eu.fasten.core.plugins.KafkaPlugin;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -224,8 +226,9 @@ public class MetadataDBExtension implements KafkaPlugin, DBConnector {
                 callGraph.getCgGenerator(), callGraph.version, null,
                 getProperTimestamp(callGraph.timestamp), new JSONObject());
 
-        var callables = insertDataExtractCallables(callGraph, metadataDao, packageVersionId);
-        var numInternal = callables.size();
+        var allCallables = insertDataExtractCallables(callGraph, metadataDao, packageVersionId);
+        var callables = allCallables.getLeft();
+        var numInternal = allCallables.getRight();
 
         var callablesIds = new LongArrayList(callables.size());
         // Save all callables in the database
@@ -264,9 +267,9 @@ public class MetadataDBExtension implements KafkaPlugin, DBConnector {
 
     // All classes that implements this class must provide an implementation
     // for this method. We cannot convert this class to an abstract class.
-    public ArrayList<CallablesRecord> insertDataExtractCallables(
+    public Pair<ArrayList<CallablesRecord>, Integer> insertDataExtractCallables(
             ExtendedRevisionCallGraph callgraph, MetadataDao metadataDao, long packageVersionId) {
-        return new ArrayList<CallablesRecord>();
+        return new ImmutablePair<>(new ArrayList<>(), 0);
     }
 
     protected List<EdgesRecord> insertEdges(Graph graph,

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabaseJavaPlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabaseJavaPlugin.java
@@ -31,6 +31,8 @@ import eu.fasten.core.data.metadatadb.codegen.tables.records.CallablesRecord;
 import eu.fasten.core.data.metadatadb.codegen.tables.records.EdgesRecord;
 import eu.fasten.core.data.metadatadb.codegen.udt.records.ReceiverRecord;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.json.JSONObject;
@@ -77,7 +79,7 @@ public class MetadataDatabaseJavaPlugin extends Plugin {
                     + groupId + File.separator + product + ".json";
         }
 
-        public ArrayList<CallablesRecord> insertDataExtractCallables(
+        public Pair<ArrayList<CallablesRecord>, Integer> insertDataExtractCallables(
                 ExtendedRevisionCallGraph callgraph, MetadataDao metadataDao, long packageVersionId) {
             ExtendedRevisionJavaCallGraph javaCallGraph = (ExtendedRevisionJavaCallGraph) callgraph;
             var callables = new ArrayList<CallablesRecord>();
@@ -92,13 +94,15 @@ public class MetadataDatabaseJavaPlugin extends Plugin {
                 callables.addAll(extractCallablesFromType(type, moduleId, true));
             }
 
+            var numInternal = callables.size();
+
             var externalTypes = cha.get(JavaScope.externalTypes);
             // Extract all external callables
             for (var fastenUri : externalTypes.keySet()) {
                 var type = externalTypes.get(fastenUri);
                 callables.addAll(extractCallablesFromType(type, -1L, false));
             }
-            return callables;
+            return new ImmutablePair<>(callables, numInternal);
         }
 
         protected long insertModule(JavaType type, FastenURI fastenUri,

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPlugin.java
@@ -33,6 +33,8 @@ import eu.fasten.core.data.metadatadb.codegen.udt.records.ReceiverRecord;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.json.JSONObject;
@@ -62,7 +64,7 @@ public class MetadataDatabasePythonPlugin extends Plugin {
             return MetadataDBPythonExtension.dslContext;
         }
 
-        public ArrayList<CallablesRecord> insertDataExtractCallables(ExtendedRevisionCallGraph callgraph, MetadataDao metadataDao, long packageVersionId) {
+        public Pair<ArrayList<CallablesRecord>, Integer> insertDataExtractCallables(ExtendedRevisionCallGraph callgraph, MetadataDao metadataDao, long packageVersionId) {
             ExtendedRevisionPythonCallGraph pythonCallGraph = (ExtendedRevisionPythonCallGraph) callgraph;
 
             var callables = new ArrayList<CallablesRecord>();
@@ -80,6 +82,8 @@ public class MetadataDatabasePythonPlugin extends Plugin {
                 callables.addAll(extractCallablesFromType(type, moduleId, true));
             }
 
+            var numInternal = callables.size();
+
             var externals = cha.get(PythonScope.external);
             // Extract all external callables
             for (var entry : externals.entrySet()) {
@@ -87,7 +91,7 @@ public class MetadataDatabasePythonPlugin extends Plugin {
                 callables.addAll(extractCallablesFromType(type, -1L, false));
             }
 
-            return callables;
+            return new ImmutablePair<>(callables, numInternal);
         }
 
         private List<CallablesRecord> extractCallablesFromType(PythonType type,


### PR DESCRIPTION
## Description
Keeping track of internal and external nodes number when creating GID graphs

## Motivation and context
Graphs that were stored in the graph database had all nodes labeled as internal. Type of nodes in important for merge algorithm.

## Testing
Regression testing + manual testing 

## Task list  
- [ ] Store the proper number of internal calls in a GID graph

