### PR TITLE
at-least-once semantics and progress tracking in local storage

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -227,6 +227,12 @@
             <artifactId>maven-artifact</artifactId>
             <version>3.6.3</version>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+
 
 
         <!-- Integration tests -->

--- a/server/README.md
+++ b/server/README.md
@@ -31,7 +31,7 @@ The FASTEN-server is a component necessary for running [FASTEN-specific plugins]
 - `ot` `--output_topic` Name of the output topic. Defaults to (simple) name of the plugin.
 - `ct` `--consume_timeout` Adds a timeout on the time a plugin can spend on its consumed records. Disabled by default.
 - `cte` `--consume_timeout_exit` Shutdowns the JVM if a consume timeout is reached. 
-- `ls` `--local_storage` Enables local storage which stores record currently processed. This ensure that records that were processed before won't be processed again (e.g. when the pod crashes). Local storage relies on the `-po` (plugin output directory), to store message hashes. Furthermore, the environment variable `POD_INSTANCE_ID` needs to be available with a static and unique id per pod.  
+- `ls` `--local_storage` Enables local storage which stores the record that is currently processed. This ensure that records that were processed before won't be processed again (e.g. when the pod crashes). Local storage relies on the `--local_storage_dir` flag, to store message hashes. Furthermore, the environment variable `POD_INSTANCE_ID` needs to be available with a static and unique id per pod.  
 - `-V` `--version` Print version information and exit.
 
 ## Usage 

--- a/server/README.md
+++ b/server/README.md
@@ -31,6 +31,7 @@ The FASTEN-server is a component necessary for running [FASTEN-specific plugins]
 - `ot` `--output_topic` Name of the output topic. Defaults to (simple) name of the plugin.
 - `ct` `--consume_timeout` Adds a timeout on the time a plugin can spend on its consumed records. Disabled by default.
 - `cte` `--consume_timeout_exit` Shutdowns the JVM if a consume timeout is reached. 
+- `ls` `--local_storage` Enables local storage which stores record currently processed. This ensure that records that were processed before won't be processed again (e.g. when the pod crashes). Local storage relies on the `-po` (plugin output directory), to store message hashes. Furthermore, the environment variable `POD_INSTANCE_ID` needs to be available with a static and unique id per pod.  
 - `-V` `--version` Print version information and exit.
 
 ## Usage 

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -144,6 +144,13 @@ public class FastenServer implements Runnable {
     )
     boolean consumeTimeoutExit;
 
+
+    @Option(names = {"-ls", "--local_storage"},
+            paramLabel = "localStorage",
+            description = "Enables local storage which stores record currently processed. This ensure that records that were processed before won't be processed again (e.g. when the pod crashes). "
+    )
+    boolean localStorage;
+
     private static final Logger logger = LoggerFactory.getLogger(FastenServer.class);
 
     @Override
