### PR TITLE
Fix Kafka configuration for OPAL (rebalancing issue)

### DIFF
--- a/analyzer/graph-plugin/src/main/java/eu/fasten/analyzer/graphplugin/GraphDatabasePlugin.java
+++ b/analyzer/graph-plugin/src/main/java/eu/fasten/analyzer/graphplugin/GraphDatabasePlugin.java
@@ -28,10 +28,9 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -194,6 +193,11 @@ public class GraphDatabasePlugin extends Plugin {
         public void freeResource() {
             rocksDao.close();
             rocksDao = null;
+        }
+
+        @Override
+        public Properties getConsumerProperties() {
+            return new Properties(); // GraphDB plugin relies on default configuration.
         }
     }
 }

--- a/analyzer/graph-plugin/src/main/java/eu/fasten/analyzer/graphplugin/GraphDatabasePlugin.java
+++ b/analyzer/graph-plugin/src/main/java/eu/fasten/analyzer/graphplugin/GraphDatabasePlugin.java
@@ -194,10 +194,5 @@ public class GraphDatabasePlugin extends Plugin {
             rocksDao.close();
             rocksDao = null;
         }
-
-        @Override
-        public Properties getConsumerProperties() {
-            return new Properties(); // GraphDB plugin relies on default configuration.
-        }
     }
 }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -27,10 +27,9 @@ import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.ExtendedRevisionJavaCallGraph;
 import eu.fasten.core.plugins.KafkaPlugin;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.json.JSONObject;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -165,6 +164,23 @@ public class OPALPlugin extends Plugin {
         @Override
         public String version() {
             return "0.1.2";
+        }
+
+        @Override
+        public Properties getConsumerProperties() {
+            Properties properties = new Properties();
+
+            // Assign a static ID to the consumer based pods' unique name in K8s env.
+            if (System.getenv("POD_INSTANCE_ID") != null) {
+                logger.info(String.format("Pod ID: %s", System.getenv("POD_INSTANCE_ID")));
+                properties.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, System.getenv("POD_INSTANCE_ID"));
+            }
+
+            // Proper configuration for OPAL consumption.
+            properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000");
+            properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "300000");
+            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
+            return properties;
         }
     }
 }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -166,21 +166,21 @@ public class OPALPlugin extends Plugin {
             return "0.1.2";
         }
 
+
         @Override
-        public Properties getConsumerProperties() {
-            Properties properties = new Properties();
-
-            // Assign a static ID to the consumer based pods' unique name in K8s env.
-            if (System.getenv("POD_INSTANCE_ID") != null) {
-                logger.info(String.format("Pod ID: %s", System.getenv("POD_INSTANCE_ID")));
-                properties.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, System.getenv("POD_INSTANCE_ID"));
-            }
-
-            // Proper configuration for OPAL consumption.
-            properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000");
-            properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "300000");
-            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
-            return properties;
+        public boolean isStaticMembership() {
+            return true; // The OPAL plugin relies on static members in a consumer group (using a K8s StatefulSet).
         }
+
+        @Override
+        public long getMaxConsumeTimeout() {
+            return 3600000; //The OPAL plugin takes up to 1h to process a record.
+        }
+
+        @Override
+        public long getSessionTimeout() {
+            return 300000; // Due to static membership we also want to tune the session timeout to 5 minutes.
+        }
+
     }
 }

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -324,12 +324,7 @@ public class MetadataDBExtension implements KafkaPlugin, DBConnector {
     }
 
     @Override
-    public Properties getConsumerProperties() {
-        Properties properties = new Properties();
-
-        // Set max poll interval to 15 minutes.
-        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "900000");
-
-        return properties;
+    public long getMaxConsumeTimeout() {
+        return 900000; //The MetadataDB plugin takes up to 15 minutes to process a record.
     }
 }

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -33,6 +33,7 @@ import eu.fasten.core.plugins.KafkaPlugin;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -47,11 +48,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.sql.BatchUpdateException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 public class MetadataDBExtension implements KafkaPlugin, DBConnector {
 
@@ -324,5 +321,15 @@ public class MetadataDBExtension implements KafkaPlugin, DBConnector {
     @Override
     public void freeResource() {
 
+    }
+
+    @Override
+    public Properties getConsumerProperties() {
+        Properties properties = new Properties();
+
+        // Set max poll interval to 15 minutes.
+        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "900000");
+
+        return properties;
     }
 }

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -287,10 +287,5 @@ public class POMAnalyzerPlugin extends Plugin {
         public void freeResource() {
 
         }
-
-        @Override
-        public Properties getConsumerProperties() {
-            return new Properties(); // Rely on default consumer configuration.
-        }
     }
 }

