### PR TITLE
Include first_patched_purls and Extended lookup for callables

### DIFF
--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -183,11 +183,22 @@ public class VulnerabilityConsumer extends Plugin {
             checkFileExtensions(v);
 
             pkgVersionPatchedIds.forEach(pkgVersionId -> {
-               v.getPatches().forEach(p -> {
-                   logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
-                   fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
-               });
+                v.getPatches().forEach(p -> {
+                    logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
+                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
+                });
             });
+
+            // temp-workaround to deal with small number of records
+            var i = pkgVersionIds.size() - 2;
+            while (fastenUris.size() == 0 && i >= 0) {
+                var pkgVersionId = pkgVersionIds.get(i);
+                v.getPatches().forEach(p -> {
+                    logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
+                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
+                });
+                i -= 1;
+            }
 
             logger.info("Collected " + fastenUris.size() + " vulnerable fasten_uris ids");
 
@@ -233,8 +244,13 @@ public class VulnerabilityConsumer extends Plugin {
         public DSLContext getVulnerabilityEcosystem(Vulnerability v) {
             assert v.getPurls().size() > 0;
             var purl = v.getPurls().iterator().next();
-            var purlObj = PURLPackage.getObjectFromPurl(purl);
-            return contexts.get(purlObj.getType());
+            try {
+                var purlObj = PURLPackage.getObjectFromPurl(purl);
+                return contexts.get(purlObj.getType());
+            } catch (Exception e) {
+                logger.error("PURL was not formatted correctly");
+                return null;
+            }
         }
 
         /**

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -25,9 +25,9 @@ import eu.fasten.analyzer.vulnerabilityconsumer.utils.PURLPackage;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
-import java.io.File;
+
+import java.io.*;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.HashSet;
@@ -162,7 +162,8 @@ public class VulnerabilityConsumer extends Plugin {
          */
         public String injectVulnerabilityIntoDB(Vulnerability v, MetadataUtility metadataUtility) throws JsonProcessingException {
             logger.info("Injecting vulnerability " + v.getId() + " into the Database");
-            var context = v.getPurls().size() > 0 ? getVulnerabilityEcosystem(v) : null;
+            var ecosystem = v.getPurls().size() > 0 ? getVulnerabilityEcosystem(v) : null;
+            var context = ecosystem == null ? null : contexts.get(ecosystem);
             if (context == null) return objectMapper.writeValueAsString(v);
             v.setFirstPatchedPurls(v.getFirstPatchedPurls().stream()
                     .filter(Objects::nonNull).collect(Collectors.toList()));
@@ -189,18 +190,18 @@ public class VulnerabilityConsumer extends Plugin {
                 });
             });
 
-            // temp-workaround to deal with small number of records
-            var i = pkgVersionIds.size() - 2;
-            while (fastenUris.size() == 0 && i >= 0) {
-                var pkgVersionId = pkgVersionIds.get(i);
-                v.getPatches().forEach(p -> {
-                    logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
-                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
-                });
-                i -= 1;
-            }
-
             logger.info("Collected " + fastenUris.size() + " vulnerable fasten_uris ids");
+
+            if (fastenUris.size() == 0) {
+                pkgVersionIds.forEach(pkgVsnId -> {
+                    if (metadataUtility.areCallablesMissing(pkgVsnId, context)) {
+                        var vsn = metadataUtility.getCache().pkgVsnIdToVsn.get(pkgVsnId);
+                        var pkgName = metadataUtility.getCache().pkgVsnToName.get(vsn);
+                        var pkgCoord = ecosystem + "/packages/" + pkgName + "/" + vsn;
+                        metadataUtility.sendIngestRequest(pkgCoord);
+                    }
+                });
+            }
 
             var fullFastenUris = new HashSet<String>();
             var vulnCallableIds = new HashSet<Long>();