@@ -222,7 +229,8 @@ public class FastenServer implements Runnable {
                     (outputTopic != null) ? outputTopic : k.getClass().getSimpleName(),
                     (consumeTimeout != -1) ? true : false,
                     consumeTimeout,
-                    consumeTimeoutExit);
+                    consumeTimeoutExit,
+                    localStorage);
         }).collect(Collectors.toList());
     }
 

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -191,36 +191,6 @@ public class FastenServer implements Runnable {
         var kafkaServerPlugins = setupKafkaPlugins(kafkaPlugins);
 
         kafkaServerPlugins.forEach(FastenServerPlugin::start);
-
-        //waitForInterruption(kafkaServerPlugins);
-    }
-
-    /**
-     * Joins threads of kafka plugins, waits for the interrupt signal and sends
-     * shutdown signal to all threads.
-     *
-     * @param plugins list of kafka plugins
-     */
-    private void waitForInterruption(List<FastenServerPlugin> plugins) {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            plugins.forEach(FastenServerPlugin::stop);
-            plugins.forEach(c -> {
-                try {
-                    c.thread().join();
-                } catch (InterruptedException e) {
-                    logger.debug("Couldn't join consumers");
-                }
-            });
-            logger.info("Fasten server has been successfully stopped");
-        }));
-
-        plugins.forEach(c -> {
-            try {
-                c.thread().join();
-            } catch (InterruptedException e) {
-                logger.debug("Couldn't join consumers");
-            }
-        });
     }
 
     /**

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -215,7 +215,7 @@ public class FastenServer implements Runnable {
         return kafkaPlugins.stream().filter(x -> plugins.contains(x.getClass().getSimpleName())).map(k -> {
             var consumerProperties = KafkaConnector.kafkaConsumerProperties(
                     kafkaServers,
-                    (consumerGroup.equals("undefined") ? k.getClass().getCanonicalName() : consumerGroup), // if consumergroup == undefined, set to canonical name. If we upgrade to picocli 2.4.6 we can use optionals.
+                    (consumerGroup.equals("undefined") ? k.getClass().getCanonicalName() : consumerGroup), // if consumergroup != undefined, set to canonical name. If we upgrade to picocli 2.4.6 we can use optionals.
                     k.getSessionTimeout(),
                     k.getMaxConsumeTimeout(),
                     k.isStaticMembership());

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -151,6 +151,11 @@ public class FastenServer implements Runnable {
     )
     boolean localStorage;
 
+    @Option(names = {"-lsd", "--local_storage_dir"},
+            paramLabel = "localStorageDir",
+            description = "Directory of local storage, must be available from every pod location. Default's to /mnt/fasten/local_storage/plugin_name")
+    String localStorageDir;
+
     private static final Logger logger = LoggerFactory.getLogger(FastenServer.class);
 
     @Override
@@ -230,7 +235,8 @@ public class FastenServer implements Runnable {
                     (consumeTimeout != -1) ? true : false,
                     consumeTimeout,
                     consumeTimeoutExit,
-                    localStorage);
+                    localStorage,
+                    (localStorageDir != null) ? localStorageDir : "/mnt/fasten/local_storage/" + k.getClass().getSimpleName());
         }).collect(Collectors.toList());
     }
 

--- a/server/src/main/java/eu/fasten/server/plugins/FastenServerPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/FastenServerPlugin.java
@@ -29,11 +29,4 @@ public interface FastenServerPlugin extends Runnable {
      * Stops the fasten plugin.
      */
     void stop();