--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -26,10 +26,9 @@ import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
 import java.io.File;
 import java.sql.Timestamp;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -287,6 +286,11 @@ public class POMAnalyzerPlugin extends Plugin {
         @Override
         public void freeResource() {
 
+        }
+
+        @Override
+        public Properties getConsumerProperties() {
+            return new Properties(); // Rely on default consumer configuration.
         }
     }
 }

--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/QualityAnalyzerPlugin.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/QualityAnalyzerPlugin.java
@@ -193,14 +193,10 @@ public class QualityAnalyzerPlugin extends Plugin {
         }
 
         @Override
-        public Properties getConsumerProperties() {
-            Properties properties = new Properties();
-
-            // Set max poll interval to 15 minutes.
-            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
-
-            return properties;
+        public long getMaxConsumeTimeout() {
+            return 3600000; //The QualityAnalyzer plugin takes up to 1h to process a record.
         }
+
     }
 
 

--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/QualityAnalyzerPlugin.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/QualityAnalyzerPlugin.java
@@ -24,6 +24,7 @@ import eu.fasten.core.data.Constants;
 import eu.fasten.core.plugins.KafkaPlugin;
 import eu.fasten.core.plugins.DBConnector;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.jooq.exception.DataAccessException;
 import org.json.JSONObject;
 import org.pf4j.Extension;
@@ -34,10 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
 import java.sql.BatchUpdateException;
-import java.util.Map;
-import java.util.Optional;
-import java.util.List;
-import java.util.Collections;
+import java.util.*;
 
 import org.jooq.DSLContext;
 
@@ -192,6 +190,16 @@ public class QualityAnalyzerPlugin extends Plugin {
 
         public void setPluginError(Throwable throwable) {
             this.pluginError = throwable;
+        }
+
+        @Override
+        public Properties getConsumerProperties() {
+            Properties properties = new Properties();
+
+            // Set max poll interval to 15 minutes.
+            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
+
+            return properties;
         }
     }
 

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -28,6 +28,9 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.json.JSONObject;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -239,6 +242,16 @@ public class RepoClonerPlugin extends Plugin {
 
         @Override
         public void freeResource() {
+        }
+
+        @Override
+        public Properties getConsumerProperties() {
+            Properties properties = new Properties();
+
+            // Set max poll interval to 30 minutes.
+            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "1800000");
+
+            return properties;
         }
     }
 }

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -245,13 +245,8 @@ public class RepoClonerPlugin extends Plugin {
         }
 
         @Override
-        public Properties getConsumerProperties() {
-            Properties properties = new Properties();
-
-            // Set max poll interval to 30 minutes.
-            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "1800000");
-
-            return properties;
+        public long getMaxConsumeTimeout() {
+            return 1800000; //The RepoCloner plugin takes up to 30 minutes to process a record.
         }
     }
 }

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -25,6 +25,7 @@ import eu.fasten.analyzer.vulnerabilityconsumer.utils.PURLPackage;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.jooq.DSLContext;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -259,6 +260,16 @@ public class VulnerabilityConsumer extends Plugin {
             logger.info("Purging ALL the databases from all vulnerability entries");
             var metadataUtility = new MetadataUtility();
             metadataUtility.purgeFromDB(contexts);
+        }
+
+        @Override
+        public Properties getConsumerProperties() {
+            Properties properties = new Properties();
+
+            // Set max poll interval to 1 hour.
+            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
+
+            return properties;
         }
     }
 }

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -263,13 +263,8 @@ public class VulnerabilityConsumer extends Plugin {
         }
 
         @Override
