### PR TITLE
Add consumer shutdown hook.

### DIFF
--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -75,6 +75,8 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
 
         this.connection = new KafkaConsumer<>(consumerProperties);
         this.producer = new KafkaProducer<>(producerProperties);
+        
+        handleConsumerShutdown();
 
         this.skipOffsets = skipOffsets;
         if (writeDirectory != null) {
@@ -368,5 +370,13 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
         } while (i <= 5 && statusRecords.count() == 0);
 
         return statusRecords;
+    }
+
+    /**
+     * Add hook for graceful consumer shutdown.
+     */
+    private void handleConsumerShutdown() {
+        Thread closeConsumer = new Thread(() -> connection.close());
+        Runtime.getRuntime().addShutdownHook(closeConsumer);
     }
 }


### PR DESCRIPTION
In the situation that we do a (graceful) shutdown, we always want to close the Kafka consumer to deal with inbalances in consumer groups. This PR adds a shutdown hook to the Java VM, which closes the Kafka consumer connection when running a FastenKafkaPlugin.