### PR TITLE
Pending topic in Vulnerability Consumer for lazy ingest

### DIFF
--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/VulnerabilityConsumer.java
@@ -36,7 +36,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.concurrent.atomic.*;
 import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.producer.*;
 import org.jooq.DSLContext;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -53,11 +56,13 @@ public class VulnerabilityConsumer extends Plugin {
     @Extension
     public static class VulnerabilityConsumerExtension implements KafkaPlugin, DBConnector {
         private String consumerTopic = "fasten.vulnerability.out";
+        private String pendingTopic = consumerTopic + ".pending";
         private String outputPath;
         private static Map<String, DSLContext> contexts;
         private Exception pluginError = null;
         private String latestVulnJson = null;
         private ObjectMapper objectMapper = new ObjectMapper();
+        private KafkaProducer<String, String> kafkaProducer;
         private static DateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         private final static String[] extensions = new String[]{".java", ".py", ".pyw", ".c", ".cpp", ".h"};
         private final Logger logger = LoggerFactory.getLogger(VulnerabilityConsumerExtension.class.getName());
@@ -75,25 +80,17 @@ public class VulnerabilityConsumer extends Plugin {
         @Override
         public void setTopic(String topicName) {
             this.consumerTopic = topicName;
+            this.pendingTopic = topicName.endsWith(".pending") ? topicName : topicName + ".pending";
         }
 
         @Override
         public void consume(String record) {
-            // Step 1: Parse the record to a Vulnerability Object
             try {
-                // Reset plugin error
-                this.pluginError = null;
-                var v = objectMapper.readValue(record, Vulnerability.class);
-                logger.info("Read vulnerability " + v.getId() + " from Kafka");
-                // Step 2: Store the vulnerability object in the DB using the MetadataUtility
-                var metadataUtility = new MetadataUtility();
-                latestVulnJson = injectVulnerabilityIntoDB(v, metadataUtility);
-                // Setting output path to save it
-                logger.info("Setting output path to store the JSON statement for " + v.getId());
-                outputPath = File.separator + "vuln" + File.separator + "consumer"
-                        + File.separator + "statements" + File.separator + v.getId() + ".json";
+                this.pluginError = null; // Reset Plugin error
+                var metadataUtility = new MetadataUtility(); // Injecting for easier testing
+                latestVulnJson = injectVulnerabilityIntoDB(record, metadataUtility);
             } catch (JsonProcessingException e) {
-                logger.error("Could not parse record JSON");
+                logger.error("[ERROR] Could not parse vulnerability record JSON");
                 setPluginError(e);
             }
         }
@@ -154,14 +151,20 @@ public class VulnerabilityConsumer extends Plugin {
             return 3600000; // The VulnerabilityConsumer plugin takes up to 1h to process a record.
         }
 
+        public void setKafkaProducer(KafkaProducer<String, String> kafkaProducer) {
+            this.kafkaProducer = kafkaProducer;
+        }
+
         /**
          * Method to inject the information contained in a Vulnerability Object.
          *
-         * @param v               - Vulnerability Object
+         * @param record          - Vulnerability JSON record
          * @param metadataUtility - Metadata DAO
          */
-        public String injectVulnerabilityIntoDB(Vulnerability v, MetadataUtility metadataUtility) throws JsonProcessingException {
-            logger.info("Injecting vulnerability " + v.getId() + " into the Database");
+        public String injectVulnerabilityIntoDB(String record, MetadataUtility metadataUtility) throws JsonProcessingException {
+            var v = objectMapper.readValue(record, Vulnerability.class);
+            logger.info("[INFO] Read vulnerability " + v.getId() + " from Kafka");
+            logger.info("[INFO] Injecting vulnerability " + v.getId() + " into the Database");
             var ecosystem = v.getPurls().size() > 0 ? getVulnerabilityEcosystem(v) : null;
             var context = ecosystem == null ? null : contexts.get(ecosystem);
             if (context == null) return objectMapper.writeValueAsString(v);
@@ -185,12 +188,13 @@ public class VulnerabilityConsumer extends Plugin {
 
             pkgVersionPatchedIds.forEach(pkgVersionId -> {
                 v.getPatches().forEach(p -> {
-                    logger.info("Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
+                    logger.info("[INFO] Searching for callables in " + p.getFileName() + " for Package Version ID: " + pkgVersionId);
                     fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p, pkgVersionId, context));
                 });
             });
 
-            logger.info("Collected " + fastenUris.size() + " vulnerable fasten_uris ids");
+            logger.info("[INFO] Collected " + fastenUris.size() + " vulnerable fasten_uris ids");
+            var pendingFlag = new AtomicBoolean(false);
 
             if (fastenUris.size() == 0) {
                 pkgVersionIds.forEach(pkgVsnId -> {
@@ -199,6 +203,7 @@ public class VulnerabilityConsumer extends Plugin {
                         var pkgName = metadataUtility.getCache().pkgVsnToName.get(vsn);
                         var pkgCoord = ecosystem + "/packages/" + pkgName + "/" + vsn;
                         metadataUtility.sendIngestRequest(pkgCoord);
+                        pendingFlag.set(true);
                     }
                 });
             }
@@ -215,9 +220,19 @@ public class VulnerabilityConsumer extends Plugin {
             v.setFastenUris(fullFastenUris);
             writePatchDate(v);
 
-            logger.info("Injecting all the information in the DB");
+            logger.info("[INFO] Injecting all the information in the DB");
             vulnPkgVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(v, id, context));
             vulnCallableIds.forEach(id -> metadataUtility.injectCallableVulnerability(v, id, context));
+
+            if (pendingFlag.get()) {
+                logger.info("[INFO] Publishing vulnerability " + v.getId() + " to pending topic");
+                kafkaProducer.send(new ProducerRecord<>(pendingTopic, record));
+            }
+
+            logger.info("[INFO] Setting output path to store the JSON statement for " + v.getId());
+            outputPath = File.separator + "vuln" + File.separator + "consumer"
+                    + File.separator + "statements" + File.separator + v.getId() + ".json";
+
             return objectMapper.writeValueAsString(v);
         }
 

--- a/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
+++ b/analyzer/vulnerability-consumer/src/test/java/eu/fasten/vulnerabilityconsumer/VulnerabilityConsumerTest.java
@@ -24,18 +24,22 @@ import eu.fasten.analyzer.vulnerabilityconsumer.VulnerabilityConsumer;
 import eu.fasten.analyzer.vulnerabilityconsumer.db.MetadataUtility;
 import eu.fasten.analyzer.vulnerabilityconsumer.utils.*;
 import eu.fasten.core.data.Constants;
+import org.apache.commons.io.*;
+import org.apache.kafka.clients.producer.*;
 import org.jooq.DSLContext;
 import org.json.JSONArray;
 import org.json.JSONTokener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.*;
 
+import java.io.*;
+import java.nio.charset.*;
 import java.util.*;
+import java.util.concurrent.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class VulnerabilityConsumerTest {
     private VulnerabilityConsumer.VulnerabilityConsumerExtension vulnerabilityConsumerExtension;
@@ -46,28 +50,20 @@ public class VulnerabilityConsumerTest {
     public void setUp() {
         context = Mockito.mock(DSLContext.class);
         vulnerabilityConsumerExtension = new VulnerabilityConsumer.VulnerabilityConsumerExtension();
-        vulnerabilityConsumerExtension.setTopic("fasten.vulnerability-consumer.out");
+        vulnerabilityConsumerExtension.setTopic("fasten.vulnerability.out");
         vulnerabilityConsumerExtension.setDBConnection(new HashMap<>(Map.of(Constants.mvnForge, context)));
     }
 
     @Test
-    public void injectIntoDBVulnerabilityStatement() throws JsonProcessingException {
-        var v = new Vulnerability();
-        v.setId("CVE-TEST");
-        v.setDescription("Mock Vulnerability");
-        v.setSeverity(Severity.HIGH);
-        v.setScoreCVSS2(7.5);
-        v.setScoreCVSS3(5.0);
-        v.setPublishedDate("12/11/2019");
-        v.setLastModifiedDate("08/31/2020");
-        v.setPurls(Arrays.asList("pkg:maven/org.testing/mock@1.0.1"));
-        var patch = new Vulnerability.Patch();
-        patch.setPatchDate("04/04/2004");
-        patch.setLineNumbers(Arrays.asList(33));
-        patch.setFileName("/src/main/java/net/GenericClass.java");
-        v.setPatches(new HashSet<>(Arrays.asList(patch)));
-
+    public void injectIntoDBVulnerabilityStatement() throws IOException {
         var metadataUtility = Mockito.mock(MetadataUtility.class);
+
+        // Read JSON
+        var recordFile = new File("./src/test/resources/record.json");
+        var record = FileUtils.readFileToString(recordFile, StandardCharsets.UTF_8);
+
+        var v = objectmapper.readValue(record, Vulnerability.class);
+        var patch = v.getPatches().iterator().next();
 
         // MOCKITO WHEN
         var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
@@ -85,7 +81,7 @@ public class VulnerabilityConsumerTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        vulnerabilityConsumerExtension.injectVulnerabilityIntoDB(v, metadataUtility);
+        vulnerabilityConsumerExtension.injectVulnerabilityIntoDB(record, metadataUtility);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v);
@@ -140,27 +136,21 @@ public class VulnerabilityConsumerTest {
     }
 
     @Test
-    public void lazyIngestCall() throws JsonProcessingException {
-        var v = new Vulnerability();
-        v.setId("CVE-TEST");
-        v.setDescription("Mock Vulnerability");
-        v.setSeverity(Severity.HIGH);
-        v.setScoreCVSS2(7.5);
-        v.setScoreCVSS3(5.0);
-        v.setPublishedDate("12/11/2019");
-        v.setLastModifiedDate("08/31/2020");
-        v.setPurls(Arrays.asList("pkg:maven/org.testing/mock@1.0.1"));
-        var patch = new Vulnerability.Patch();
-        patch.setPatchDate("04/04/2004");
-        patch.setLineNumbers(Arrays.asList(33));
-        patch.setFileName("/src/main/java/net/GenericClass.java");
-        v.setPatches(new HashSet<>(Arrays.asList(patch)));
-
+    public void lazyIngestCall() throws IOException {
         var metadataUtility = Mockito.mock(MetadataUtility.class);
+        var mockProducer = Mockito.mock(KafkaProducer.class);
+        vulnerabilityConsumerExtension.setKafkaProducer(mockProducer);
+        var pendingTopic = "fasten.vulnerability.out.pending";
+        // Read JSON
+        var recordFile = new File("./src/test/resources/record.json");
+        var record = FileUtils.readFileToString(recordFile, StandardCharsets.UTF_8);
+
         var cache = new Cache();
         cache.pkgVsnIdToVsn.put(1L, "1.0.1");
         cache.pkgVsnToName.put("1.0.1", "org.testing:mock");
 
+        var v = objectmapper.readValue(record, Vulnerability.class);
+        var patch = v.getPatches().iterator().next();
         var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
         when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(Vulnerability.class))).thenReturn(pkgIds);
         when(metadataUtility.getPackageVersionIds(v.getPurls(), context, pkgIds, v)).thenReturn(Arrays.asList(1L));
@@ -172,8 +162,12 @@ public class VulnerabilityConsumerTest {
         var coord = "mvn/packages/org.testing:mock/1.0.1";
         doNothing().when(metadataUtility).sendIngestRequest(coord);
 
+        // INJECT Kafka Producer
+        var pendingRecord = new ProducerRecord<>(pendingTopic, record);
+        var future  = Mockito.mock(Future.class);
+        when(mockProducer.send(Mockito.any())).thenReturn(future);
         // CALL
-        vulnerabilityConsumerExtension.injectVulnerabilityIntoDB(v, metadataUtility);
+        vulnerabilityConsumerExtension.injectVulnerabilityIntoDB(record, metadataUtility);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v);
@@ -184,5 +178,16 @@ public class VulnerabilityConsumerTest {
         Mockito.verify(metadataUtility).injectPackageVersionVulnerability(v, 1L, context);
         //VERIFY lazy ingestion
         Mockito.verify(metadataUtility).sendIngestRequest(coord);
+        // VERIFY Published record to Pending
+        Mockito.verify(mockProducer).send(pendingRecord);
+    }
+
+    @Test
+    public void testReadRecordFromProducer() throws IOException {
+        var recordFile = new File("./src/test/resources/statement.json");
+        var record = FileUtils.readFileToString(recordFile, StandardCharsets.UTF_8);
+        var v = objectmapper.readValue(record, Vulnerability.class);
+        // Check if object mapper was able to read it
+        assertEquals("CVE-2012-4387", v.getId());
     }
 }

--- a/analyzer/vulnerability-consumer/src/test/resources/record.json
+++ b/analyzer/vulnerability-consumer/src/test/resources/record.json
@@ -1,0 +1,33 @@
+{
+    "id": "CVE-TEST",
+    "description": "Mock Vulnerability",
+    "severity": "MODERATE",
+    "scoreCVSS2": 5.0,
+    "scoreCVSS3": 7.5,
+    "vectorCVSS2": "AV:N/AC:M/Au:S/C:N/I:P/A:N",
+    "vectorCVSS3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+    "cweIds": ["CWE-79"],
+    "published_date": "2019-09-11",
+    "last_modified_date": "2020-06-10",
+    "purls": [
+      "pkg:maven/org.testing/mock@1.0.1"
+    ],
+    "first_patched_purls": [
+      "pkg:maven/org.testing/mock@1.0.1"
+    ],
+    "references": [],
+    "patch_links": [
+      "https://github.com/apache/struts/commit/87935af56a27235e9399308ee1fcfb74f8edcefa"
+    ],
+    "exploits": [],
+    "patches": [
+      {
+        "filename": "/src/main/java/net/GenericClass.java",
+        "date": "2004-04-04",
+        "line_numbers": [
+          33
+        ],
+        "patchUrl": "git://github.com/apache/struts@87935af56a27235e9399308ee1fcfb74f8edcefa"
+      }
+    ]
+}

--- a/analyzer/vulnerability-consumer/src/test/resources/statement.json
+++ b/analyzer/vulnerability-consumer/src/test/resources/statement.json
@@ -1,0 +1,43 @@
+{
+  "id": "CVE-2012-4387",
+  "purls": [
+    "pkg:maven/org.apache.struts/struts2-core@2.0.5",
+    "pkg:maven/org.apache.struts/struts2-core@2.2.1",
+    "pkg:maven/org.apache.struts/struts2-core@2.2.3",
+    "pkg:maven/org.apache.struts/struts2-core@2.2.3.1"
+  ],
+  "first_patched_purls": [
+    "pkg:maven/org.apache.struts/struts2-core@2.3.7"
+  ],
+  "references": [
+    "http://struts.apache.org/docs/s2-011.html"
+  ],
+  "patch_links": [
+    "https://github.com/apache/struts/commit/87935af56a27235e9399308ee1fcfb74f8edcefa"
+  ],
+  "exploits": [],
+  "patches": [
+    {
+      "filename": "xwork-core/src/main/java/com/opensymphony/xwork2/interceptor/ParametersInterceptor.java",
+      "date": "2012-08-03",
+      "line_numbers": [
+        98,
+        100,
+        132,
+        153,
+        163,
+        353,
+        356
+      ],
+      "patchUrl": "git://github.com/apache/struts@87935af56a27235e9399308ee1fcfb74f8edcefa"
+    },
+    {
+      "filename": "xwork-core/src/test/java/com/opensymphony/xwork2/interceptor/ParametersInterceptorTest.java",
+      "date": "2012-08-03",
+      "line_numbers": [
+        204
+      ],
+      "patchUrl": "git://github.com/apache/struts@87935af56a27235e9399308ee1fcfb74f8edcefa"
+    }
+  ]
+}


### PR DESCRIPTION
Takes care of #272, using a new `pending` topic to enqueue vulnerabilities that we were not able to inject and for which we used lazy ingestion. The logic is implemented by including a `KafkaProducer<String, String>` object in the `VulnerabilityConsumerExtension` class and we use it to publish to a new pending topic. 

To avoid recursive pending topics (e.g. pending consumer publishing to a `pending.pending` consumer), in the `setTopic` method, we check if we are already in a `pending` context by looking at the `topicName` to consume from passed by the FASTEN server (https://github.com/fasten-project/fasten/commit/14d7886837c7ae1969e3457a4a5cf13031916887#diff-6d444bb0169e676186af6b8a2a71a16fddbae23bf90ba36650fca11e6fa4ff8eR83).