-        public Properties getConsumerProperties() {
-            Properties properties = new Properties();
-
-            // Set max poll interval to 1 hour.
-            properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
-
-            return properties;
+        public long getMaxConsumeTimeout() {
+            return 3600000; // The VulnerabilityConsumer plugin takes up to 1h to process a record.
         }
     }
 }

--- a/core/src/main/java/eu/fasten/core/plugins/KafkaPlugin.java
+++ b/core/src/main/java/eu/fasten/core/plugins/KafkaPlugin.java
@@ -67,9 +67,37 @@ public interface KafkaPlugin extends FastenPlugin {
 
 
     /**
-     * This properties can be used to override the default Kafka consumer properties.
+     * Corresponds to `max.poll.interval.ms` in the Kafka Consumer config.
+     * Default is set to 2 minutes.
      *
-     * @return consumer properties.
+     * Overriding this method will be reflected in the Kafka Consumer config.
+     * @return the maximum time (in ms) a plugin can spend on a single record before timeout.
      */
-    Properties getConsumerProperties();
+    default long getMaxConsumeTimeout() {
+        return 120000;
+    }
+
+    /**
+     * Corresponds to `session.timeout.ms` in the Kafka Consumer config.
+     * Default is set to 1 minute.
+     *
+     * Overriding this method will be reflected in the Kafka Consumer config.
+     * @return the maximum time (in ms) a plugin can be unresponsive in the heartbeat thread, before it's considered 'dead'.
+     */
+    default long getSessionTimeout() {
+        return 60000;
+    }
+
+    /**
+     * Reflects if the Kafka consumer should enable 'Static Membership'.
+     * Default is set to false.
+     *
+     * Overriding this method will be reflected in the Kafka Consumer config.
+     * If enabled, the plugin should set `POD_INSTANCE_ID` as environment variable. Each plugin/deployment should have an unique and static id.
+     * This `POD_INSTANCE_ID` will be set in Kafka Consumer config for the key `group.instance.id`.
+     * @return if the plugin should consume using 'Static Membership'.
+     */
+    default boolean isStaticMembership() {
+        return false;
+    }
 }

--- a/core/src/main/java/eu/fasten/core/plugins/KafkaPlugin.java
+++ b/core/src/main/java/eu/fasten/core/plugins/KafkaPlugin.java
@@ -20,6 +20,7 @@ package eu.fasten.core.plugins;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 public interface KafkaPlugin extends FastenPlugin {
     /**
@@ -63,4 +64,12 @@ public interface KafkaPlugin extends FastenPlugin {
      * @return relative path to the output file
      */
     String getOutputPath();
+
+
+    /**
+     * This properties can be used to override the default Kafka consumer properties.
+     *
+     * @return consumer properties.
+     */
+    Properties getConsumerProperties();
 }

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -211,7 +211,10 @@ public class FastenServer implements Runnable {
         return kafkaPlugins.stream().filter(x -> plugins.contains(x.getClass().getSimpleName())).map(k -> {
             var consumerProperties = KafkaConnector.kafkaConsumerProperties(
                     kafkaServers,
-                    k.getClass().getCanonicalName());
+                    k.getClass().getCanonicalName(),
+                    k.getSessionTimeout(),
+                    k.getMaxConsumeTimeout(),
+                    k.isStaticMembership());
             var producerProperties = KafkaConnector.kafkaProducerProperties(
                     kafkaServers,
                     k.getClass().getCanonicalName());

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -125,6 +125,12 @@ public class FastenServer implements Runnable {
     )
     String consumerGroup;
 
+    @Option(names = {"-ot", "--output_topic"},
+            paramLabel = "outputTopic",
+            description = "Name of the output topic. Defaults to (simple) name of the plugin."
+    )
+    String outputTopic;
+
     private static final Logger logger = LoggerFactory.getLogger(FastenServer.class);
 
     @Override
@@ -229,7 +235,8 @@ public class FastenServer implements Runnable {
 
             return new FastenKafkaPlugin(consumerProperties, producerProperties, k, skipOffsets,
                     (outputDirs != null) ? outputDirs.get(k.getClass().getSimpleName()) : null,
-                    (outputLinks != null) ? outputLinks.get(k.getClass().getSimpleName()) : null);
+                    (outputLinks != null) ? outputLinks.get(k.getClass().getSimpleName()) : null,
+                    (outputTopic != null) ? outputTopic : k.getClass().getSimpleName());
         }).collect(Collectors.toList());
     }
 

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -36,6 +36,7 @@ import java.sql.SQLException;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -116,6 +117,13 @@ public class FastenServer implements Runnable {
             paramLabel = "PATH",
             description = "Path to base directory to which data will be written")
     String baseDir;
