### PR TITLE
Setting callSiteOnly switch for Kafka Plugin (true) and CLI use (false)

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/Main.java
@@ -287,7 +287,8 @@ public class Main implements Runnable {
             revisionCallGraph = PartialCallGraph
                     .createExtendedRevisionJavaCallGraph((MavenCoordinate) artifact, mainClass,
                             algorithm, Long.parseLong(this.commands.computations.timestamp),
-                            (repos == null || repos.size() < 1) ? MavenUtilities.MAVEN_CENTRAL_REPO : repos.get(0));
+                            (repos == null || repos.size() < 1) ? MavenUtilities.MAVEN_CENTRAL_REPO : repos.get(0),
+                            false);
         }
 
         logger.info("Generated the call graph in {} seconds.", new DecimalFormat("#0.000")

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -79,7 +79,7 @@ public class OPALPlugin extends Plugin {
                 // Generate CG and measure construction duration.
                 logger.info("[CG-GENERATION] [UNPROCESSED] [-1] [" + mavenCoordinate.getCoordinate() + "] [NONE] ");
                 this.graph = PartialCallGraph.createExtendedRevisionJavaCallGraph(mavenCoordinate,
-                        "", "CHA", kafkaConsumedJson.optLong("date", -1), artifactRepository);
+                        "", "CHA", kafkaConsumedJson.optLong("date", -1), artifactRepository, true);
                 long endTime = System.nanoTime();
                 long duration = (endTime - startTime) / 1000000; // Compute duration in ms. 
 

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraph.java
@@ -67,7 +67,7 @@ public class PartialCallGraph {
     private final int nodeCount;
 
     public PartialCallGraph(CallGraphConstructor constructor) throws OPALException{
-        this(constructor, false);
+        this(constructor, true);
     }
 
     /**
@@ -123,7 +123,7 @@ public class PartialCallGraph {
      */
     public static ExtendedRevisionJavaCallGraph createExtendedRevisionJavaCallGraph(
             final MavenCoordinate coordinate, final String mainClass,
-            final String algorithm, final long timestamp, final String artifactRepo)
+            final String algorithm, final long timestamp, final String artifactRepo, final boolean callSiteOnly)
             throws MissingArtifactException, OPALException {
 
         File file = null;
@@ -131,7 +131,7 @@ public class PartialCallGraph {
             file = new MavenCoordinate.MavenResolver().downloadArtifact(coordinate, artifactRepo);
             final var opalCG = new CallGraphConstructor(file, mainClass, algorithm);
 
-            final var partialCallGraph = new PartialCallGraph(opalCG);
+            final var partialCallGraph = new PartialCallGraph(opalCG, callSiteOnly);
 
             return new ExtendedRevisionJavaCallGraph(Constants.mvnForge, coordinate.getProduct(),
                     coordinate.getVersionConstraint(), timestamp,

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/JSONUtilsTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/JSONUtilsTest.java
@@ -40,17 +40,17 @@ class JSONUtilsTest {
         var coordinate =
             new MavenCoordinate("com.github.shoothzj", "java-tool", "3.0.30.RELEASE", "jar");
         graph = PartialCallGraph.createExtendedRevisionJavaCallGraph(coordinate,
-            "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO);
+            "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO, true);
 
         coordinate =
             new MavenCoordinate("abbot", "costello", "1.4.0", "jar");
         artifact = PartialCallGraph.createExtendedRevisionJavaCallGraph(coordinate,
-            "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO);
+            "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO, true);
 
         coordinate =
             new MavenCoordinate("abbot", "abbot", "1.4.0", "jar");
         dependency = PartialCallGraph.createExtendedRevisionJavaCallGraph(coordinate,
-            "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO);
+            "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO, true);
         final var deps = new ArrayList<>(Collections.singletonList(dependency));
         deps.add(artifact);
         final var merger = new LocalMerger(deps);
@@ -100,7 +100,7 @@ class JSONUtilsTest {
         for (int i = 0; i < coordsSize; i++) {
             MavenCoordinate coord = coords.get(i);
             final var cg = PartialCallGraph.createExtendedRevisionJavaCallGraph(coord,
-                "", "CHA", 1574072773, MavenUtilities.getRepos().get(0));
+                "", "CHA", 1574072773, MavenUtilities.getRepos().get(0), true);
 
             logger.debug("Serialization for: {}", coord.getCoordinate());
             final var ser1 = avgConsumption(cg, "direct", "direct", 20, 20);

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraphTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/data/PartialCallGraphTest.java
@@ -69,7 +69,7 @@ class PartialCallGraphTest {
         singleCallCG = new PartialCallGraph(new CallGraphConstructor(
                 new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
                         .getResource("SingleSourceToTarget.class")).getFile()), "", "CHA"),
-            false);
+            true);
     }
 
     @Test
@@ -185,7 +185,7 @@ class PartialCallGraphTest {
     void createExtendedRevisionJavaCallGraph() throws MissingArtifactException, OPALException {
         var coordinate = new MavenCoordinate("org.slf4j", "slf4j-api", "1.7.29", "jar");
         var cg = PartialCallGraph.createExtendedRevisionJavaCallGraph(coordinate,
-                "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO);
+                "", "CHA", 1574072773, MavenUtilities.MAVEN_CENTRAL_REPO, true);
         assertNotNull(cg);
         Assertions.assertEquals(Constants.mvnForge, cg.forge);
         Assertions.assertEquals("1.7.29", cg.version);


### PR DESCRIPTION
Changed the default of callSiteOnly in PartialCallGraph constructor to true, the Kafka Plugin uses true explicitly, and the CLI tool uses false.
