### PR TITLE
Experiment with OPAL timeout and update some log levels.

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -174,7 +174,7 @@ public class OPALPlugin extends Plugin {
 
         @Override
         public long getMaxConsumeTimeout() {
-            return 3600000; //The OPAL plugin takes up to 1h to process a record.
+            return Integer.MAX_VALUE; // It can take very long to generate OPAL CG's.
         }
 
         @Override

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -21,6 +21,8 @@
         <target>System.err</target>
     </appender>
 
+    <logger name="org.jooq" level="INFO"/>
+    <logger name="org.apache.kafka" level="INFO"/>
 
     <root level="info">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Set log level for Kafka to info to reduce spam. 
Moreover, I will experiment with `max.poll.interval.ms` to Integer.MAX_INT. The idea is that we don't want to consider a consumer dead if it hasn't processed for a while (because this can vary a lot for OPAL), only when it stopped sending heartbeats (so when it actually crashed). 