+
+    @Option(names = {"-cg", "--consumer_group"},
+            paramLabel = "consumerGroup",
+            description = "Name of the consumer group. Defaults to (canonical) name of the plugin.",
+            defaultValue = "undefined"
+    )
+    String consumerGroup;
 
     private static final Logger logger = LoggerFactory.getLogger(FastenServer.class);
 
@@ -211,7 +219,7 @@ public class FastenServer implements Runnable {
         return kafkaPlugins.stream().filter(x -> plugins.contains(x.getClass().getSimpleName())).map(k -> {
             var consumerProperties = KafkaConnector.kafkaConsumerProperties(
                     kafkaServers,
-                    k.getClass().getCanonicalName(),
+                    (consumerGroup.equals("undefined") ? k.getClass().getCanonicalName() : consumerGroup), // if consumergroup == undefined, set to canonical name. If we upgrade to picocli 2.4.6 we can use optionals.
                     k.getSessionTimeout(),
                     k.getMaxConsumeTimeout(),
                     k.isStaticMembership());

--- a/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
+++ b/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
@@ -24,17 +24,24 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KafkaConnector {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaConnector.class);
 
     /**
      * Returns Kafka properties.
      *
      * @param serverAddresses broker address
      * @param groupId         group id
+     * @param sessionTimeout a value for `session.timeout.ms`.
+     * @param maxPollInterval a value for `max.poll.interval.ms`.
+     * @param staticMemberShip if static membership should be enabled.
      * @return Kafka Properties
      */
-    public static Properties kafkaConsumerProperties(List<String> serverAddresses, String groupId) {
+    public static Properties kafkaConsumerProperties(List<String> serverAddresses, String groupId, long sessionTimeout, long maxPollInterval, boolean staticMemberShip) {
         String deserializer = StringDeserializer.class.getName();
         Properties properties = new Properties();
 
@@ -47,14 +54,24 @@ public class KafkaConnector {
         properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         properties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         properties.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
+        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "5000"); // 5 seconds
 
-        // Default consumption configuration.
-        // heartbeat.interval is 5 seconds
+        if (staticMemberShip) {
+            // Assign a static ID to the consumer based pods' unique name in K8s env.
+            if (System.getenv("POD_INSTANCE_ID") != null) {
+                logger.info(String.format("Static Membership ID: %s", System.getenv("POD_INSTANCE_ID")));
+                properties.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, System.getenv("POD_INSTANCE_ID"));
+            } else {
+                logger.warn("Static Membership was enabled but POD_INSTANCE_ID was not defined. Plugin will proceed without Static Membership.");
+            }
+
+        }
+
+        // Default consumption configuration
         // session.timeout is 1 minutes
         // max.poll.interval is 2 minutes
-        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "5000");
-        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "60000");
-        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
+        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, String.valueOf(sessionTimeout));
+        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(maxPollInterval));
 
         return properties;
     }

--- a/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
+++ b/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
@@ -56,8 +56,8 @@ public class KafkaConnector {
 
         // Gives more time to the consumer for processing the records so
         // that the broker will NOT kill the consumer.
-        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "200000");
-        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "700000");
+        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000");
+        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "300000");
         properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
 
         return properties;

