### PR TITLE
Utility parser for partial FASTEN URI

### DIFF
--- a/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
+++ b/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
@@ -76,18 +76,19 @@ public class FastenUriUtils {
         }
 
         // URI is usually stored encoded, so decode for parsing.
+        // E.g., `/com.sun.istack.localization/Localizer.%3Cinit%3E(%2Fjava.util%2FLocale)%2Fjava.lang%2FVoidType`
         partialFastenUri = java.net.URLDecoder.decode(partialFastenUri, StandardCharsets.UTF_8);
 
         // Namespace: `/{namespace}/`
         Pattern namespacePattern = Pattern.compile("(?<=/)(.+?)(?=/)");
         Matcher namespaceMatcher = namespacePattern.matcher(partialFastenUri);
-        if (!namespaceMatcher.find())
+        if (!namespaceMatcher.find() || namespaceMatcher.group(0).isEmpty())
             throw new IllegalArgumentException(partialUriFormatException);
 
         // Class: `/{class}.*(`
         Pattern classPattern = Pattern.compile("(?<=/)([^\\/]+)(?=\\.([^./]+)\\()");
         Matcher classMatcher = classPattern.matcher(partialFastenUri);
-        if (!classMatcher.find())
+        if (!classMatcher.find() || classMatcher.group(0).isEmpty())
             throw new IllegalArgumentException(partialUriFormatException);
 
 

