### PR TITLE
Kbapi: Dummy Vulnerability Detection Endpoint

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/StitchingApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/StitchingApi.java
@@ -55,4 +55,10 @@ public class StitchingApi {
                                             @RequestParam(required = false, defaultValue = "-1") long timestamp) {
         return service.getDirectedGraph(packageVersionId, needStitching, timestamp);
     }
+
+    @GetMapping(value = "/__INTERNAL__/packages/{pkg}/{pkg_ver}/vulnerabilities", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<String> getTransitiveVulnerabilities(@PathVariable("pkg") String package_name,
+                                                        @PathVariable("pkg_ver") String package_version) {
+        return service.getTransitiveVulnerabilities(package_name, package_version);
+    }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/StitchingApiService.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/StitchingApiService.java
@@ -30,4 +30,6 @@ public interface StitchingApiService {
     ResponseEntity<String> resolveMultipleDependencies(List<String> mavenCoordinates);
 
     ResponseEntity<String> getDirectedGraph(long packageVersionId, boolean needStitching, long timestamp);
+
+    ResponseEntity<String> getTransitiveVulnerabilities(String package_name, String version);
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImpl.java
@@ -161,7 +161,7 @@ public class StitchingApiServiceImpl implements StitchingApiService {
     public ResponseEntity<String> getTransitiveVulnerabilities(String package_name, String version) {
         // TODO: dummy data; implement actual stitching response of transitive vulnerabilities.
         return new ResponseEntity<>(
-                "[{\"vulnerability\":\"https://nvd.nist.gov/vuln/detail/CVE-2019-11777\",\"path\":[{\"id\":0,\"fastenUri\":\"test_uri\",\"className\":\"ClassA\",\"methodName\":\"MethodA()\"},{\"id\":1,\"fastenUri\":\"test_uri1\",\"className\":\"ClassB\",\"methodName\":\"MethodB()\"},{\"id\":2,\"fastenUri\":\"test_uri2\",\"className\":\"ClassC\",\"methodName\":\"MethodC()\"}]},{\"vulnerability\":\"https://nvd.nist.gov/vuln/detail/CVE-2019-11777\",\"path\":[{\"id\":0,\"fastenUri\":\"test_uri\",\"className\":\"ClassJ\",\"methodName\":\"MethodA()\"},{\"id\":1,\"fastenUri\":\"test_uri1\",\"className\":\"ClassC\",\"methodName\":\"MethodZ()\"}]}]",
+                "[{\"vulnerability\":\"https://nvd.nist.gov/vuln/detail/CVE-2019-11777\",\"path\":[{\"id\":0,\"uri\":\"test_uri\",\"className\":\"ClassA\",\"methodName\":\"MethodA()\"},{\"id\":1,\"uri\":\"test_uri1\",\"className\":\"ClassB\",\"methodName\":\"MethodB()\"},{\"id\":2,\"uri\":\"test_uri2\",\"className\":\"ClassC\",\"methodName\":\"MethodC()\"}]},{\"vulnerability\":\"https://nvd.nist.gov/vuln/detail/CVE-2019-11777\",\"path\":[{\"id\":0,\"uri\":\"test_uri\",\"className\":\"ClassJ\",\"methodName\":\"MethodA()\"},{\"id\":1,\"uri\":\"test_uri1\",\"className\":\"ClassC\",\"methodName\":\"MethodZ()\"}]}]",
                 HttpStatus.OK
         );
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImpl.java
@@ -156,4 +156,13 @@ public class StitchingApiServiceImpl implements StitchingApiService {
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
+
+    @Override
+    public ResponseEntity<String> getTransitiveVulnerabilities(String package_name, String version) {
+        // TODO: dummy data; implement actual stitching response of transitive vulnerabilities.
+        return new ResponseEntity<>(
+                "[{\"vulnerability\":\"https://nvd.nist.gov/vuln/detail/CVE-2019-11777\",\"path\":[{\"id\":0,\"fastenUri\":\"test_uri\",\"className\":\"ClassA\",\"methodName\":\"MethodA()\"},{\"id\":1,\"fastenUri\":\"test_uri1\",\"className\":\"ClassB\",\"methodName\":\"MethodB()\"},{\"id\":2,\"fastenUri\":\"test_uri2\",\"className\":\"ClassC\",\"methodName\":\"MethodC()\"}]},{\"vulnerability\":\"https://nvd.nist.gov/vuln/detail/CVE-2019-11777\",\"path\":[{\"id\":0,\"fastenUri\":\"test_uri\",\"className\":\"ClassJ\",\"methodName\":\"MethodA()\"},{\"id\":1,\"fastenUri\":\"test_uri1\",\"className\":\"ClassC\",\"methodName\":\"MethodZ()\"}]}]",
+                HttpStatus.OK
+        );
+    }
 }


### PR DESCRIPTION
## Description
The endpoint for stitching and retrieving transitive package vulnerabilities. Currently returns dummy data (hard-coded). Intended to return all call chains that lead from the package to a vulnerable method in any of its (transitive dependencies).

## Motivation and context
Implemented for illustrating the potential of fine-grained call-graph information for security information. 
