### PR TITLE
Reducing the size of the Docker image for FASTEN dev.

### DIFF
--- a/.github/workflows/dockerpublish_develop_slim.yaml
+++ b/.github/workflows/dockerpublish_develop_slim.yaml
@@ -1,0 +1,63 @@
+name: Publish Docker image
+
+on:
+  push:
+    # Publish `develop` as Docker `latest` image.
+    branches:
+      - develop
+
+  # Run tests for any PRs.
+  pull_request:
+    branches:
+      - develop
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: fasten.server.develop.slim
+
+jobs:
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+
+    runs-on: ubuntu-18.04
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Build jar
+        run: mvn clean install
+      - name: Build image
+        run: cd docker/ && docker build . -f slim/Dockerfile -t fasten.server.develop.slim
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "develop" ] && VERSION=${GITHUB_SHA::8}
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          # Push images
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:latest
+          docker push $IMAGE_ID:latest

--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -170,7 +170,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <minimizeJar>true</minimizeJar>
+                            <minimizeJar>false</minimizeJar>
                             <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
                             <artifactSet>
                                 <excludes>

--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -177,6 +177,15 @@
 <!--                                    <exclude>org.slf4j:slf4j-simple:*</exclude>-->
 <!--                                    <exclude>org.slf4j:slf4j-api:*</exclude>-->
                                     <exclude>org.rocksdb:*</exclude>
+                                    <exclude>org.jooq:*</exclude>
+                                    <exclude>it.unimi.dsi:webgraph-big:*</exclude>
+                                    <exclude>it.unimi.dsi:webgraph:*</exclude>
+                                    <exclude>it.unimi.dsi:sux4j:*</exclude>
+                                    <exclude>org.postgresql:*</exclude>
+                                    <exclude>com.github.zafarkhaja:*</exclude>
+                                    <exlude>org.apache.maven:*</exlude>
+                                    <exlude>org.apache.maven.resolver:*</exlude>
+                                    <exclude>org.apache.maven.wagon:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <transformers>

--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -170,7 +170,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <minimizeJar>false</minimizeJar>
+                            <minimizeJar>true</minimizeJar>
                             <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
                             <artifactSet>
                                 <excludes>

--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -176,6 +176,7 @@
                                 <excludes>
 <!--                                    <exclude>org.slf4j:slf4j-simple:*</exclude>-->
 <!--                                    <exclude>org.slf4j:slf4j-api:*</exclude>-->
+                                    <exclude>org.rocksdb:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <transformers>

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:11-jre-slim-buster
 
 WORKDIR /
 

--- a/docker/slim/Dockerfile
+++ b/docker/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:11-jre-slim-buster
 
 WORKDIR /
 


### PR DESCRIPTION
## Description
In this PR, I try to reduce the size of the FASTEN's dev. image and the JAR files of plugins as much as possible. Also, we need to make sure that we will not encounter any issues as a result of reducing the size of images and removing unnecessary dependencies.

Specifically, I made changes to the following files:
- `fasten/docker/server/Dockerfile`: Added `openjdk:11-jre-slim-buster` for reducing the size of the image.
- `fasten/analyzer/javacg-opal/pom.xml`: Enabled `<minimizeJar>true</minimizeJar>` for reducing the size of the JAR file.

## Motivation and context
As pointed out by the partners, the size of the FASTEN dev. image has recently increased, i.e., 1.2GB. By using the slim version of the OpenJDK and minimizing JARs, it is possible to reduce the size of the image significantly.

## Testing
- The FASTEN server image should be deployed and tested to ensure that it will not have issues after reducing the size of its image.
- The OPAL plugin should be tested using its `Main` class and the FASTEN server.

## Task list  
- [x] Add `openjdk:11-jre-slim-buster` to the FASTEN server's Docker file
- [x] Enable minimize JAR option for the OPAL plugin in its POM file
- [x] Test the FASTEN server with various plugins with the new image
- [x] Test the OPAL plugin after minimizing its JAR file

## Additional context
- The size of the FASTEN dev. image is reduced by around 60%. Its size is now around **730MB**.
- The size of the OPAL plugin's JAR file is reduced by 50%. Its size is now 99MB.
