### PR TITLE
Optional drill-down + Extra Info Vulnerability

### DIFF
--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
@@ -244,8 +244,23 @@ public class MetadataUtility {
                 .fetch();
 
         var callIds = new HashSet<>(callInfo.map(Record2::value1));
+//        callIds.addAll(callIdsSubProj);
+        callInfo.forEach(r -> cache.callIdToPkgVsn.put(r.value1(), cache.pkgVsnIdToVsn.get(r.value2())));
+        return callIds;
+    }
 
-        // Drill-down technique
+    /**
+     * Implements drill-down technique to find subprojects carrying the same callables.
+     * @param pkgVersionIds - map of package versions
+     * @param callIds - callable IDs of the main project
+     * @param fastenUri - fasten_uri to drill
+     * @param context - DSL context
+     * @return - List of callable IDs that we were able to drill
+     */
+    public List<Long> getDrilledDownCallables(HashSet<Long> pkgVersionIds,
+                                              Set<Long> callIds,
+                                              String fastenUri,
+                                              DSLContext context) {
         var callIdsSubProj = new ArrayList<Long>();
         var pkgVersions = pkgVersionIds.stream().map(id -> cache.pkgVsnIdToVsn.get(id)).collect(Collectors.toList());
         callIds.forEach(callId -> {
@@ -264,9 +279,7 @@ public class MetadataUtility {
         });
 
         if (callIdsSubProj.size() > 0)  logger.info("Found " + (callIdsSubProj.size() - 1) + " extra callable(s) using drill-down");
-        callIds.addAll(callIdsSubProj);
-        callInfo.forEach(r -> cache.callIdToPkgVsn.put(r.value1(), cache.pkgVsnIdToVsn.get(r.value2())));
-        return callIds;
+        return callIdsSubProj;
     }
 
     /**

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
@@ -93,6 +93,9 @@ public class Vulnerability {
     private List<String> firstPatchedPurls;
     private Double scoreCVSS2;
     private Double scoreCVSS3;
+    private String vectorCVSS2;
+    private String vectorCVSS3;
+    private List<String> cweIds;
     private Severity severity;
 
     private String publishedDate;
@@ -139,6 +142,18 @@ public class Vulnerability {
 
     public Double getScoreCVSS3() {
         return scoreCVSS3;
+    }
+
+    public String getVectorCVSS2() {
+        return vectorCVSS2;
+    }
+
+    public String getVectorCVSS3() {
+        return vectorCVSS3;
+    }
+
+    public List<String> getCweIds() {
+        return cweIds;
     }
 
     public Severity getSeverity() {
@@ -204,6 +219,18 @@ public class Vulnerability {
 
     public void setScoreCVSS3(Double scoreCVSS3) {
         this.scoreCVSS3 = scoreCVSS3;
+    }
+
+    public void setVectorCVSS2(String vectorCVSS2) {
+        this.vectorCVSS2 = vectorCVSS2;
+    }
+
+    public void setVectorCVSS3(String vectorCVSS3) {
+        this.vectorCVSS3 = vectorCVSS3;
+    }
+
+    public void setCweIds(List<String> cweIds) {
+        this.cweIds = cweIds;
     }
 
     public void setSeverity(Severity severity) {


### PR DESCRIPTION
The drill-down is currently not included in the consumer pipeline, more indexes need to be placed on the DB to accommodate this option. The following fields have been included in the Vulnerability definition: `vectorCVSS2`, `vectorCVSS3`, `cweIds`. Soon the statements stored in the DB will include this information.