--- a/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
+++ b/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
@@ -1,5 +1,6 @@
 package eu.fasten.core.utils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -34,7 +35,7 @@ public class FastenUriUtils {
 
     /**
      * Given a full FASTEN URI, produces a list consisting of package name, package version and partial FASTEN URI.
-     * Specification: fasten://{forge}!{package_name}${version}/{partial_fasten_uri}
+     * Specification: `fasten://{forge}!{package_name}${version}/{partial_fasten_uri}`
      *
      * @param fullFastenUri Fully-qualified FASTEN URI
      * @return List containing first forge, then package name, then package version, and lastly partial FASTEN URI
@@ -58,51 +59,64 @@ public class FastenUriUtils {
 
     /**
      * Given a partial FASTEN URI, produces a list consisting of namespace, class, method name and its signature.
-     * Specification: /{namespace}/{class}.<{method}>({signature.args})/{signature.returnType}
+     * Specification: `/{namespace}/{class}.{method}({signature.args})/{signature.returnType}`
      *
      * @param partialFastenUri a partial FASTEN URI
-     * @return List containing namespace, class name, method name and its signature.
+     * @return List containing namespace, class name, method name, method's args, method's return type.
      */
     public static List<String> parsePartialFastenUri(String partialFastenUri) {
+
+        // Exception messages
+        var fullUriException = "Invalid partial FASTEN URI. You may want to use parser for full FASTEN URI instead.";
+        var partialUriFormatException = "Invalid partial FASTEN URI. The format is corrupted.\nMust be: `/{namespace}/{class}.{method}({signature.args})/{signature.returnType}`";
+
+        // Ensure that this is not a Full FASTEN URI
         if (partialFastenUri.startsWith("fasten://") && partialFastenUri.contains("!") && partialFastenUri.contains("$") && partialFastenUri.contains("/")) {
-            throw new IllegalArgumentException("Invalid partial FASTEN URI. You may want to use parser for full FASTEN URI instead.");
+            throw new IllegalArgumentException(fullUriException);
         }
 
-        // Use regex to find the part before `.<`, which is start of the method.
-        // This part is module, including namespace and class.
-        Pattern modulePattern = Pattern.compile(".+?(?=\\.<)");
-        Matcher moduleMatcher = modulePattern.matcher(partialFastenUri);
-        if (!moduleMatcher.find())
-            throw new IllegalArgumentException("Invalid partial FASTEN URI: module was not found.");
+        // URI is usually stored encoded, so decode for parsing.
+        partialFastenUri = java.net.URLDecoder.decode(partialFastenUri, StandardCharsets.UTF_8);
 
-        var splitModule = moduleMatcher.group(0).split("/");
-        var namespace = splitModule[1];
-        var className = splitModule[2];
+        // Namespace: `/{namespace}/`
+        Pattern namespacePattern = Pattern.compile("(?<=/)(.+?)(?=/)");
+        Matcher namespaceMatcher = namespacePattern.matcher(partialFastenUri);
+        if (!namespaceMatcher.find())
+            throw new IllegalArgumentException(partialUriFormatException);
 
-        // Use regex to find the part of `<{method}>`.
-        Pattern methodNamePattern = Pattern.compile("(?<=<)(.+?)(?=>)");
+        // Class: `/{class}.*(`
+        Pattern classPattern = Pattern.compile("(?<=/)([^\\/]+)(?=\\.([^./]+)\\()");
+        Matcher classMatcher = classPattern.matcher(partialFastenUri);
+        if (!classMatcher.find())
+            throw new IllegalArgumentException(partialUriFormatException);
+
+
+        // Method: `.{method}(`
+        Pattern methodNamePattern = Pattern.compile("(?<=\\.)([^.]+)(?=\\()");
         Matcher methodNameMatcher = methodNamePattern.matcher(partialFastenUri);
         if (!methodNameMatcher.find() || methodNameMatcher.group(0).isEmpty())
-            throw new IllegalArgumentException("Invalid partial FASTEN URI: method name was not found.");
+            throw new IllegalArgumentException(partialUriFormatException);
 
-        var methodName = methodNameMatcher.group(0);
 
-        // Use regex to find method's arguments of `({arguments})`.
-        Pattern methodArgsPattern = Pattern.compile("(?<=\\()(.+?)(?=\\))");
+        // Method Args: `({args})`
+        Pattern methodArgsPattern = Pattern.compile("(?<=\\()(.*)(?=\\))");
         Matcher methodArgsMatcher = methodArgsPattern.matcher(partialFastenUri);
-        if (!methodArgsMatcher.find() || methodArgsMatcher.group(0).isEmpty())
-            throw new IllegalArgumentException("Invalid partial FASTEN URI: method's arguments were not found.");
+        if (!methodArgsMatcher.find())
+            throw new IllegalArgumentException(partialUriFormatException);
 
-        var methodArgs = methodArgsMatcher.group(0);
 
-        // Use regex to find method's return type after closing `){return}`.
+        // Method Return Type: `)/{type}`
         Pattern methodReturnPattern = Pattern.compile("(?<=\\))(.*)");
         Matcher methodReturnMatcher = methodReturnPattern.matcher(partialFastenUri);
         if (!methodReturnMatcher.find() || methodReturnMatcher.group(0).isEmpty())
-            throw new IllegalArgumentException("Invalid partial FASTEN URI: method's return type was not found.");
+            throw new IllegalArgumentException(partialUriFormatException);
 
+
+        var namespace = namespaceMatcher.group(0);
+        var className = classMatcher.group(0);
+        var methodName = methodNameMatcher.group(0);
+        var methodArgs = methodArgsMatcher.group(0);
         var methodReturnType = methodReturnMatcher.group(0);
-
 
         return List.of(namespace, className, methodName, methodArgs, methodReturnType);
     }

--- a/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
+++ b/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
@@ -118,7 +118,7 @@ public class FastenUriUtilsTest {
 
     @Test
     void testParsePartialFastenUriFailedMissingNamespace() {
-        var partialUri = "/AboutDialog.<init>(/java.awt/Frame)"; // missing return type.
+        var partialUri = "/AboutDialog.<init>(/java.awt/Frame)"; // missing namespace.
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             FastenUriUtils.parsePartialFastenUri(partialUri);
         });

--- a/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
+++ b/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
@@ -1,6 +1,9 @@
 package eu.fasten.core.utils;
 
+import eu.fasten.core.data.FastenURI;
 import org.junit.jupiter.api.Test;
+
+import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,6 +25,28 @@ public class FastenUriUtilsTest {
         var actual = FastenUriUtils.generateFullFastenUri(forge, pkg, version, partial);
 
         assertEquals(expectedFullUri, actual);
+    }
+
+    @Test
+    void testGenerateFullFastenUriObjectSuccess() {
+
+        var forge = "forge";
+        var pkg = "name";
+        var version = "1.0";
+        var namespace = "namespace";
+        var entity = "class.method()/void";
+
+        var partial = "/" + namespace + "/" + entity;
+
+        var uri = FastenUriUtils.generateFullFastenUri(forge, pkg, version, partial);
+        var fastenUri = FastenURI.create(uri);
+
+        assertEquals(forge, fastenUri.getForge());
+        assertEquals(pkg, fastenUri.getProduct());
+        assertEquals(version, fastenUri.getVersion());
+        assertEquals(namespace, fastenUri.getNamespace());
+        assertEquals(entity, fastenUri.getEntity());
+
     }
 
     @Test

--- a/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
+++ b/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
@@ -1,0 +1,116 @@
+package eu.fasten.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FastenUriUtilsTest {
+
+    @Test
+    void testGenerateFullFastenUriSuccess() {
+
+        var forge = "forge";
+        var pkg = "name";
+        var version = "1.0";
+        var partial = "/partial";
+
+        var expectedFullUri = "fasten://forge!name$1.0/partial";
+
+        var actual = FastenUriUtils.generateFullFastenUri(forge, pkg, version, partial);
+
+        assertEquals(expectedFullUri, actual);
+    }
+
+    @Test
+    void testParseFullFastenUriSuccess() {
+
+        var fullUri = "fasten://forge!name$1.0/partial";
+
+        var expectedForge = "forge";
+        var expectedPackage = "name";
+        var expectedVersion = "1.0";
+        var expectedPartial = "/partial";
+
+        var actual = FastenUriUtils.parseFullFastenUri(fullUri);
+
+        assertEquals(expectedForge, actual.get(0));
+        assertEquals(expectedPackage, actual.get(1));
+        assertEquals(expectedVersion, actual.get(2));
+        assertEquals(expectedPartial, actual.get(3));
+    }
+
+    @Test
+    void testParsePartialFastenUriSuccess() {
+
+        var partialUri = "/junit.awtui/AboutDialog.<init>(/java.awt/Frame)/java.lang/VoidType";
+
+        var expectedNamespace = "junit.awtui";
+        var expectedClass = "AboutDialog";
+        var expectedMethod = "init";
+        var expectedArgs = "/java.awt/Frame";
+        var expectedReturnType = "/java.lang/VoidType";
+
+        var actual = FastenUriUtils.parsePartialFastenUri(partialUri);
+
+        assertEquals(expectedNamespace, actual.get(0));
+        assertEquals(expectedClass, actual.get(1));
+        assertEquals(expectedMethod, actual.get(2));
+        assertEquals(expectedArgs, actual.get(3));
+        assertEquals(expectedReturnType, actual.get(4));
+    }
+
+    @Test
+    void testParsePartialFastenUriFailedModule() {
+        var partialUri = "/junit.awtui/AboutDialog<init>(/java.awt/Frame)/java.lang/VoidType";  // missing leading `.` after class name.
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            FastenUriUtils.parsePartialFastenUri(partialUri);
+        });
+
+        String expectedMessage = "Invalid partial FASTEN URI: module was not found.";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    void testParsePartialFastenUriFailedMethod() {
+        var partialUri = "/junit.awtui/AboutDialog.<init(/java.awt/Frame)/java.lang/VoidType"; // missing trailing `>`.
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            FastenUriUtils.parsePartialFastenUri(partialUri);
+        });
+
+        String expectedMessage = "Invalid partial FASTEN URI: method name was not found.";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    void testParsePartialFastenUriFailedMethodArgs() {
+        var partialUri = "/junit.awtui/AboutDialog.<init>/java.awt/Frame)/java.lang/VoidType"; // missing leading `(`.
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            FastenUriUtils.parsePartialFastenUri(partialUri);
+        });
+
+        String expectedMessage = "Invalid partial FASTEN URI: method's arguments were not found.";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    void testParsePartialFastenUriFailedMethodReturnT() {
+        var partialUri = "/junit.awtui/AboutDialog.<init>(/java.awt/Frame)"; // missing return type.
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            FastenUriUtils.parsePartialFastenUri(partialUri);
+        });
+
+        String expectedMessage = "Invalid partial FASTEN URI: method's return type was not found.";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+}

