### PR TITLE
WIP Consume timeout for FastenKafkaPlugins

### DIFF
--- a/core/src/main/java/eu/fasten/core/plugins/FastenPlugin.java
+++ b/core/src/main/java/eu/fasten/core/plugins/FastenPlugin.java
@@ -77,6 +77,13 @@ public interface FastenPlugin extends ExtensionPoint {
     Throwable getPluginError();
 
     /**
+     * Set the plugin error or exception that was encountered during plugin execution.
+     *
+     * @param throwable exception or error.
+     */
+    default void setPluginError(Throwable throwable) {}
+
+    /**
      * The purpose of this method is to release all the resources of a plug-in. For example,
      * closing a stream or setting a big object to null.
      */

--- a/server/README.md
+++ b/server/README.md
@@ -27,6 +27,9 @@ The FASTEN-server is a component necessary for running [FASTEN-specific plugins]
     - `-pl` `--plugin_list` List of plugins to run. Can be used multiple times.
     - `-po` `--plugin_output` Path to directory where plugin output messages will be stored
     - `-pol` `--plugin_output_link` HTTP link to the root directory where output messages will be stored
+- `cg` `--consumer_group` Name of the consumer group. Defaults to (canonical) name of the plugin.
+- `ot` `--output_topic` Name of the output topic. Defaults to (simple) name of the plugin.
+- `ct` `--consume_timeout` Adds a timeout on the time a plugin can spend on its consumed records. Disabled by default.
 - `-V` `--version` Print version information and exit.
 
 ## Usage 

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -131,6 +131,13 @@ public class FastenServer implements Runnable {
     )
     String outputTopic;
 
+    @Option(names = {"-ct", "--consume_timeout"},
+            paramLabel = "consumeTimeout",
+            description = "Adds a timeout on the time a plugin can spend on its consumed records. Disabled by default",
+            defaultValue = "-1"
+    )
+    long consumeTimeout;
+
     private static final Logger logger = LoggerFactory.getLogger(FastenServer.class);
 
     @Override
@@ -236,7 +243,9 @@ public class FastenServer implements Runnable {
             return new FastenKafkaPlugin(consumerProperties, producerProperties, k, skipOffsets,
                     (outputDirs != null) ? outputDirs.get(k.getClass().getSimpleName()) : null,
                     (outputLinks != null) ? outputLinks.get(k.getClass().getSimpleName()) : null,
-                    (outputTopic != null) ? outputTopic : k.getClass().getSimpleName());
+                    (outputTopic != null) ? outputTopic : k.getClass().getSimpleName(),
+                    (consumeTimeout != -1) ? true : false,
+                    consumeTimeout);
         }).collect(Collectors.toList());
     }
 

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -133,7 +133,7 @@ public class FastenServer implements Runnable {
 
     @Option(names = {"-ct", "--consume_timeout"},
             paramLabel = "consumeTimeout",
-            description = "Adds a timeout on the time a plugin can spend on its consumed records. Disabled by default",
+            description = "Adds a timeout on the time a plugin can spend on its consumed records. Disabled by default.",
             defaultValue = "-1"
     )
     long consumeTimeout;

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -399,7 +399,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      *
      * Based on: https://stackoverflow.com/questions/1164301/how-do-i-call-some-blocking-method-with-a-timeout-in-java
      */
-    private void consumeWithTimeout(String input, long timeout) {
+    public void consumeWithTimeout(String input, long timeout) {
         Runnable consumeTask = () -> {
             plugin.consume(input);
         };
@@ -413,7 +413,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             // In this situation the consumeTask took longer than the timeout.
             // We will send an error to the err topic by setting the plugin error.
             plugin.setPluginError(timeoutException);
-            logger.error("A TimeoutException occurred", timeoutException);
+            logger.error("A TimeoutException occurred, processing a record took more than " + timeout + " seconds.");
         } catch (InterruptedException interruptedException) {
             // The consumeTask thread was interrupted.
             plugin.setPluginError(interruptedException);

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -388,6 +388,8 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      * Consumes an input with a timeout. If the timeout is exceeded the thread handling the message is killed.
      * @param input the input message to be consumed.
      * @param timeout the timeout in seconds. I.e. the maximum time a plugin can spend on processing a record.
+     *
+     * Based on: https://stackoverflow.com/questions/1164301/how-do-i-call-some-blocking-method-with-a-timeout-in-java
      */
     private void consumeWithTimeout(String input, long timeout) {
         Runnable consumeTask = () -> {

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
@@ -1,0 +1,115 @@
+package eu.fasten.server.plugins.kafka;
+
+import eu.fasten.core.plugins.KafkaPlugin;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+public class KafkaConsumeTimeoutTest {
+
+    @Test
+    public void testDisableTimeout() {
+        DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
+
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1);
+
+        assertFalse(plugin.isConsumeTimeoutEnabled());
+        assertEquals(-1, plugin.getConsumeTimeout());
+    }
+
+    @Test
+    public void testEnableTimeout() {
+        DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
+
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10);
+
+        assertTrue(plugin.isConsumeTimeoutEnabled());
+        assertEquals(10, plugin.getConsumeTimeout());
+    }
+
+    class DummyPlugin implements KafkaPlugin {
+
+        private final boolean blocking;
+        private final int blockTime;
+
+        public DummyPlugin(boolean blocking, int blockTime) {
+            this.blocking = blocking;
+            this.blockTime = 0;
+        }
+
+        @Override
+        public Optional<List<String>> consumeTopic() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void setTopic(String topicName) {
+
+        }
+
+        @Override
+        public void consume(String record) {
+            try {
+                if (blocking) {
+                    Thread.sleep(blockTime * 1000);
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        @Override
+        public Optional<String> produce() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String getOutputPath() {
+            return null;
+        }
+
+        @Override
+        public String name() {
+            return null;
+        }
+
+        @Override
+        public String description() {
+            return null;
+        }
+
+        @Override
+        public String version() {
+            return null;
+        }
+
+        @Override
+        public void start() {
+
+        }
+
+        @Override
+        public void stop() {
+
+        }
+
+        @Override
+        public Throwable getPluginError() {
+            return null;
+        }
+
+        @Override
+        public void freeResource() {
+
+        }
+    }
+}

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
@@ -4,15 +4,16 @@ import eu.fasten.core.plugins.KafkaPlugin;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 public class KafkaConsumeTimeoutTest {
 
@@ -36,14 +37,72 @@ public class KafkaConsumeTimeoutTest {
         assertEquals(10, plugin.getConsumeTimeout());
     }
 
+    @Test
+    public void testTimeoutNoInterrupt() {
+        long blockTime = 2;
+        long timeOut = 3;
+        DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
+
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut);
+
+        long startTime  = System.currentTimeMillis();
+        plugin.consumeWithTimeout("dummy", timeOut);
+        long endTime = System.currentTimeMillis();
+        long duration = (endTime - startTime) / 1000;
+
+        assertTrue(duration >= blockTime);
+    }
+
+    @Test
+    public void testTimeoutInterrupt() {
+        long blockTime = 10;
+        long timeOut = 2;
+        DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
+
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut);
+
+        long startTime  = System.currentTimeMillis();
+        plugin.consumeWithTimeout("dummy", timeOut);
+        long endTime = System.currentTimeMillis();
+        long duration = (endTime - startTime) / 1000;
+
+
+        assertTrue(duration >= timeOut);
+        assertEquals(new TimeoutException().getClass(), dummyPlugin.getPluginError().getClass()); // verify if a TimeoutException
+    }
+
+    @Test
+    public void testTimeoutInterruptBlockForever() {
+        long blockTime = -1; //this will block forever
+        long timeOut = 2;
+        DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
+
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut);
+
+        long startTime  = System.currentTimeMillis();
+        plugin.consumeWithTimeout("dummy", timeOut);
+        long endTime = System.currentTimeMillis();
+        long duration = (endTime - startTime) / 1000;
+
+
+        assertTrue(duration >= timeOut);
+        assertEquals(new TimeoutException().getClass(), dummyPlugin.getPluginError().getClass()); // verify if a TimeoutException
+    }
+
+
+
+
+
+
     class DummyPlugin implements KafkaPlugin {
 
         private final boolean blocking;
-        private final int blockTime;
+        private final long blockTime;
+        private Throwable error;
 
-        public DummyPlugin(boolean blocking, int blockTime) {
+        public DummyPlugin(boolean blocking, long blockTime) {
             this.blocking = blocking;
-            this.blockTime = 0;
+            this.blockTime = blockTime;
         }
 
         @Override
@@ -59,8 +118,10 @@ public class KafkaConsumeTimeoutTest {
         @Override
         public void consume(String record) {
             try {
-                if (blocking) {
+                if (blocking && blockTime != -1) { //block for blockTime seconds
                     Thread.sleep(blockTime * 1000);
+                } else if (blocking) { //block forever
+                    while (true) {}
                 }
             } catch (InterruptedException e) {
                 e.printStackTrace();
@@ -104,7 +165,12 @@ public class KafkaConsumeTimeoutTest {
 
         @Override
         public Throwable getPluginError() {
-            return null;
+            return this.error;
+        }
+
+        @Override
+        public void setPluginError(Throwable error) {
+            this.error = error;
         }
 
         @Override


### PR DESCRIPTION
## Description
I added a timeout for the consumer part of a Kafka plugin. This will run the consumer part in a different thread and kill it if it did not process it in time. For example, the OPAL plugin might take hours to process on CG (and probably will run OoM eventually) adding a timeout of x minutes will prevent that.

It can be configured by adding this flag to the startup arguments:
`--consume_timeout [TIME_IN_SECONDS]`


If the plugin is working on one record for too long and the timeout is reached, the [thread will be interrupted](https://docs.oracle.com/javase/tutorial/essential/concurrency/interrupt.html) as done on [this line](https://github.com/fasten-project/fasten/blob/3795681682f3f8d25b3ac15e5eab20dddd253d64/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java#L428). However, I'm not sure if this will actually stop the processing. For OPAL I think it does, since [this line](https://github.com/fasten-project/fasten/blob/b07b6450ef24561c1add313eac431d2d8435d515/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/CallGraphConstructor.java#L74) catches all exceptions including the `InterruptedException`. I'm not sure if this is the case for other plugins nor do I know how to handle this properly and ensure the consume thread (i.e. the thread that calls `consume(r.value())` for a particular record) is killed so that I can move onto the next record. 

## Motivation and context
Plugins are working on 1 record for hours which is not desirable. It causes Kafka problems in the form of rebalances. 

## Testing
I did some tests using Mockito. However, it is hard to predict what happens for certain plugins.

## Task list  
- [ ] Test on the cluster with OPAL

