### PR TITLE
Using JSONUtils to send/save very large call graphs

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
@@ -24,6 +24,7 @@ import eu.fasten.analyzer.javacgopal.data.PartialCallGraph;
 import eu.fasten.analyzer.javacgopal.data.exceptions.MissingArtifactException;
 import eu.fasten.analyzer.javacgopal.data.exceptions.OPALException;
 import eu.fasten.core.data.ExtendedRevisionJavaCallGraph;
+import eu.fasten.core.data.JSONUtils;
 import eu.fasten.core.data.JavaScope;
 import eu.fasten.core.merge.LocalMerger;
 import eu.fasten.core.merge.CallGraphUtils;
@@ -238,7 +239,7 @@ public class Main implements Runnable {
             if (!this.output.isEmpty()) {
                 CallGraphUtils.writeToFile(Paths.get(Paths.get(this.output).getParent().toString(),
                         FilenameUtils.getBaseName(this.output) + "_" + result.product + "_merged" + "." +
-                                FilenameUtils.getExtension(this.output)).toString(), result.toJSON(), "");
+                                FilenameUtils.getExtension(this.output)).toString(), JSONUtils.toJSONString(result), "");
             }
         }
 
@@ -287,7 +288,8 @@ public class Main implements Runnable {
                 .format((System.currentTimeMillis() - startTime) / 1000d));
 
         if (writeToFile) {
-            CallGraphUtils.writeToFile(this.output, revisionCallGraph.toJSON(), "");
+            CallGraphUtils.writeToFile(this.output, JSONUtils.toJSONString(revisionCallGraph), "");
+
         }
         return revisionCallGraph;
     }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -25,6 +25,7 @@ import eu.fasten.analyzer.javacgopal.data.exceptions.MissingArtifactException;
 import eu.fasten.analyzer.javacgopal.data.exceptions.OPALException;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.ExtendedRevisionJavaCallGraph;
+import eu.fasten.core.data.JSONUtils;
 import eu.fasten.core.plugins.KafkaPlugin;
 import java.io.File;
 import java.util.ArrayList;
@@ -115,7 +116,7 @@ public class OPALPlugin extends Plugin {
         @Override
         public Optional<String> produce() {
             if (this.graph != null && !this.graph.isCallGraphEmpty()) {
-                return Optional.of(graph.toJSON().toString());
+                return Optional.of(JSONUtils.toJSONString(graph));
             } else {
                 return Optional.empty();
             }

--- a/core/src/main/java/eu/fasten/core/merge/CallGraphUtils.java
+++ b/core/src/main/java/eu/fasten/core/merge/CallGraphUtils.java
@@ -20,6 +20,7 @@ package eu.fasten.core.merge;
 
 import eu.fasten.core.data.ExtendedRevisionCallGraph;
 import eu.fasten.core.data.ExtendedRevisionJavaCallGraph;
+import eu.fasten.core.data.JSONUtils;
 import eu.fasten.core.data.JavaNode;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -63,8 +64,8 @@ public class CallGraphUtils {
         final String graphPath =
                 resultPath + graphNumber + "_" + firstGraph.product + "." + firstGraph.version;
 
-        writeToFile(graphPath, firstGraph.toJSON(), "_1.txt");
-        writeToFile(graphPath, secondGraph.toJSON(), "_2.txt");
+        writeToFile(graphPath, JSONUtils.toJSONString(firstGraph), "_1.txt");
+        writeToFile(graphPath, JSONUtils.toJSONString(secondGraph), "_2.txt");
 
         Runtime.getRuntime().exec(new String[]{"sh", "-c",
                 "diff " + graphPath + "_1.txt" + " " + graphPath + "_2.txt" + " > " + graphPath
@@ -79,14 +80,14 @@ public class CallGraphUtils {
      * @param suffix the suffix to put at the end of the path, most of the time file name
      * @throws IOException throws if IO problems occur during writing in a file
      */
-    public static void writeToFile(final String path, final JSONObject graph, final String suffix)
+    public static void writeToFile(final String path, final String graph, final String suffix)
             throws IOException {
         if (!graph.isEmpty()) {
             logger.info("Writing graph to {}", path + suffix);
         }
         final BufferedWriter writer;
         writer = new BufferedWriter(new FileWriter(path + suffix));
-        writer.write(graph.toString(4));
+        writer.write(graph);
         writer.close();
     }
 

--- a/core/src/main/java/eu/fasten/core/merge/Merger.java
+++ b/core/src/main/java/eu/fasten/core/merge/Merger.java
@@ -21,6 +21,7 @@ package eu.fasten.core.merge;
 import ch.qos.logback.classic.Level;
 import eu.fasten.core.data.ExtendedRevisionCallGraph;
 import eu.fasten.core.data.ExtendedRevisionJavaCallGraph;
+import eu.fasten.core.data.JSONUtils;
 import eu.fasten.core.data.JavaScope;
 import eu.fasten.core.data.graphdb.RocksDao;
 import eu.fasten.core.dbconnectors.PostgresConnector;
@@ -161,7 +162,7 @@ public class Merger implements Runnable {
 
                     if (output != null) {
                         try {
-                            CallGraphUtils.writeToFile(output, mergedERCG.toJSON(), "");
+                            CallGraphUtils.writeToFile(output, JSONUtils.toJSONString(mergedERCG), "");
                         } catch (IOException e) {
                             logger.error("Unable to write to file");
                         }


### PR DESCRIPTION
## Description
The newly-developed`JSONUtils` in `eu.fasten.core.data` is used to send and save very large call graphs produced by the OPAL plugin. Specifically, I have made the necessary changes to `CallGraphUtils` and the OPAL plug-in itself.

## Motivation and context
Previously, we encountered quite a number of `OutOfMemoryError`exceptions when converting very large ERCGs objects to a JSON string.

## Testing
- The `Main` module of the OPAL plug-in works fine while saving a very large CG, i.e. `org.jetbrains.kotlin:kotlin-compiler:1.4.21`
- The FASTEN server can now send or save very large CGs on the disk.

## Task list  
- [x] Make changes to `CallGraphUtils.write()` and its usages to make it work with `JSONUtils.toJSONString()`.
- [x] Use `JSONUtils.toJSONString()` in the `Main` module and the `OPAL` pluging class. 