--- a/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
+++ b/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
@@ -48,16 +48,12 @@ public class KafkaConnector {
         properties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         properties.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
 
-        // Assign a static ID to the consumer based pods' unique name in K8s env.
-        if (System.getenv("POD_INSTANCE_ID") != null) {
-            System.out.println(String.format("Pod ID: %s", System.getenv("POD_INSTANCE_ID")));
-            properties.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, System.getenv("POD_INSTANCE_ID"));
-        }
-
-        // Gives more time to the consumer for processing the records so
-        // that the broker will NOT kill the consumer.
-        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000");
-        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "300000");
+        // Default consumption configuration.
+        // heartbeat.interval is 5 seconds
+        // session.timeout is 1 minutes
+        // max.poll.interval is 2 minutes
+        properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "5000");
+        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "60000");
         properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "3600000");
 
         return properties;

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -72,6 +72,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
         this.plugin = plugin;
 
         // Override default consumer properties.
+        // 'putAll' will override or add k/v pairs.
         consumerProperties.putAll(this.plugin.getConsumerProperties());
 
         this.connection = new KafkaConsumer<>(consumerProperties);

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -53,7 +53,9 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final KafkaConsumer<String, String> connection;
+
     private final KafkaProducer<String, String> producer;
+    private final String outputTopic;
 
     private final int skipOffsets;
 
@@ -68,7 +70,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      * @param skipOffsets        skip offset number
      */
     public FastenKafkaPlugin(Properties consumerProperties, Properties producerProperties,
-                             KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink) {
+                             KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink, String outputTopic) {
         this.plugin = plugin;
 
         this.connection = new KafkaConsumer<>(consumerProperties);
@@ -88,6 +90,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             this.writeLink = null;
         }
 
+        this.outputTopic = outputTopic;
         logger.debug("Constructed a Kafka plugin for " + plugin.getClass().getCanonicalName());
     }
 