--- a/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
+++ b/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
@@ -63,6 +63,26 @@ public class FastenUriUtilsTest {
     }
 
     @Test
+    void testParsePartialFastenEncodedUriSuccess() {
+
+        var partialUri = "/com.sun.istack.localization/Localizer.%3Cinit%3E(%2Fjava.util%2FLocale)%2Fjava.lang%2FVoidType";
+
+        var expectedNamespace = "com.sun.istack.localization";
+        var expectedClass = "Localizer";
+        var expectedMethod = "<init>";
+        var expectedArgs = "/java.util/Locale";
+        var expectedReturnType = "/java.lang/VoidType";
+
+        var actual = FastenUriUtils.parsePartialFastenUri(partialUri);
+
+        assertEquals(expectedNamespace, actual.get(0));
+        assertEquals(expectedClass, actual.get(1));
+        assertEquals(expectedMethod, actual.get(2));
+        assertEquals(expectedArgs, actual.get(3));
+        assertEquals(expectedReturnType, actual.get(4));
+    }
+
+    @Test
     void testParsePartialFastenUriSuccessWithEmptyArgs() {
         var partialUri = "/junit.awtui/AboutDialog.<init>()/java.lang/VoidType";
         var expectedArgs = "";


### PR DESCRIPTION
Closes #207

## Description
PR brings a new utility method to `core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java` that parses partial FASTEN uri.

For example,

**INPUT:** `/junit.awtui/AboutDialog.<init>(/java.awt/Frame)/java.lang/VoidType`

**OUTPUT:**
- Namespace: `junit.awtui`
- Class: `AboutDialog`
- Method: `init`
- Method Args: `/java.awt/Frame`
- Method Return Type: `/java.lang/VoidType`

## Task list  
- [x] Implement parser
- [x] Write tests for the parser
- [x] Write tests for other methods in FastenUriUtilis