### PR TITLE
Custom exceptions for the vulnerability consumer

### DIFF
--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -23,6 +23,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.fasten.analyzer.vulnerabilityconsumer.db.MetadataUtility;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.PURLPackage;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.Vulnerability;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.ContextNotFoundException;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.PackageNotFoundException;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.PackageVersionsNotFoundException;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.CallablesNotFoundException;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
 import java.io.File;
@@ -79,12 +83,11 @@ public class VulnerabilityConsumer extends Plugin {
 
         @Override
         public void consume(String record) {
+            this.pluginError = null;
             // Step 1: Parse the record to a Vulnerability Object
             try {
-                // Reset plugin error
-                this.pluginError = null;
                 var v = objectMapper.readValue(record, Vulnerability.class);
-                logger.info("Read vulnerability " + v.getId() + " from Kafka");
+                logger.info("[READING] Read vulnerability " + v.getId() + " from Kafka");
                 // Step 2: Store the vulnerability object in the DB using the MetadataUtility
                 var metadataUtility = new MetadataUtility();
                 latestVulnJson = injectVulnerabilityIntoDB(v, metadataUtility);
@@ -163,22 +166,28 @@ public class VulnerabilityConsumer extends Plugin {
         public String injectVulnerabilityIntoDB(Vulnerability v, MetadataUtility metadataUtility) throws JsonProcessingException {
             logger.info("Injecting vulnerability " + v.getId() + " into the Database");
             var context = v.getPurls().size() > 0 ? getVulnerabilityEcosystem(v) : null;
-            // TODO: Throw a custom exception here for context not found
-            if (context == null) return objectMapper.writeValueAsString(v);
+            if (context == null) {
+                setPluginError(new ContextNotFoundException());
+                return objectMapper.writeValueAsString(v);
+            }
             v.setFirstPatchedPurls(v.getFirstPatchedPurls().stream()
                     .filter(Objects::nonNull).collect(Collectors.toList()));
 
             var pkgIds = metadataUtility.getPackageIds(context, v);
-            // TODO: Throw a custom exception here for package IDs not found
-            if (pkgIds.size() == 0) return objectMapper.writeValueAsString(v);
+            if (pkgIds.size() == 0) {
+                setPluginError(new PackageNotFoundException());
+                return objectMapper.writeValueAsString(v);
+            }
 
             var pkgVersionIds = metadataUtility.getPackageVersionIds(v.getPurls(), context,
                     pkgIds, v);
             var pkgVersionPatchedIds = metadataUtility.getPackageVersionIds(v.getFirstPatchedPurls(),
                     context, pkgIds, null);
 
-            // TODO: Throw a custom exception here for package version IDs not found
-            if (pkgVersionIds.size() == 0) return objectMapper.writeValueAsString(v);
+            if (pkgVersionIds.size() == 0) {
+                setPluginError(new PackageVersionsNotFoundException());
+                return objectMapper.writeValueAsString(v);
+            }
             var fastenUris = new HashSet<String>();
             var latestVersionId = pkgVersionIds.get(pkgVersionIds.size() - 1);
             pkgVersionPatchedIds.add(latestVersionId);
@@ -195,6 +204,9 @@ public class VulnerabilityConsumer extends Plugin {
 
             // TODO: Throw a custom exception here for callables not found
             logger.info("Collected " + fastenUris.size() + " vulnerable fasten_uris ids");
+//            if (fastenUris.size() == 0 && v.getPatches().size() > 0) {
+//                setPluginError(new CallablesNotFoundException());
+//            }
 
             var fullFastenUris = new HashSet<String>();
             var vulnCallableIds = new HashSet<Long>();

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -23,10 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.fasten.analyzer.vulnerabilityconsumer.db.MetadataUtility;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.PURLPackage;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.Vulnerability;
-import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.ContextNotFoundException;
-import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.PackageNotFoundException;
-import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.PackageVersionsNotFoundException;
-import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.CallablesNotFoundException;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.*;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
 import java.io.File;
@@ -95,8 +92,8 @@ public class VulnerabilityConsumer extends Plugin {
                 logger.info("Setting output path to store the JSON statement for " + v.getId());
                 outputPath = File.separator + "vuln" + File.separator + "consumer"
                         + File.separator + "statements" + File.separator + v.getId() + ".json";
-            } catch (JsonProcessingException e) {
-                logger.error("Could not parse record JSON");
+            } catch (JsonProcessingException | ContextNotFoundException | PackageNotFoundException | PackageVersionsNotFoundException e) {
+                logger.error("Exception in the consumer: " + e.getMessage(), e);
                 setPluginError(e);
             }
         }
@@ -163,20 +160,19 @@ public class VulnerabilityConsumer extends Plugin {
          * @param v               - Vulnerability Object
          * @param metadataUtility - Metadata DAO
          */
-        public String injectVulnerabilityIntoDB(Vulnerability v, MetadataUtility metadataUtility) throws JsonProcessingException {
+        public String injectVulnerabilityIntoDB(Vulnerability v, MetadataUtility metadataUtility) throws JsonProcessingException,
+                ContextNotFoundException, PackageNotFoundException, PackageVersionsNotFoundException {
             logger.info("Injecting vulnerability " + v.getId() + " into the Database");
             var context = v.getPurls().size() > 0 ? getVulnerabilityEcosystem(v) : null;
             if (context == null) {
-                setPluginError(new ContextNotFoundException());
-                return objectMapper.writeValueAsString(v);
+                throw new ContextNotFoundException();
             }
             v.setFirstPatchedPurls(v.getFirstPatchedPurls().stream()
                     .filter(Objects::nonNull).collect(Collectors.toList()));
 
             var pkgIds = metadataUtility.getPackageIds(context, v);
             if (pkgIds.size() == 0) {
-                setPluginError(new PackageNotFoundException());
-                return objectMapper.writeValueAsString(v);
+                throw new PackageNotFoundException();
             }
 
             var pkgVersionIds = metadataUtility.getPackageVersionIds(v.getPurls(), context,
@@ -185,8 +181,7 @@ public class VulnerabilityConsumer extends Plugin {
                     context, pkgIds, null);
 
             if (pkgVersionIds.size() == 0) {
-                setPluginError(new PackageVersionsNotFoundException());
-                return objectMapper.writeValueAsString(v);
+                throw new PackageVersionsNotFoundException();
             }
             var fastenUris = new HashSet<String>();
             var latestVersionId = pkgVersionIds.get(pkgVersionIds.size() - 1);
@@ -196,29 +191,34 @@ public class VulnerabilityConsumer extends Plugin {
 
             pkgVersionPatchedIds.forEach(pkgVersionId -> {
                 // TODO: Throw a custom exception here for package version IDs that do not have a patch at all.
-               v.getPatches().forEach(p -> {
-                   logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
-                   fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
-               });
+               if (v.getPatches().size() != 0) {
+                   v.getPatches().forEach(p -> {
+                       logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
+                       fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
+                   });
+                   writePatchDate(v);
+               } else {
+                   setPluginError(new PatchNotFoundException());
+               }
             });
 
             // TODO: Throw a custom exception here for callables not found
             logger.info("Collected " + fastenUris.size() + " vulnerable fasten_uris ids");
-//            if (fastenUris.size() == 0 && v.getPatches().size() > 0) {
-//                setPluginError(new CallablesNotFoundException());
-//            }
-
             var fullFastenUris = new HashSet<String>();
             var vulnCallableIds = new HashSet<Long>();
             var vulnPkgVersionIds = new HashSet<>(pkgVersionIds);
-            fastenUris.forEach(uri -> {
-                var callIds = metadataUtility.getCallableIdsForFastenUri(uri, vulnPkgVersionIds, context);
-                callIds.forEach(id -> fullFastenUris.add(metadataUtility.getFullFastenUri(uri, id)));
-                vulnCallableIds.addAll(callIds);
-            });
 
-            v.setFastenUris(fullFastenUris);
-            writePatchDate(v);
+            if (fastenUris.size() != 0) {
+                fastenUris.forEach(uri -> {
+                    var callIds = metadataUtility.getCallableIdsForFastenUri(uri, vulnPkgVersionIds, context);
+                    callIds.forEach(id -> fullFastenUris.add(metadataUtility.getFullFastenUri(uri, id)));
+                    vulnCallableIds.addAll(callIds);
+                });
+
+                v.setFastenUris(fullFastenUris);
+            } else if (v.getPatches().size() > 0) {
+                setPluginError(new CallablesNotFoundException());
+            }
 
             logger.info("Injecting all the information in the DB");
             vulnPkgVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(v, id, context));
@@ -274,6 +274,7 @@ public class VulnerabilityConsumer extends Plugin {
                 if (set)
                     v.setPatchDate(sdf.format(latestDate));
             } catch (Exception e) {
+                // TODO: Why an empty exception block?
             }
         }
 

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -163,11 +163,13 @@ public class VulnerabilityConsumer extends Plugin {
         public String injectVulnerabilityIntoDB(Vulnerability v, MetadataUtility metadataUtility) throws JsonProcessingException {
             logger.info("Injecting vulnerability " + v.getId() + " into the Database");
             var context = v.getPurls().size() > 0 ? getVulnerabilityEcosystem(v) : null;
+            // TODO: Throw a custom exception here for context not found
             if (context == null) return objectMapper.writeValueAsString(v);
             v.setFirstPatchedPurls(v.getFirstPatchedPurls().stream()
                     .filter(Objects::nonNull).collect(Collectors.toList()));
 
             var pkgIds = metadataUtility.getPackageIds(context, v);
+            // TODO: Throw a custom exception here for package IDs not found
             if (pkgIds.size() == 0) return objectMapper.writeValueAsString(v);
 
             var pkgVersionIds = metadataUtility.getPackageVersionIds(v.getPurls(), context,
@@ -175,6 +177,7 @@ public class VulnerabilityConsumer extends Plugin {
             var pkgVersionPatchedIds = metadataUtility.getPackageVersionIds(v.getFirstPatchedPurls(),
                     context, pkgIds, null);
 
+            // TODO: Throw a custom exception here for package version IDs not found
             if (pkgVersionIds.size() == 0) return objectMapper.writeValueAsString(v);
             var fastenUris = new HashSet<String>();
             var latestVersionId = pkgVersionIds.get(pkgVersionIds.size() - 1);
@@ -183,12 +186,14 @@ public class VulnerabilityConsumer extends Plugin {
             checkFileExtensions(v);
 
             pkgVersionPatchedIds.forEach(pkgVersionId -> {
+                // TODO: Throw a custom exception here for package version IDs that do not have a patch at all.
                v.getPatches().forEach(p -> {
                    logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
                });
             });
 
+            // TODO: Throw a custom exception here for callables not found
             logger.info("Collected " + fastenUris.size() + " vulnerable fasten_uris ids");
 
             var fullFastenUris = new HashSet<String>();

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
@@ -244,8 +244,23 @@ public class MetadataUtility {
                 .fetch();
 
         var callIds = new HashSet<>(callInfo.map(Record2::value1));
+//        callIds.addAll(callIdsSubProj);
+        callInfo.forEach(r -> cache.callIdToPkgVsn.put(r.value1(), cache.pkgVsnIdToVsn.get(r.value2())));
+        return callIds;
+    }
 
-        // Drill-down technique
+    /**
+     * Implements drill-down technique to find subprojects carrying the same callables.
+     * @param pkgVersionIds - map of package versions
+     * @param callIds - callable IDs of the main project
+     * @param fastenUri - fasten_uri to drill
+     * @param context - DSL context
+     * @return - List of callable IDs that we were able to drill
+     */
+    public List<Long> getDrilledDownCallables(HashSet<Long> pkgVersionIds,
+                                              Set<Long> callIds,
+                                              String fastenUri,
+                                              DSLContext context) {
         var callIdsSubProj = new ArrayList<Long>();
         var pkgVersions = pkgVersionIds.stream().map(id -> cache.pkgVsnIdToVsn.get(id)).collect(Collectors.toList());
         callIds.forEach(callId -> {
@@ -264,9 +279,7 @@ public class MetadataUtility {
         });
 
         if (callIdsSubProj.size() > 0)  logger.info("Found " + (callIdsSubProj.size() - 1) + " extra callable(s) using drill-down");
-        callIds.addAll(callIdsSubProj);
-        callInfo.forEach(r -> cache.callIdToPkgVsn.put(r.value1(), cache.pkgVsnIdToVsn.get(r.value2())));
-        return callIds;
+        return callIdsSubProj;
     }
 
     /**

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/CallablesNotFoundException.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/CallablesNotFoundException.java
@@ -1,0 +1,13 @@
+package eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions;
+
+/**
+ * Exception thrown if patches are present but no fasten_uri is found for the vulnerability.
+ */
+public class CallablesNotFoundException extends Exception {
+    /**
+     * Default constructor without a message.
+     */
+    public CallablesNotFoundException() {
+        super();
+    }
+}

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/ContextNotFoundException.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/ContextNotFoundException.java
@@ -1,0 +1,13 @@
+package eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions;
+
+/**
+ * Exception thrown if the context of the vulnerability was not found.
+ */
+public class ContextNotFoundException extends Exception {
+    /**
+     * Default constructor without a message.
+     */
+    public ContextNotFoundException() {
+        super();
+    }
+}

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/PackageNotFoundException.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/PackageNotFoundException.java
@@ -1,0 +1,13 @@
+package eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions;
+
+/**
+ * Exception thrown if no Package was found from the PURLs of the vulnerability.
+ */
+public class PackageNotFoundException extends Exception {
+    /**
+     * Default constructor without a message.
+     */
+    public PackageNotFoundException() {
+        super();
+    }
+}

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/PackageVersionsNotFoundException.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/PackageVersionsNotFoundException.java
@@ -1,0 +1,13 @@
+package eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions;
+
+/**
+ * Exception thrown if the Package Version could not be located from the PURLs.
+ */
+public class PackageVersionsNotFoundException extends Exception {
+    /**
+     * Default constructor without a message.
+     */
+    public PackageVersionsNotFoundException() {
+        super();
+    }
+}

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/PatchNotFoundException.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/exceptions/PatchNotFoundException.java
@@ -1,0 +1,11 @@
+package eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions;
+
+/**
+ * Exception thrown if patches are not present for the vulnerability.
+ */
+public class PatchNotFoundException extends Exception {
+
+    public PatchNotFoundException() {
+        super();
+    }
+}

--- a/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
+++ b/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
@@ -24,6 +24,10 @@ import eu.fasten.analyzer.vulnerabilityconsumer.VulnerabilityConsumer;
 import eu.fasten.analyzer.vulnerabilityconsumer.db.MetadataUtility;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.Severity;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.Vulnerability;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.ContextNotFoundException;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.PackageNotFoundException;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.PackageVersionsNotFoundException;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.exceptions.CallablesNotFoundException;
 import eu.fasten.core.data.Constants;
 import org.jooq.DSLContext;
 import org.json.JSONArray;
@@ -39,16 +43,16 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 public class VulnerabilityConsumerTest {
-    private VulnerabilityConsumer.VulnerabilityConsumerExtension vulnerabilityConsumerExtension;
+    private VulnerabilityConsumer.VulnerabilityConsumerExtension vc;
     private ObjectMapper objectmapper = new ObjectMapper();
     private DSLContext context;
 
     @BeforeEach
     public void setUp() {
         context = Mockito.mock(DSLContext.class);
-        vulnerabilityConsumerExtension = new VulnerabilityConsumer.VulnerabilityConsumerExtension();
-        vulnerabilityConsumerExtension.setTopic("fasten.vulnerability-consumer.out");
-        vulnerabilityConsumerExtension.setDBConnection(new HashMap<>(Map.of(Constants.mvnForge, context)));
+        vc = new VulnerabilityConsumer.VulnerabilityConsumerExtension();
+        vc.setTopic("fasten.vulnerability-consumer.out");
+        vc.setDBConnection(new HashMap<>(Map.of(Constants.mvnForge, context)));
     }
 
     @Test
@@ -116,7 +120,7 @@ public class VulnerabilityConsumerTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        vulnerabilityConsumerExtension.injectVulnerabilityIntoDB(v, metadataUtility);
+        vc.injectVulnerabilityIntoDB(v, metadataUtility);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v);
@@ -128,6 +132,61 @@ public class VulnerabilityConsumerTest {
         Mockito.verify(metadataUtility).injectPackageVersionVulnerability(v, 1L, context);
         Mockito.verify(metadataUtility).injectCallableVulnerability(v, 42L, context);
         Mockito.verify(metadataUtility).getFullFastenUri(fasten_uri, 42L);
+    }
+
+    @Test
+    public void testContextNotFoundExceptionIsThrown() throws JsonProcessingException {
+        var v = new Vulnerability();
+        v.setId("CVE-NO-PURL");
+        v.setDescription("Mock Vulnerability");
+        v.setSeverity(Severity.HIGH);
+        v.setScoreCVSS2(7.5);
+        v.setScoreCVSS3(5.0);
+        v.setPurls(new java.util.ArrayList<>());
+
+        var metadataUtility = Mockito.mock(MetadataUtility.class);
+        vc.injectVulnerabilityIntoDB(v, metadataUtility);
+
+        assertEquals(ContextNotFoundException.class.getSimpleName(), vc.getPluginError().getClass().getSimpleName());
+    }
+
+    @Test
+    public void testPackageNotFoundExceptionIsThrown() throws JsonProcessingException {
+        var v = new Vulnerability();
+        v.setId("CVE-NO-PURL");
+        v.setDescription("Mock Vulnerability");
+        v.setSeverity(Severity.HIGH);
+        v.setScoreCVSS2(7.5);
+        v.setScoreCVSS3(5.0);
+        v.setPurls(Arrays.asList("pkg:maven/org.testing/mock@1.0.1"));
+
+        var metadataUtility = Mockito.mock(MetadataUtility.class);
+        var pkgIds = new HashMap<String, Long>();
+        when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(Vulnerability.class))).thenReturn(pkgIds);
+
+        vc.injectVulnerabilityIntoDB(v, metadataUtility);
+
+        assertEquals(PackageNotFoundException.class.getSimpleName(), vc.getPluginError().getClass().getSimpleName());
+    }
+
+    @Test
+    public void testPackageVersionsNotFoundExceptionIsThrown() throws JsonProcessingException {
+        var v = new Vulnerability();
+        v.setId("CVE-NO-PURL");
+        v.setDescription("Mock Vulnerability");
+        v.setSeverity(Severity.HIGH);
+        v.setScoreCVSS2(7.5);
+        v.setScoreCVSS3(5.0);
+        v.setPurls(Arrays.asList("pkg:maven/org.testing/mock@1.0.1"));
+
+        var metadataUtility = Mockito.mock(MetadataUtility.class);
+        var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
+        when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(Vulnerability.class))).thenReturn(pkgIds);
+        when(metadataUtility.getPackageVersionIds(v.getPurls(), context, pkgIds, v)).thenReturn(new ArrayList<>());
+
+        vc.injectVulnerabilityIntoDB(v, metadataUtility);
+
+        assertEquals(PackageVersionsNotFoundException.class.getSimpleName(), vc.getPluginError().getClass().getSimpleName());
     }
 
     @Test


### PR DESCRIPTION
## Description
In this PR, custom exceptions will be implemented for the vulnerability consumer. The required custom exceptions are described in issue #249.

## Motivation and context
To better measure the precision and performance of the vulnerability consumer, custom exceptions are needed.

## Testing
We need to run the plugin again and analyze its output Kafka topic, and also its error topic.

## Task list  
- [] Implement classes for custom exceptions described in #249 
- [] Throw custom exceptions in the method `injectVulnerabilityIntoDB` in the specified places