### PR TITLE
Sets output path of payload, so it can be stored to disk.

### DIFF
--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -161,6 +161,9 @@ public class MetadataDBExtension implements KafkaPlugin, DBConnector {
                         restartTransaction = false;
                         logger.info("Saved the '" + revision + "' callgraph metadata "
                                 + "to the database with package version ID = " + id);
+
+                        // Set the output path for this call graph, so that it can be stored to disk if necessary.
+                        setOutputPath(callgraph);
                     }
                 });
             } catch (Exception expected) {


### PR DESCRIPTION
OPAL can write its payload to disk (to prevent CG's which are too big for Kafka). In the metadata plugin, this output path was not set and therefore the write-payload-to-disk did not work. This PR resolves that issue.