### PR TITLE
Add flag to shutdown JVM on consume timeout.

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -30,6 +30,7 @@ The FASTEN-server is a component necessary for running [FASTEN-specific plugins]
 - `cg` `--consumer_group` Name of the consumer group. Defaults to (canonical) name of the plugin.
 - `ot` `--output_topic` Name of the output topic. Defaults to (simple) name of the plugin.
 - `ct` `--consume_timeout` Adds a timeout on the time a plugin can spend on its consumed records. Disabled by default.
+- `cte` `--consume_timeout_exit` Shutdowns the JVM if a consume timeout is reached. 
 - `-V` `--version` Print version information and exit.
 
 ## Usage 

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -138,6 +138,12 @@ public class FastenServer implements Runnable {
     )
     long consumeTimeout;
 
+    @Option(names = {"-cte", "--consume_timeout_exit"},
+            paramLabel = "consumeTimeoutExit",
+            description = "Shutdowns the JVM if a consume timeout is reached."
+    )
+    boolean exitOnTimeout;
+
     private static final Logger logger = LoggerFactory.getLogger(FastenServer.class);
 
     @Override
@@ -245,7 +251,8 @@ public class FastenServer implements Runnable {
                     (outputLinks != null) ? outputLinks.get(k.getClass().getSimpleName()) : null,
                     (outputTopic != null) ? outputTopic : k.getClass().getSimpleName(),
                     (consumeTimeout != -1) ? true : false,
-                    consumeTimeout);
+                    consumeTimeout,
+                    exitOnTimeout);
         }).collect(Collectors.toList());
     }
 

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
@@ -21,7 +21,7 @@ public class KafkaConsumeTimeoutTest {
     public void testDisableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1, false);
 
         assertFalse(plugin.isConsumeTimeoutEnabled());
         assertEquals(-1, plugin.getConsumeTimeout());
@@ -31,7 +31,7 @@ public class KafkaConsumeTimeoutTest {
     public void testEnableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10, false);
 
         assertTrue(plugin.isConsumeTimeoutEnabled());
         assertEquals(10, plugin.getConsumeTimeout());
@@ -43,10 +43,10 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 3;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false);
 
         long startTime  = System.currentTimeMillis();
-        plugin.consumeWithTimeout("dummy", timeOut);
+        plugin.consumeWithTimeout("dummy", timeOut, false);
         long endTime = System.currentTimeMillis();
         long duration = (endTime - startTime) / 1000;
 
@@ -59,10 +59,10 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false);
 
         long startTime  = System.currentTimeMillis();
-        plugin.consumeWithTimeout("dummy", timeOut);
+        plugin.consumeWithTimeout("dummy", timeOut, false);
         long endTime = System.currentTimeMillis();
         long duration = (endTime - startTime) / 1000;
 
@@ -77,10 +77,10 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false);
 
         long startTime  = System.currentTimeMillis();
-        plugin.consumeWithTimeout("dummy", timeOut);
+        plugin.consumeWithTimeout("dummy", timeOut, false);
         long endTime = System.currentTimeMillis();
         long duration = (endTime - startTime) / 1000;
 


### PR DESCRIPTION
Adding `--consume_timeout_exit` `true` to the CL arguments will terminate the JVM when a timeout is reached. Defaults to false.