@@ -177,12 +180,12 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             }
 
             emitMessage(this.producer, String.format("fasten.%s.out",
-                    plugin.getClass().getSimpleName()),
+                    outputTopic),
                     getStdOutMsg(input, payload, consumeTimestamp));
 
         } catch (Exception e) {
             emitMessage(this.producer, String.format("fasten.%s.err",
-                    plugin.getClass().getSimpleName()),
+                    outputTopic),
                     getStdErrMsg(input, e, consumeTimestamp));
         }
     }

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -71,10 +71,6 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
                              KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink) {
         this.plugin = plugin;
 
-        // Override default consumer properties.
-        // 'putAll' will override or add k/v pairs.
-        consumerProperties.putAll(this.plugin.getConsumerProperties());
-
         this.connection = new KafkaConsumer<>(consumerProperties);
         this.producer = new KafkaProducer<>(producerProperties);
 

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -71,6 +71,9 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
                              KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink) {
         this.plugin = plugin;
 
+        // Override default consumer properties.
+        consumerProperties.putAll(this.plugin.getConsumerProperties());
+
         this.connection = new KafkaConsumer<>(consumerProperties);
         this.producer = new KafkaProducer<>(producerProperties);
 


### PR DESCRIPTION
## The problem
We noticed that every now and then (read: almost every hour) OPAL consumption would go idle due to [Kafka rebalancing](https://medium.com/streamthoughts/apache-kafka-rebalance-protocol-or-the-magic-behind-your-streams-applications-e94baf68e4f2) its consumer group. Sometimes rebalancing took an hour, causing heavy disruption in the consuming process.
![cg-generation](https://i.imgur.com/BCL00VT.png)

Generally, there are 2 situations when a rebalance is triggered:

A consumer _joins_ a group (and therefore causes a rebalance):
- when an application is (re)started; this happens all the time for OPAL and is inevitable since some CG generations will cause OoM.
- when an application is scaled up; only manually OPAL pods will be scaled upwards.

A consumer _leaves_ a group (and therefore causes a rebalance):
- `max.poll.interval.ms` is exceeded, which means that the polled records are not processed in time. CG generation can take a long time, so this value should be as high as the maximum time spent on generating a CG.
- `session.timeout.ms` is exceeded, which means that the heartbeat thread is not sending heartbeats anymore.
- consumer shuts down (pod relocation, app scale-down, etc.)

Another reason why Kafka rebalances a consumer group could be a ZK session timeout (see [here](https://stackoverflow.com/questions/30988002/what-does-rebalancing-mean-in-apache-kafka-context)). We won't consider that scenario for this PR, but should be taken into account if issues still remain.

When a group is rebalancing, partitions get reassigned and current partitions get revoked. However, a partition gets revoked _only_ when that consumer is done processing its current poll. Since OPAL has (potentially) high processing times it can take up to `max.poll.interval.ms` before OPAL is done and a partition gets revoked. Currently `max.poll.interval.ms` is set to `1 hour`, so this is how long a rebalance might take. We can't change the rebalance protocol nor the time OPAL takes to process a poll, so we want to minimize the amount of rebalances.

## Proposed solution
Kafka Static Membership with a Kubernetes Stateful set. Kafka Static Membership allows for (static) consumers whose identities are persisted and recognized when restarted. This means that when a consumer restarts it gets assigned the _same_ partitions and no rebalancing is happening unless the `session.timeout.ms` is exceeded. We already use static membership in the current setup, but without a K8s stateful set. We need static pod id's and a persisted state, which is not guaranteed for a Deployment (which we currently use). More explicitly, I think we should use the following configuration/setup:
- Kafka Static Membership (this is already implemented)
- Deployment as a Stateful set, see [the PR in the deployment repo](https://github.com/fasten-project/k8s-deployments/pull/9).
- `max.poll.interval.ms` still set to `1 hour`. This is inevitable since we can't influence OPAL's speed.
- `session.timeout.ms` should be `5 minutes`. This is the time after which a consumer is considered 'dead' (i.e. it did not receive heartbeats in that period) and a rebalance is triggered. Moreover, this is the time a pod can safely restart/crash without triggering a rebalance.
- `heartbeat.interval.ms` to `10 seconds`. This is the interval at which heartbeats are sent to the coordinator, but also used to inform a rebalance is in progress. If this value is too high, healthy consumers are taking longer to be aware of a rebalance (currently it's set to 3 minutes). 


## Some considerations
- Default Kafka (consumer) configurations are applied in the Kafka server, which means that every plugin/analyzer will get the same configuration. Since OPAL's config is rather specific, we might want to override the default configuration for OPAL and create a more generic default configuration (without static membership).
- When we deploy a set of OPAL pods, not every application is started at exactly the same time. Therefore many rebalances could be triggered because consumers keep on joining the group (even with static membership). Therefore Kafka has the `group.initial.rebalance.delay.ms` configuration, which decides the initial rebalance delay. This is currently set to `0 ms`. I updated it to `10 seconds` which seems more reasonable. Though, it requires a full cluster restart which might not be preferable at the moment. 

## Task list
- [x] Change `Deployment` to `Stateful set`. See [this PR](https://github.com/fasten-project/k8s-deployments/pull/9).
- [x] Default Kafka config
    - Default heartbeat interval: `5 seconds`
    - Default session timeout: `1 minute`
    - Default max poll interval: `2 minutes`
- [x] Custom plugin configs
  - [x] Custom OPAL config implementing the above mentioned changes.
  - [x] Custom Metadata config: max poll interval of `15 minutes`.
  - [x] Custom Quality Analyzer config:  max poll interval of `1 hour`.
  - [x] Custom Vulnerability Consumer config: max poll interval of `1 hour`.
  - [x] Custom RepoCloner config: max poll interval of `30 minutes`.
  - [x] All other plugins fall back to all default consumer configs. 
- [x] Being able to override consumer group by using `-cg` or `--consumer_group`
- [x] Being able to override output topic by using `-ot` or `--output_topic`. Note: this value is still subsituted in `fasten.OUTPUT_TOPIC.[out|err]`
- [ ] Test?

## Testing
I still have to figure out how to properly test this.

## References
I based my ideas and observations on reading the [Kafka configuration reference](https://docs.confluent.io/platform/current/installation/configuration/broker-configs.html), [this blog post covering a similar issue](https://medium.com/bakdata/solving-my-weird-kafka-rebalancing-problems-c05e99535435g), [a blog post on Kafka rebalancing](https://medium.com/streamthoughts/apache-kafka-rebalance-protocol-or-the-magic-behind-your-streams-applications-e94baf68e4f2),  [a stackoverflow post on rebalancing](https://stackoverflow.com/questions/30988002/what-does-rebalancing-mean-in-apache-kafka-context) and some internal discussions over the past months.