-
-    /**
-     * Returns the current thread the fasten plugin is running on.
-     *
-     * @return current plugin thread
-     */
-    Thread thread();
 }

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/ExistsInLocalStorageException.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/ExistsInLocalStorageException.java
@@ -1,0 +1,9 @@
+package eu.fasten.server.plugins.kafka;
+
+public class ExistsInLocalStorageException extends Exception {
+
+    public ExistsInLocalStorageException(String errorMessage) {
+        super(errorMessage);
+    }
+
+}

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -83,7 +83,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      * @param skipOffsets        skip offset number
      */
     public FastenKafkaPlugin(boolean enableKafka, Properties consumerProperties, Properties producerProperties,
-                             KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink, String outputTopic, boolean consumeTimeoutEnabled, long consumeTimeout, boolean exitOnTimeout, boolean enableLocalStorage) {
+                             KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink, String outputTopic, boolean consumeTimeoutEnabled, long consumeTimeout, boolean exitOnTimeout, boolean enableLocalStorage, String localStorageDir) {
         this.plugin = plugin;
 
         if (enableKafka) {
@@ -95,16 +95,8 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
         if (writeDirectory != null) {
             this.writeDirectory = writeDirectory.endsWith(File.separator)
                     ? writeDirectory.substring(0, writeDirectory.length() - 1) : writeDirectory;
-
-            // If the write link is not null, and local storage is enabled. Initialize it.
-            if (enableLocalStorage) {
-                this.localStorage = new LocalStorage(this.writeDirectory);
-            } else {
-                this.localStorage = null;
-            }
         } else {
             this.writeDirectory = null;
-            this.localStorage = null;
         }
         if (writeLink != null) {
             this.writeLink = writeLink.endsWith(File.separator)
@@ -115,6 +107,13 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             this.writeLink = null;
         }
 
+        // If the write link is not null, and local storage is enabled. Initialize it.
+        if (enableLocalStorage) {
+            this.localStorage = new LocalStorage(localStorageDir);
+        } else {
+            this.localStorage = null;
+        }
+
         this.outputTopic = outputTopic;
         this.consumeTimeoutEnabled = consumeTimeoutEnabled;
         this.consumeTimeout = consumeTimeout;
@@ -123,8 +122,8 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
     }
 
     public FastenKafkaPlugin(Properties consumerProperties, Properties producerProperties,
-                             KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink, String outputTopic, boolean consumeTimeoutEnabled, long consumeTimeout, boolean exitOnTimeout, boolean enableLocalStorage) {
-        this(true, consumerProperties, producerProperties, plugin, skipOffsets, writeDirectory, writeLink, outputTopic, consumeTimeoutEnabled, consumeTimeout, exitOnTimeout, enableLocalStorage);
+                             KafkaPlugin plugin, int skipOffsets, String writeDirectory, String writeLink, String outputTopic, boolean consumeTimeoutEnabled, long consumeTimeout, boolean exitOnTimeout, boolean enableLocalStorage, String localStorageDir) {
+        this(true, consumerProperties, producerProperties, plugin, skipOffsets, writeDirectory, writeLink, outputTopic, consumeTimeoutEnabled, consumeTimeout, exitOnTimeout, enableLocalStorage, localStorageDir);
     }
 
 

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -170,7 +170,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
     /**
      * Consumes a message from a Kafka topics and passes it to a plugin.
      */
-    private void handleConsuming() {
+    public void handleConsuming() {
         ConsumerRecords<String, String> records = connection.poll(Duration.ofSeconds(1));
         Long consumeTimestamp = System.currentTimeMillis() / 1000L;
 
@@ -245,7 +245,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      *
      * @param input input message [can be null]
      */
-    private void handleProducing(String input, long consumeTimestamp) {
+    public void handleProducing(String input, long consumeTimestamp) {
         try {
             if (plugin.getPluginError() != null) {
                 throw new Exception(plugin.getPluginError());

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
@@ -41,7 +41,7 @@ public class LocalStorage {
      * @return true if local storage, otherwise false.
      */
     public boolean exists(String message) {
-        String hashedMessage = digestUtils.digestAsHex(message);
+        String hashedMessage = getSHA1(message);
         String[] filesInFolder = storageFolder.list();
 
         for (String hash : filesInFolder) {
@@ -63,9 +63,20 @@ public class LocalStorage {
             return false;
         }
 
-        String hashedMessage = digestUtils.digestAsHex(message);
+        String hashedMessage = getSHA1(message);
         File fileToRemove = new File(storageFolder.getPath() + File.separator + hashedMessage);
 
+        return fileToRemove.delete();
+    }
+
+    /**
+     * Deletes a file by hash.
+     *
+     * @param hash the hash to remove from local storage.
+     * @return if successfully deleted.
+     */
+    private boolean deleteByHash(String hash) {
+        File fileToRemove = new File(storageFolder.getPath() + File.separator + hash);
         return fileToRemove.delete();
     }
 
@@ -81,10 +92,31 @@ public class LocalStorage {
             return false;
         }
 
-        String hashedMessage = digestUtils.digestAsHex(message);
+        String hashedMessage = getSHA1(message);
         File fileToCreate = new File(storageFolder.getPath() + File.separator + hashedMessage);
 
         return fileToCreate.createNewFile();
+    }
+
+    /**
+     * Remove all hashes/files from local storage.
+     */
+    public void clear() {
+        String[] filesInFolder = storageFolder.list();
+
+        for (String hash : filesInFolder) {
+            deleteByHash(hash);
+        }
+    }
+
+    /**
+     * Hashes a message using SHA1.
+     *
+     * @param message the message to hash.
+     * @return the hashed message.
+     */
+    public String getSHA1(String message) {
+        return digestUtils.digestAsHex(message);
     }
 
 

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
@@ -12,6 +12,13 @@ public class LocalStorage {
     private final File storageFolder;
     private final DigestUtils digestUtils = new DigestUtils(SHA_1);
 
+    /**
+     * Helper class to store a SHA-1 hash of a message in local storage of a plugin instance.
+     * This can be used to detect if a plugin crashed while working on a certain input, and appropriate action can be taken.
+     *
+     * The folder name will be suffixed by the $POD_INSTANCE_ID env. variable. Ensure this is unique per plugin instance.
+     * @param folder the folder to store in. A plugin instance should always have access to this folder (so preferable some sort of NFS mount).
+     */
     public LocalStorage(String folder) {
         if (System.getenv("POD_INSTANCE_ID") != null) {
             instanceId = System.getenv("POD_INSTANCE_ID");
@@ -27,6 +34,12 @@ public class LocalStorage {
         }
     }
 
+    /**
+     * Verify if a message is already in the local storage.
+     *
+     * @param message the message to verify.
+     * @return true if local storage, otherwise false.
+     */
     public boolean exists(String message) {
         String hashedMessage = digestUtils.digestAsHex(message);
         String[] filesInFolder = storageFolder.list();
@@ -39,6 +52,12 @@ public class LocalStorage {
         return false;
     }
 
+    /**
+     * Remove a message from local storage.
+     *
+     * @param message the message to remove.
+     * @return true if sucessfully deleted, otherwise false (for instance, when it doesn't exist).
+     */
     public boolean delete(String message) {
         if (!exists(message)) {
             return false;
@@ -50,6 +69,13 @@ public class LocalStorage {
         return fileToRemove.delete();
     }
 
+    /**
+     * Stores a message in local storage.
+     *
+     * @param message the raw message to store. Will be hashed into SHA-1 format.
+     * @return if successfully stored.
+     * @throws IOException when file can't be created.
+     */
     public boolean store(String message) throws IOException {
         if (exists(message)) {
             return false;

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
@@ -1,0 +1,26 @@
+package eu.fasten.server.plugins.kafka;
+
+import java.io.File;
+
+public class LocalStorage {
+
+    private final String instanceId;
+    private final File storageFolder;
+
+    public LocalStorage(String folder) {
+        if (System.getenv("POD_INSTANCE_ID") != null) {
+            instanceId = System.getenv("POD_INSTANCE_ID");
+        } else {
+            throw new IllegalArgumentException("Trying to initialize local storage but $POD_INSTANCE_ID is not in the environemnt variables.");
+        }
+
+        storageFolder = new File(folder);
+
+        // Create folder if it doesn't exist yet.
+        if (!storageFolder.exists()) {
+            storageFolder.mkdirs();
+        }
+    }
+
+
+}

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
@@ -1,11 +1,16 @@
 package eu.fasten.server.plugins.kafka;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
+import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_1;
 import java.io.File;
+import java.io.IOException;
 
 public class LocalStorage {
 
     private final String instanceId;
     private final File storageFolder;
+    private final DigestUtils digestUtils = new DigestUtils(SHA_1);
 
     public LocalStorage(String folder) {
         if (System.getenv("POD_INSTANCE_ID") != null) {
@@ -14,12 +19,46 @@ public class LocalStorage {
             throw new IllegalArgumentException("Trying to initialize local storage but $POD_INSTANCE_ID is not in the environemnt variables.");
         }
 
-        storageFolder = new File(folder);
+        storageFolder = new File(folder + File.separator + instanceId + File.separator);
 
         // Create folder if it doesn't exist yet.
         if (!storageFolder.exists()) {
             storageFolder.mkdirs();
         }
+    }
+
+    public boolean exists(String message) {
+        String hashedMessage = digestUtils.digestAsHex(message);
+        String[] filesInFolder = storageFolder.list();
+
+        for (String hash : filesInFolder) {
+            if (hash.equals(hashedMessage)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean delete(String message) {
+        if (!exists(message)) {
+            return false;
+        }
+
+        String hashedMessage = digestUtils.digestAsHex(message);
+        File fileToRemove = new File(storageFolder.getPath() + File.separator + hashedMessage);
+
+        return fileToRemove.delete();
+    }
+
+    public boolean store(String message) throws IOException {
+        if (exists(message)) {
+            return false;
+        }
+
+        String hashedMessage = digestUtils.digestAsHex(message);
+        File fileToCreate = new File(storageFolder.getPath() + File.separator + hashedMessage);
+
+        return fileToCreate.createNewFile();
     }
 
 

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
@@ -89,11 +89,6 @@ public class KafkaConsumeTimeoutTest {
         assertEquals(new TimeoutException().getClass(), dummyPlugin.getPluginError().getClass()); // verify if a TimeoutException
     }
 
-
-
-
-
-
     class DummyPlugin implements KafkaPlugin {
 
         private final boolean blocking;

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
@@ -21,7 +21,7 @@ public class KafkaConsumeTimeoutTest {
     public void testDisableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1, false, false);
 
         assertFalse(plugin.isConsumeTimeoutEnabled());
         assertEquals(-1, plugin.getConsumeTimeout());
@@ -31,7 +31,7 @@ public class KafkaConsumeTimeoutTest {
     public void testEnableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10, false, false);
 
         assertTrue(plugin.isConsumeTimeoutEnabled());
         assertEquals(10, plugin.getConsumeTimeout());
@@ -43,7 +43,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 3;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false);
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false);
@@ -59,7 +59,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false);
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false);
@@ -77,7 +77,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false);
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false);

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
@@ -21,7 +21,7 @@ public class KafkaConsumeTimeoutTest {
     public void testDisableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1, false, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1, false, false, "");
 
         assertFalse(plugin.isConsumeTimeoutEnabled());
         assertEquals(-1, plugin.getConsumeTimeout());
@@ -31,7 +31,7 @@ public class KafkaConsumeTimeoutTest {
     public void testEnableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10, false, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10, false, false, "");
 
         assertTrue(plugin.isConsumeTimeoutEnabled());
         assertEquals(10, plugin.getConsumeTimeout());
@@ -43,7 +43,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 3;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false, "");
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false);
@@ -59,7 +59,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false, "");
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false);
@@ -77,7 +77,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false);
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false, "");
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false);

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaPluginConsumeBehaviourTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaPluginConsumeBehaviourTest.java
@@ -1,0 +1,192 @@
+package eu.fasten.server.plugins.kafka;
+
+import eu.fasten.core.plugins.KafkaPlugin;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+
+public class KafkaPluginConsumeBehaviourTest {
+
+    DummyPlugin dummyPlugin;
+
+    @BeforeEach
+    public void setUp() {
+        dummyPlugin = mock(DummyPlugin.class);
+    }
+
+    public void setupMocks(FastenKafkaPlugin kafkaPlugin) throws IllegalAccessException {
+        // Hacky way to override consumer and producer with a mock.
+        KafkaConsumer<String, String> mockConsumer = mock(KafkaConsumer.class);
+        FieldUtils.writeField(kafkaPlugin, "connection", mockConsumer, true);
+        KafkaProducer<String, String> mockProducer = mock(KafkaProducer.class);
+        FieldUtils.writeField(kafkaPlugin, "producer", mockProducer, true);
+
+        // Another set of mocks.
+        ConsumerRecords<String, String> records = mock(ConsumerRecords.class);
+        ConsumerRecord<String, String> record = mock(ConsumerRecord.class);
+
+        ArrayList<ConsumerRecord<String, String>> listOfRecords = new ArrayList<>();
+        listOfRecords.add(record);
+
+        when(mockConsumer.poll(any())).thenReturn(records);
+        when(records.iterator()).thenReturn(listOfRecords.iterator());
+        when(record.value()).thenReturn("{key: 'Im a record!'}");
+    }
+
+    @Test
+    public void testNoLocalStorageNoTimeout() throws IllegalAccessException {
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, 0, false, false, ""));
+        setupMocks(kafkaPlugin);
+
+        kafkaPlugin.handleConsuming();
+
+        verify(dummyPlugin).consume("{key: 'Im a record!'}");
+    }
+
+    @Test
+    public void testNoLocalStorageTimeout() throws IllegalAccessException {
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, 0, false, false, ""));
+        setupMocks(kafkaPlugin);
+
+        kafkaPlugin.handleConsuming();
+
+        verify(dummyPlugin).consume("{key: 'Im a record!'}");
+    }
+
+    @Test
+    public void testAlreadyInLocalStorage() throws Exception {
+        setEnv("POD_INSTANCE_ID", "test_pod");
+
+        LocalStorage localStorage = new LocalStorage("src/test/resources");
+        localStorage.clear();
+        localStorage.store("{key: 'Im a record!'}");
+
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 5, false, true, "src/test/resources"));
+        setupMocks(kafkaPlugin);
+
+        kafkaPlugin.handleConsuming();
+
+        verify(dummyPlugin).setPluginError(any());
+        verify(dummyPlugin, never()).consume(any());
+    }
+
+    @Test
+    public void testLocalStorage() throws Exception {
+        setEnv("POD_INSTANCE_ID", "test_pod");
+
+        LocalStorage localStorage = new LocalStorage("src/test/resources");
+        localStorage.clear();
+
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, 5, false, true, "src/test/resources"));
+        setupMocks(kafkaPlugin);
+
+        kafkaPlugin.handleConsuming();
+        verify(dummyPlugin).consume("{key: 'Im a record!'}");
+    }
+
+    @Test
+    public void testLocalStorageTimeoutWithTimeout() throws Exception {
+        setEnv("POD_INSTANCE_ID", "test_pod");
+
+        LocalStorage localStorage = new LocalStorage("src/test/resources");
+        localStorage.clear();
+
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 5, false, true, "src/test/resources"));
+        setupMocks(kafkaPlugin);
+
+        kafkaPlugin.handleConsuming();
+        verify(dummyPlugin).consume("{key: 'Im a record!'}");
+    }
+
+    //From: https://stackoverflow.com/questions/19600527/java-program-setting-an-environment-variable
+    public static void setEnv(String key, String value) {
+        try {
+            Map<String, String> env = System.getenv();
+            Class<?> cl = env.getClass();
+            Field field = cl.getDeclaredField("m");
+            field.setAccessible(true);
+            Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+            writableEnv.put(key, value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to set environment variable", e);
+        }
+    }
+
+    class DummyPlugin implements KafkaPlugin {
+
+
+        @Override
+        public Optional<List<String>> consumeTopic() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void setTopic(String topicName) {
+        }
+
+        @Override
+        public void consume(String record) {
+        }
+
+        @Override
+        public Optional<String> produce() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String getOutputPath() {
+            return null;
+        }
+
+        @Override
+        public String name() {
+            return null;
+        }
+
+        @Override
+        public String description() {
+            return null;
+        }
+
+        @Override
+        public String version() {
+            return null;
+        }
+
+        @Override
+        public void start() {
+
+        }
+
+        @Override
+        public void stop() {
+
+        }
+
+        @Override
+        public Throwable getPluginError() {
+            return null;
+        }
+
+        @Override
+        public void setPluginError(Throwable throwable) {
+
+        }
+
+
+        @Override
+        public void freeResource() {
+
+        }
+    }
+}

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
@@ -1,0 +1,86 @@
+package eu.fasten.server.plugins.kafka;
+
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class LocalStorageTest {
+
+    private LocalStorage localStorage;
+
+    @BeforeEach
+    public void setupStorage() throws URISyntaxException {
+        setEnv("POD_INSTANCE_ID", "test_pod");
+       localStorage = new LocalStorage(new File("src/test/resources").getAbsolutePath());
+    }
+
+    @AfterEach
+    public void clearStorage() {
+        localStorage = null;
+        File toRemove = new File("src/test/resources/test_pod/");
+
+        String[] entries = toRemove.list();
+
+        for(String s: entries){
+            File currentFile = new File(toRemove.getPath(), s);
+            currentFile.delete();
+        }
+
+        toRemove.delete();
+    }
+
+    @Test
+    public void test_create_positive() throws IOException {
+        Assertions.assertTrue(localStorage.store("A very nice message!"));
+        Assertions.assertTrue(localStorage.store("Second message!"));
+    }
+
+    @Test
+    public void test_exists() throws IOException {
+        Assertions.assertTrue(localStorage.store("A very nice message!"));
+        Assertions.assertTrue(localStorage.store("Extra message"));
+        Assertions.assertTrue(localStorage.exists("A very nice message!"));
+        Assertions.assertFalse(localStorage.exists("Doesn't exist"));
+    }
+
+    @Test
+    public void test_create_negative() throws IOException {
+        Assertions.assertTrue(localStorage.store("A very nice message!"));
+        Assertions.assertFalse(localStorage.store("A very nice message!"));
+        Assertions.assertTrue(localStorage.store("Second message!"));
+        Assertions.assertFalse(localStorage.store("Second message!"));
+    }
+
+    @Test
+    public void test_remove() throws IOException {
+        Assertions.assertTrue(localStorage.store("A very nice message!"));
+        Assertions.assertTrue(localStorage.exists("A very nice message!"));
+        Assertions.assertTrue(localStorage.delete("A very nice message!"));
+        Assertions.assertFalse(localStorage.exists("A very nice message!"));
+    }
+
+    @Test
+    public void test_remove_negative() throws IOException {
+        Assertions.assertFalse(localStorage.delete("Non existent message"));
+    }
+
+
+    //From: https://stackoverflow.com/questions/19600527/java-program-setting-an-environment-variable
+    public static void setEnv(String key, String value) {
+        try {
+            Map<String, String> env = System.getenv();
+            Class<?> cl = env.getClass();
+            Field field = cl.getDeclaredField("m");
+            field.setAccessible(true);
+            Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+            writableEnv.put(key, value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to set environment variable", e);
+        }
+    }
+}

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
@@ -35,13 +35,13 @@ public class LocalStorageTest {
     }
 
     @Test
-    public void test_create_positive() throws IOException {
+    public void testCreatePositive() throws IOException {
         Assertions.assertTrue(localStorage.store("A very nice message!"));
         Assertions.assertTrue(localStorage.store("Second message!"));
     }
 
     @Test
-    public void test_exists() throws IOException {
+    public void testExists() throws IOException {
         Assertions.assertTrue(localStorage.store("A very nice message!"));
         Assertions.assertTrue(localStorage.store("Extra message"));
         Assertions.assertTrue(localStorage.exists("A very nice message!"));
@@ -49,7 +49,7 @@ public class LocalStorageTest {
     }
 
     @Test
-    public void test_create_negative() throws IOException {
+    public void testCreateNegative() throws IOException {
         Assertions.assertTrue(localStorage.store("A very nice message!"));
         Assertions.assertFalse(localStorage.store("A very nice message!"));
         Assertions.assertTrue(localStorage.store("Second message!"));
@@ -57,7 +57,7 @@ public class LocalStorageTest {
     }
 
     @Test
-    public void test_remove() throws IOException {
+    public void testRemove() throws IOException {
         Assertions.assertTrue(localStorage.store("A very nice message!"));
         Assertions.assertTrue(localStorage.exists("A very nice message!"));
         Assertions.assertTrue(localStorage.delete("A very nice message!"));
@@ -65,18 +65,18 @@ public class LocalStorageTest {
     }
 
     @Test
-    public void test_remove_negative() throws IOException {
+    public void testRemoveNegative() throws IOException {
         Assertions.assertFalse(localStorage.delete("Non existent message"));
     }
 
     @Test
-    public void test_sha() throws IOException {
+    public void testSHA() throws IOException {
         Assertions.assertEquals(localStorage.getSHA1("Same message"),localStorage.getSHA1("Same message"));
         Assertions.assertNotEquals(localStorage.getSHA1("Same message"),localStorage.getSHA1("Different message"));
     }
 
     @Test
-    public void test_clear() throws IOException {
+    public void testClear() throws IOException {
         localStorage.store("Number 1");
         localStorage.store("Number 2");
         Assertions.assertTrue(localStorage.exists("Number 1"));

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
@@ -69,6 +69,23 @@ public class LocalStorageTest {
         Assertions.assertFalse(localStorage.delete("Non existent message"));
     }
 
+    @Test
+    public void test_sha() throws IOException {
+        Assertions.assertEquals(localStorage.getSHA1("Same message"),localStorage.getSHA1("Same message"));
+        Assertions.assertNotEquals(localStorage.getSHA1("Same message"),localStorage.getSHA1("Different message"));
+    }
+
+    @Test
+    public void test_clear() throws IOException {
+        localStorage.store("Number 1");
+        localStorage.store("Number 2");
+        Assertions.assertTrue(localStorage.exists("Number 1"));
+        Assertions.assertTrue(localStorage.exists("Number 2"));
+        localStorage.clear();
+        Assertions.assertFalse(localStorage.exists("Number 1"));
+        Assertions.assertFalse(localStorage.exists("Number 2"));
+    }
+
 
     //From: https://stackoverflow.com/questions/19600527/java-program-setting-an-environment-variable
     public static void setEnv(String key, String value) {


### PR DESCRIPTION
## Description
This PR covers two improvements:
1. Change default behaviour to **at-least-once** semantics (currently it is **at-most-once**). This means that we always first consume, produce and _then_ commit its offset. This way, we will never lose a record due to shutdown, crashes or errors.
2. Consequently, I also implemented a feature described as __LocalStorage__. Each record that is consumed, is first hashed (using [SHA-1](https://en.wikipedia.org/wiki/SHA-1)) and stored in local storage. Once it's properly processed and the output is sent to the producer, the hashed record is removed from this local storage. This prevents a scenario where a pod crashes during processing, restarts, and then start re-processing that same record (which might result in a deadlock for unprocessable records). We need this kind of behaviour to allow **at-least-once** semantics. 
	
     Requirements to use LocalStorage:
		    - Enable LocalStorage using the `--local_storage` flag.
		    - Use `---local_storage_dir` flag to define output directory. Ensure that this directory is accessible by all pods on all servers (e.g. NFS mount). 
		  - Configure environment variable `POD_INSTANCE_ID`. This needs to be static and unique per pod (i.e. use a StatefulSet deployment).
		
The full commit protocol using local storage is as follows:
```
1. Poll one record (by default).
2. If the record hash is in local storage:
     a. Produce to error topic (this record is probably processed before and caused a crash or timeout).
     b. Commit the offset, only if the producer confirmed sending the message.
     c. Delete record in local storage.
     d. Go back to 1.
3. If the record hash is _not_ in local storage:
     a. Process the record.
     b. Produce its results (either to the error topic, or output topic).
     c. Commit the offset, only if the producer confirmed sending the message.
     d. Delete record in local storage.
     e. Go back to 1.
```

__Some notes:__
-  Most of our plugins are not fast; they spend quite some time processing only one record. If you have a plugin which is very fast, local storage might slow this down (reads and writes to NFS mount can be considered expensive). 
- Local storage is only tested with batch size 1 (this is also the default for all our plugins). 
## Motivation and context
Currently, we have **at-most-once** semantics which gives us no guarantees if all records will be processed. Moreover, if we want to support **at-least-once** we have to deal with artifacts that crash a pod (for example for OPAL OoM errors). Local storage allows us to discard/skip records that we processed before and caused an issue. 

## Testing
I tested the LocalStorage feature in a unit test. The new commit strategy is tested using some (simplified) mock scenario. It still requires a test on the cluster. 

## Task list  
- [ ] Test on cluster for OPAL.