### PR TITLE
Update log level from 'debug' to 'info'. 

### DIFF
--- a/analyzer/javacg-opal/src/main/resources/logback.xml
+++ b/analyzer/javacg-opal/src/main/resources/logback.xml
@@ -22,7 +22,7 @@
     </appender>
 
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="STDOUT-ERROR" />
     </root>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -22,7 +22,7 @@
     </appender>
 
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="STDOUT-ERROR" />
     </root>


### PR DESCRIPTION
Update default log level from 'debug' to 'info'. This code is used in a production environment and printing all debug statements makes it very hard to keep track of the logs. Making 'info' default will reduce some log statements. 
