### PR TITLE
Enable Static Membership if `POD_INSTANCE_ID` is in the env.

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -179,7 +179,7 @@ public class OPALPlugin extends Plugin {
 
         @Override
         public long getSessionTimeout() {
-            return 300000; // Due to static membership we also want to tune the session timeout to 5 minutes.
+            return 1800000; // Due to static membership we also want to tune the session timeout to 30 minutes.
         }
 
     }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -73,7 +73,7 @@ public class OPALPlugin extends Plugin {
             long startTime = System.nanoTime();
             try {
                 // Generate CG and measure construction duration.
-                logger.info("[CG-GENERATION] [UNPROCESSED] [-1i] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
+                logger.info("[CG-GENERATION] [UNPROCESSED] [-1] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
                 this.graph = PartialCallGraph.createExtendedRevisionJavaCallGraph(mavenCoordinate,
                         "", "CHA", kafkaConsumedJson.optLong("date", -1));
                 long endTime = System.nanoTime();
@@ -94,19 +94,19 @@ public class OPALPlugin extends Plugin {
                         + firstLetter + File.separator
                         + artifactId + File.separator + product + ".json";
 
-                logger.info("[CG-GENERATION] [SUCCESS] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
+                logger.info("[CG-GENERATION] [SUCCESS] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
 
             } catch (OPALException | EmptyCallGraphException e) {
                 long endTime = System.nanoTime();
                 long duration = (endTime - startTime) / 1000000; // Compute duration in ms.
 
-                logger.error("[CG-GENERATION] [FAILED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
+                logger.error("[CG-GENERATION] [FAILED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
                 setPluginError(e);
             } catch (MissingArtifactException e) {
                 long endTime = System.nanoTime();
                 long duration = (endTime - startTime) / 1000000; // Compute duration in ms.
 
-                logger.error("[ARTIFACT-DOWNLOAD] [FAILED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
+                logger.error("[ARTIFACT-DOWNLOAD] [FAILED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] " + e.getMessage(), e);
                 setPluginError(e);
             }
         }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/MavenCoordinate.java
@@ -180,12 +180,12 @@ public class MavenCoordinate {
                     found = false;
 
                     long duration = computeDurationInMs(startTime);
-                    logger.warn("[ARTIFACT-DOWNLOAD] [UNPROCESSED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
+                    logger.warn("[ARTIFACT-DOWNLOAD] [UNPROCESSED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
                 }
 
                 if (jar.isPresent()) {
                     long duration = computeDurationInMs(startTime);
-                    logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
+                    logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
                     return jar.get();
                 } else if (found && i == repos.size() - 1) {
                     throw new MissingArtifactException("Artifact couldn't be retrieved for repo: " + repos.get(i), null);
@@ -202,11 +202,11 @@ public class MavenCoordinate {
                         found = false;
 
                         long duration = computeDurationInMs(startTime);
-                        logger.warn("[ARTIFACT-DOWNLOAD] [UNPROCESSED] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
+                        logger.warn("[ARTIFACT-DOWNLOAD] [UNPROCESSED] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [" + e.getClass().getSimpleName() + "] Artifact couldn't be retrieved for repo: " + repos.get(i), e);
                     }
 
                     if (jar.isPresent()) {long duration = computeDurationInMs(startTime);
-                        logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "i] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
+                        logger.info("[ARTIFACT-DOWNLOAD] [SUCCESS] [" + duration + "] [" + mavenCoordinate.getCoordinate() + "] [NONE] Artifact retrieved from repo: " + repos.get(i));
                         return jar.get();
                     } else if (found && i == repos.size() - 1) {
                         throw new MissingArtifactException("Artifact couldn't be retrieved for repo: " + repos.get(i), null);

--- a/core/src/main/java/eu/fasten/core/plugins/KafkaPlugin.java
+++ b/core/src/main/java/eu/fasten/core/plugins/KafkaPlugin.java
@@ -79,18 +79,22 @@ public interface KafkaPlugin extends FastenPlugin {
 
     /**
      * Corresponds to `session.timeout.ms` in the Kafka Consumer config.
-     * Default is set to 1 minute.
+     * Default is set to 1 minute for non static membership, otherwise 10 minutes.
      *
      * Overriding this method will be reflected in the Kafka Consumer config.
      * @return the maximum time (in ms) a plugin can be unresponsive in the heartbeat thread, before it's considered 'dead'.
      */
     default long getSessionTimeout() {
-        return 60000;
+        if (!isStaticMembership()) {
+            return 600000;
+        } else {
+            return 60000;
+        }
     }
 
     /**
      * Reflects if the Kafka consumer should enable 'Static Membership'.
-     * Default is set to false.
+     * Default is enabled if the env POD_INSTANCE_ID is used.
      *
      * Overriding this method will be reflected in the Kafka Consumer config.
      * If enabled, the plugin should set `POD_INSTANCE_ID` as environment variable. Each plugin/deployment should have an unique and static id.
@@ -98,6 +102,6 @@ public interface KafkaPlugin extends FastenPlugin {
      * @return if the plugin should consume using 'Static Membership'.
      */
     default boolean isStaticMembership() {
-        return false;
+        return System.getenv("POD_INSTANCE_ID") != null;
     }
 }

--- a/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
+++ b/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
@@ -20,6 +20,8 @@ package eu.fasten.server.connectors;
 
 import java.util.List;
 import java.util.Properties;
+
+import eu.fasten.core.plugins.KafkaPlugin;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -56,6 +58,10 @@ public class KafkaConnector {
         properties.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
         properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "5000"); // 5 seconds
 
+        // Default consumption configuration
+        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, String.valueOf(sessionTimeout));
+        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(maxPollInterval));
+
         if (staticMemberShip) {
             // Assign a static ID to the consumer based pods' unique name in K8s env.
             if (System.getenv("POD_INSTANCE_ID") != null) {
@@ -66,12 +72,6 @@ public class KafkaConnector {
             }
 
         }
-
-        // Default consumption configuration
-        // session.timeout is 1 minutes
-        // max.poll.interval is 2 minutes
-        properties.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, String.valueOf(sessionTimeout));
-        properties.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(maxPollInterval));
 
         return properties;
     }

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -23,6 +23,7 @@
 
     <logger name="org.jooq" level="INFO"/>
     <logger name="org.apache.kafka" level="INFO"/>
+    <logger name="eu.fasten" level="INFO"/>
 
     <root level="info">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
A few changes:
- Static membership is automatically enabled if `POD_INSTANCE_ID` is defined in the environment
- Change some log levels
- Change OPAL session timeout to 30 minutes.
- If static membership is enabled, session timeout default is 10 min, otherwise 1 minute. 