@@ -241,12 +242,12 @@ public class VulnerabilityConsumer extends Plugin {
          * @param v - Vulnerability Object
          * @return DSLContext
          */
-        public DSLContext getVulnerabilityEcosystem(Vulnerability v) {
+        public String getVulnerabilityEcosystem(Vulnerability v) {
             assert v.getPurls().size() > 0;
             var purl = v.getPurls().iterator().next();
             try {
                 var purlObj = PURLPackage.getObjectFromPurl(purl);
-                return contexts.get(purlObj.getType());
+                return purlObj.getType();
             } catch (Exception e) {
                 logger.error("PURL was not formatted correctly");
                 return null;

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
@@ -33,6 +33,8 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.*;
+import java.net.*;
 import java.util.*;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -48,6 +50,10 @@ public class MetadataUtility {
     private final Logger logger = LoggerFactory.getLogger(MetadataUtility.class.getName());
 
     public MetadataUtility() {
+    }
+
+    public Cache getCache() {
+        return cache;
     }
 
     /**
@@ -420,6 +426,35 @@ public class MetadataUtility {
 
             context.batch(vulnCallUpdates).execute();
             logger.info("Cleaned " + vulnCallUpdates.size() + " vulnerabilities from Callables Table");
+        }
+    }
+
+    /**
+     * Helper function to find if callable information for the given package version are not in KB.
+     * @param pkgVersionIds - Long
+     * @param context - DSLContext
+     * @return True if no module is found
+     */
+    public boolean areCallablesMissing(Long pkgVersionIds, DSLContext context) {
+        return context.selectCount().from(Modules.MODULES)
+                .where(Modules.MODULES.PACKAGE_VERSION_ID.eq(pkgVersionIds)).execute() <= 0;
+    }
+
+    /**
+     * Sends HTTP GET request to API to lazy ingest things.
+     * @param pkgCoord - String
+     */
+    public void sendIngestRequest(String pkgCoord) {
+        try {
+            var url = new URL("https://api.fasten.eu/api/" + pkgCoord);
+            var con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("GET");
+            int status = con.getResponseCode();
+            if (status == 201) {
+                logger.info("Successfully sent request to lazily ingest " + pkgCoord);
+            }
+        } catch (IOException e) {
+            logger.error("Could not send request to lazy ingest");
         }
     }
 }

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
@@ -131,7 +131,7 @@ public class Vulnerability {
         return purls;
     }
 
-    @JsonIgnore
+    @JsonProperty("first_patched_purls")
     public List<String> getFirstPatchedPurls() {
         return firstPatchedPurls;
     }

--- a/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
+++ b/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
@@ -22,8 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.fasten.analyzer.vulnerabilityconsumer.VulnerabilityConsumer;
 import eu.fasten.analyzer.vulnerabilityconsumer.db.MetadataUtility;
-import eu.fasten.analyzer.vulnerabilityconsumer.utils.Severity;
-import eu.fasten.analyzer.vulnerabilityconsumer.utils.Vulnerability;
+import eu.fasten.analyzer.vulnerabilityconsumer.utils.*;
 import eu.fasten.core.data.Constants;
 import org.jooq.DSLContext;
 import org.json.JSONArray;
@@ -53,36 +52,6 @@ public class VulnerabilityConsumerTest {
 
     @Test
     public void injectIntoDBVulnerabilityStatement() throws JsonProcessingException {
-        // VULNERABILITY OBJECT
-        var vulnJson = "[\n" +
-                "  {\n" +
-                "    \"id\": \"CVE-TEST\",\n" +
-                "    \"description\": \"Mock Vulnerability\",\n" +
-                "    \"severity\": \"HIGH\",\n" +
-                "    \"scoreCVSS2\": 7.5,\n" +
-                "    \"scoreCVSS3\": 5.0,\n" +
-                "    \"published_date\": \"12/11/2019\",\n" +
-                "    \"last_modified_date\": \"08/31/2020\",\n" +
-                "    \"purls\": [\n" +
-                "      \"pkg:maven/org.testing/mock@1.0.1\"\n" +
-                "    ],\n" +
-                "    \"references\": [],\n" +
-                "    \"patch_links\": [],\n" +
-                "    \"exploits\": [],\n" +
-                "    \"patches\": [\n" +
-                "      {\n" +
-                "        \"filename\": \"/src/main/java/net/GenericClass.java\",\n" +
-                "        \"date\": \"04/04/2004\",\n" +
-                "        \"line_numbers\": [\n" +
-                "          33\n" +
-                "        ]\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  }\n" +
-                "]";
-
-        final JSONArray vulnsJson = new JSONArray(new JSONTokener(vulnJson));
-
         var v = new Vulnerability();
         v.setId("CVE-TEST");
         v.setDescription("Mock Vulnerability");
@@ -168,5 +137,52 @@ public class VulnerabilityConsumerTest {
         VulnerabilityConsumer.VulnerabilityConsumerExtension.checkFileExtensions(v);
 
         assertEquals(new HashSet<>(Arrays.asList(patch)), v.getPatches());
+    }
+
+    @Test
+    public void lazyIngestCall() throws JsonProcessingException {
+        var v = new Vulnerability();
+        v.setId("CVE-TEST");
+        v.setDescription("Mock Vulnerability");
+        v.setSeverity(Severity.HIGH);
+        v.setScoreCVSS2(7.5);
+        v.setScoreCVSS3(5.0);
+        v.setPublishedDate("12/11/2019");
+        v.setLastModifiedDate("08/31/2020");
+        v.setPurls(Arrays.asList("pkg:maven/org.testing/mock@1.0.1"));
+        var patch = new Vulnerability.Patch();
+        patch.setPatchDate("04/04/2004");
+        patch.setLineNumbers(Arrays.asList(33));
+        patch.setFileName("/src/main/java/net/GenericClass.java");
+        v.setPatches(new HashSet<>(Arrays.asList(patch)));
+
+        var metadataUtility = Mockito.mock(MetadataUtility.class);
+        var cache = new Cache();
+        cache.pkgVsnIdToVsn.put(1L, "1.0.1");
+        cache.pkgVsnToName.put("1.0.1", "org.testing:mock");
+
+        var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
+        when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(Vulnerability.class))).thenReturn(pkgIds);
+        when(metadataUtility.getPackageVersionIds(v.getPurls(), context, pkgIds, v)).thenReturn(Arrays.asList(1L));
+        when(metadataUtility.getPackageVersionIds(v.getFirstPatchedPurls(), context, pkgIds, null)).thenReturn(new ArrayList<>());
+        when(metadataUtility.areCallablesMissing(Mockito.anyLong(), Mockito.any(DSLContext.class))).thenReturn(true);
+        when(metadataUtility.getCache()).thenReturn(cache);
+        when(metadataUtility.getFastenUrisForPatch(patch, 1L, context)).thenReturn(new HashSet<>());
+
+        var coord = "mvn/packages/org.testing:mock/1.0.1";
+        doNothing().when(metadataUtility).sendIngestRequest(coord);
+
+        // CALL
+        vulnerabilityConsumerExtension.injectVulnerabilityIntoDB(v, metadataUtility);
+
+        // MOCKITO VERIFY
+        Mockito.verify(metadataUtility).getPackageIds(context, v);
+        Mockito.verify(metadataUtility).getPackageVersionIds(v.getPurls(), context, pkgIds, v);
+        Mockito.verify(metadataUtility).getPackageVersionIds(v.getFirstPatchedPurls(), context, pkgIds, null);
+        Mockito.verify(metadataUtility).getFastenUrisForPatch(patch, 1L, context);
+        // VERIFY injection at package-level
+        Mockito.verify(metadataUtility).injectPackageVersionVulnerability(v, 1L, context);
+        //VERIFY lazy ingestion
+        Mockito.verify(metadataUtility).sendIngestRequest(coord);
     }
 }


### PR DESCRIPTION
- included the `first_patched_purl` in the published statement
- extended callable lookup to versions before `last_vulnerable` in case nothing is found
- catching exception on parsing of PURLs since some are problematic from the producer. The `getObjectFromPurl` will be refactored soon