### PR TITLE
Added patchUrl field to Patch class, fix for Kafka message parsing in Vulnerability Consumer

### DIFF
--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/utils/Vulnerability.java
@@ -28,6 +28,7 @@ public class Vulnerability {
     public static class Patch {
         public String fileName;
         public String patchDate;
+        public String patchUrl;
         public List<Integer> lineNumbers;
 
         /**
@@ -44,6 +45,8 @@ public class Vulnerability {
             return patchDate;
         }
 
+        public String getPatchUrl() { return patchUrl; }
+
         public List<Integer> getLineNumbers() {
             return lineNumbers;
         }
@@ -58,6 +61,11 @@ public class Vulnerability {
             this.patchDate = patchDate;
         }
 
+        @JsonProperty("patchUrl")
+        public void setPatchUrl(String patchUrl) {
+            this.patchUrl = patchUrl;
+        }
+
         @JsonProperty("line_numbers")
         public void setLineNumbers(List<Integer> lineNumbers) {
             this.lineNumbers = lineNumbers;
@@ -70,12 +78,13 @@ public class Vulnerability {
             Patch patch = (Patch) o;
             return fileName.equals(patch.fileName) &&
                     Objects.equals(patchDate, patch.patchDate) &&
+                    Objects.equals(patchUrl, patch.patchUrl) &&
                     lineNumbers.equals(patch.lineNumbers);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(fileName, patchDate, lineNumbers);
+            return Objects.hash(fileName, patchDate, patchUrl, lineNumbers);
         }
 
         @Override
@@ -83,6 +92,7 @@ public class Vulnerability {
             return "{" +
                     "filename='" + fileName + '\'' +
                     ", patch_date='" + patchDate + '\'' +
+                    ", patchUrl='" + patchUrl + '\'' +
                     ", line_numbers=" + lineNumbers +
                     '}';
         }


### PR DESCRIPTION
## Description
The Vulnerability$Path class was missing the patchUrl, causing parse failures of Kafka messages from the current Vulnerability Producer.

Fixes #264 

## Testing
Ran the Vulnerability Producer & Consumer in a local deployment and observed it was parsing the messages correctly.

