### PR TITLE
API: Add module exist check for endpoints

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/BinaryModuleApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/BinaryModuleApiServiceImpl.java
@@ -34,6 +34,9 @@ public class BinaryModuleApiServiceImpl implements BinaryModuleApiService {
                                                           int limit) {
         String result = KnowledgeBaseConnector.kbDao.getPackageBinaryModules(
                 package_name, package_version, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
@@ -59,6 +62,9 @@ public class BinaryModuleApiServiceImpl implements BinaryModuleApiService {
                                                        int limit) {
         String result = KnowledgeBaseConnector.kbDao.getBinaryModuleFiles(
                 package_name, package_version, binary_module, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImpl.java
@@ -36,6 +36,9 @@ public class CallableApiServiceImpl implements CallableApiService {
                                                       int limit) {
         String result = KnowledgeBaseConnector.kbDao.getPackageCallables(
                 package_name, package_version, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/DependencyApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/DependencyApiServiceImpl.java
@@ -34,6 +34,9 @@ public class DependencyApiServiceImpl implements DependencyApiService {
                                                          int limit) {
         String result = KnowledgeBaseConnector.kbDao.getPackageDependencies(
                 package_name, package_version, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/EdgeApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/EdgeApiServiceImpl.java
@@ -34,6 +34,9 @@ public class EdgeApiServiceImpl implements EdgeApiService {
                                                   int limit) {
         String result = KnowledgeBaseConnector.kbDao.getPackageEdges(
                 package_name, package_version, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/FileApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/FileApiServiceImpl.java
@@ -34,6 +34,9 @@ public class FileApiServiceImpl implements FileApiService {
                                                   int limit) {
         String result = KnowledgeBaseConnector.kbDao.getPackageFiles(
                 package_name, package_version, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImpl.java
@@ -34,6 +34,9 @@ public class ModuleApiServiceImpl implements ModuleApiService {
                                                     int limit) {
         String result = KnowledgeBaseConnector.kbDao.getPackageModules(
                 package_name, package_version, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImpl.java
@@ -71,6 +71,9 @@ public class ModuleApiServiceImpl implements ModuleApiService {
                                                  int limit) {
         String result = KnowledgeBaseConnector.kbDao.getModuleCallables(
                 package_name, package_version, module_namespace, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImpl.java
@@ -59,6 +59,9 @@ public class ModuleApiServiceImpl implements ModuleApiService {
                                                  int limit) {
         String result = KnowledgeBaseConnector.kbDao.getModuleFiles(
                 package_name, package_version, module_namespace, offset, limit);
+        if (result == null) {
+            return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
+        }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1500,17 +1500,7 @@ public class MetadataDao {
                                   int offset,
                                   int limit) {
 
-        // SQL query
-        /*
-            SELECT {e.* | (e.source_id, e.target_id)}
-            FROM edges AS e
-                JOIN callables AS c ON e.source_id = c.id
-                JOIN modules AS m ON m.id = c.module_id
-                JOIN package_versions AS pv ON pv.id = m.package_version_id
-                JOIN packages AS p ON p.id = pv.package_id
-            WHERE p.package_name = <packageName>
-                AND pv.version = <packageVersion>;
-         */
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
 
         // Tables
         Packages p = Packages.PACKAGES;

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -907,6 +907,20 @@ public class MetadataDao {
                 .and(PackageVersions.PACKAGE_VERSIONS.VERSION.equalIgnoreCase(version));
     }
 
+    protected boolean assertPackageExistence(String name, String version) {
+        Packages p = Packages.PACKAGES;
+        PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;
+
+        Record selectPackage = context
+                .select(p.fields())
+                .from(p)
+                .innerJoin(pv).on(p.ID.eq(pv.PACKAGE_ID))
+                .where(packageVersionWhereClause(name, version))
+                .fetchOne();
+
+        return selectPackage != null;
+    }
+
     protected boolean assertModulesExistence(String name, String version, String namespace) {
         Packages p = Packages.PACKAGES;
         PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;
@@ -1309,6 +1323,8 @@ public class MetadataDao {
 
         // Where clause
         Condition whereClause = packageVersionWhereClause(packageName, packageVersion);
+
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
 
         // Building and executing the query
         Result<Record> queryResult = context

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1209,6 +1209,8 @@ public class MetadataDao {
     }
 
     public String getPackageBinaryModules(String packageName, String packageVersion, int offset, int limit) {
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
+
         // Tables
         Packages p = Packages.PACKAGES;
         PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;
@@ -1274,6 +1276,7 @@ public class MetadataDao {
                                        String binaryModule,
                                        int offset,
                                        int limit) {
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
 
         // Tables
         Packages p = Packages.PACKAGES;

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1087,6 +1087,9 @@ public class MetadataDao {
                                     String packageVersion,
                                     int offset,
                                     int limit) {
+
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
+
         // Tables
         Packages p = Packages.PACKAGES;
         PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1167,7 +1167,19 @@ public class MetadataDao {
         Modules m = Modules.MODULES;
         Callables c = Callables.CALLABLES;
 
-        // Query
+        // Check if module namespace exists
+        Result<Record> selectModule = context
+                .select(m.fields())
+                .from(p)
+                .innerJoin(pv).on(p.ID.eq(pv.PACKAGE_ID))
+                .innerJoin(m).on(pv.ID.eq(m.PACKAGE_VERSION_ID))
+                .where(packageVersionWhereClause(packageName, packageVersion))
+                .and(m.NAMESPACE.equalIgnoreCase(moduleNamespace))
+                .fetch();
+
+        if(selectModule.isEmpty()) return null;
+
+        // Main Query
         Result<Record> queryResult = context
                 .select(c.fields())
                 .from(p)

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1062,6 +1062,8 @@ public class MetadataDao {
      */
     public String getPackageDependencies(String packageName, String packageVersion, int offset, int limit) {
 
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
+
         // Tables
         Packages p = Packages.PACKAGES;
         PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1150,25 +1150,13 @@ public class MetadataDao {
                                  int offset,
                                  int limit) {
 
-        // SQL query
-        /*
-            SELECT f.*
-            FROM packages AS p
-                JOIN package_versions AS pv ON p.id = pv.package_id
-                JOIN modules AS m ON pv.id = m.package_version_id
-                JOIN files AS f ON pv.id = f.package_version_id
-            WHERE p.package_name = <packageName>
-                AND pv.version = <packageVersion>
-                AND m.namespace = <moduleNamespace>
-        */
+        if(!assertModulesExistence(packageName, packageVersion, moduleNamespace)) return null;
 
         // Tables
         Packages p = Packages.PACKAGES;
         PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;
         Modules m = Modules.MODULES;
         Files f = Files.FILES;
-
-        if(!assertModulesExistence(packageName, packageVersion, moduleNamespace)) return null;
 
         // Query
         Result<Record> queryResult = context
@@ -1194,13 +1182,13 @@ public class MetadataDao {
                                      int offset,
                                      int limit) {
 
+        if(!assertModulesExistence(packageName, packageVersion, moduleNamespace)) return null;
+
         // Tables
         Packages p = Packages.PACKAGES;
         PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;
         Modules m = Modules.MODULES;
         Callables c = Callables.CALLABLES;
-
-        if(!assertModulesExistence(packageName, packageVersion, moduleNamespace)) return null;
 
         // Main Query
         Result<Record> queryResult = context
@@ -1312,6 +1300,9 @@ public class MetadataDao {
     }
 
     public String getPackageCallables(String packageName, String packageVersion, int offset, int limit) {
+
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
+
         // Tables
         Packages p = Packages.PACKAGES;
         PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;
@@ -1323,8 +1314,6 @@ public class MetadataDao {
 
         // Where clause
         Condition whereClause = packageVersionWhereClause(packageName, packageVersion);
-
-        if(!assertPackageExistence(packageName, packageVersion)) return null;
 
         // Building and executing the query
         Result<Record> queryResult = context

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1154,6 +1154,8 @@ public class MetadataDao {
         Modules m = Modules.MODULES;
         Files f = Files.FILES;
 
+        if(!assertModulesExistence(packageName, packageVersion, moduleNamespace)) return null;
+
         // Query
         Result<Record> queryResult = context
                 .select(f.fields())

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -1444,15 +1444,7 @@ public class MetadataDao {
 
     public String getPackageFiles(String packageName, String packageVersion, int offset, int limit) {
 
-        // SQL query
-        /*
-            SELECT f.*
-            FROM packages AS p
-                JOIN package_versions AS pv ON p.id = pv.package_id
-                JOIN files AS f ON pv.id = f.package_version_id
-            WHERE p.package_name = <packageName>
-                AND pv.version = <packageVersion>
-        */
+        if(!assertPackageExistence(packageName, packageVersion)) return null;
 
         // Tables
         Packages p = Packages.PACKAGES;


### PR DESCRIPTION
Closes #213 

## Description
PR adds check for module existence in the endpoints of internal elements.  In the current implementation, if the module doesn't exist, such endpoints would still return `200` with an empty set, while supposed `404`.

For example, retrieval of the callables for a module, `/{pkg}/{pkg_ver}/modules/callables`.
   