### PR TITLE
Kbapi: Fix Latest Version bug

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImpl.java
@@ -38,9 +38,6 @@ public class PackageApiServiceImpl implements PackageApiService {
     @Override
     public ResponseEntity<String> getPackageLastVersion(String package_name) {
         String result = KnowledgeBaseConnector.kbDao.getPackageLastVersion(package_name);
-        if (result == null) {
-            return new ResponseEntity<>("Latest package version not found", HttpStatus.NOT_FOUND);
-        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -918,9 +918,9 @@ public class MetadataDao {
                 .select(p.fields())
                 .select(pv.VERSION)
                 .from(p)
-                .innerJoin(pv).on(p.ID.eq(pv.PACKAGE_ID))
+                .leftJoin(pv).on(p.ID.eq(pv.PACKAGE_ID))
                 .where(p.PACKAGE_NAME.equalIgnoreCase(packageName))
-                .orderBy(pv.CREATED_AT.sortDesc())
+                .orderBy(pv.CREATED_AT.sortDesc().nullsLast())
                 .limit(1)
                 .fetchOne();
 


### PR DESCRIPTION
Closes #205 

## Description
PR fixes the error, when some packages without versions would throw `Latest package version not found` on basic `mvn/packages/{packageName}` endpoint.

## Motivation and context
When using the endpoint on frontend, API shall return any information it has, even without versions, for better usability.

## Task list  
- [x] Replace inner joint with left joint between packages and versions, so there is always a package to return (although sometimes without a version).
- [x] Fix order by created date, so `null` dates are listed in the end.