### PR TITLE
Set Kafka max message size to 50MB

### DIFF
--- a/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
+++ b/server/src/main/java/eu/fasten/server/connectors/KafkaConnector.java
@@ -56,6 +56,7 @@ public class KafkaConnector {
         properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         properties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         properties.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
+        properties.setProperty(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, "50000000"); //Set max read size to 50 MB.
         properties.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "5000"); // 5 seconds
 
         // Default consumption configuration
@@ -92,7 +93,8 @@ public class KafkaConnector {
                 StringSerializer.class.getName());
         p.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 StringSerializer.class.getName());
-
+        p.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG,
+                "50000000"); //Set produce size to 50MB.
         return p;
     }
 }


### PR DESCRIPTION
Addresses issue as reported here: https://github.com/fasten-project/fasten-docker-deployment/issues/1

Set producer and consumer side max message size to 50MB. This is in line with the broker configuration. 