### PR TITLE
Fix uri parser

### DIFF
--- a/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
+++ b/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
@@ -83,27 +83,27 @@ public class FastenUriUtils {
         Pattern namespacePattern = Pattern.compile("(?<=/)(.+?)(?=/)");
         Matcher namespaceMatcher = namespacePattern.matcher(partialFastenUri);
         if (!namespaceMatcher.find() || namespaceMatcher.group(0).isEmpty())
-            throw new IllegalArgumentException(partialUriFormatException);
+            throw new IllegalArgumentException(partialUriFormatException + "; failed to parse namespace.");
 
         // Class: `/{class}.*(`
         Pattern classPattern = Pattern.compile("(?<=/)([^,;./]+?)(?=(\\$|\\.)([^./]+)\\()");
         Matcher classMatcher = classPattern.matcher(partialFastenUri);
         if (!classMatcher.find() || classMatcher.group(0).isEmpty())
-            throw new IllegalArgumentException(partialUriFormatException);
+            throw new IllegalArgumentException(partialUriFormatException + "; failed to parse class name.");
 
 
         // Method: `.{method}(`
         Pattern methodNamePattern = Pattern.compile("(?<=\\.(\\$?))([^,;./$]+?)(?=\\()");
         Matcher methodNameMatcher = methodNamePattern.matcher(partialFastenUri);
         if (!methodNameMatcher.find() || methodNameMatcher.group(0).isEmpty())
-            throw new IllegalArgumentException(partialUriFormatException);
+            throw new IllegalArgumentException(partialUriFormatException + "; failed to parse method name.");
 
 
         // Method Args: `({args})`
         Pattern methodArgsPattern = Pattern.compile("(?<=" + methodNameMatcher.group(0) + "\\()(.*?)(?=\\))");
         Matcher methodArgsMatcher = methodArgsPattern.matcher(partialFastenUri);
         if (!methodArgsMatcher.find())
-            throw new IllegalArgumentException(partialUriFormatException);
+            throw new IllegalArgumentException(partialUriFormatException + "; failed to parse method args.");
 
 
         // Method Return Type: `)/{type}`
@@ -111,7 +111,7 @@ public class FastenUriUtils {
                 "(?<=" + methodNameMatcher.group(0) + "\\(" + methodArgsMatcher.group(0) + "\\))(.*)");
         Matcher methodReturnMatcher = methodReturnPattern.matcher(partialFastenUri);
         if (!methodReturnMatcher.find() || methodReturnMatcher.group(0).isEmpty())
-            throw new IllegalArgumentException(partialUriFormatException);
+            throw new IllegalArgumentException(partialUriFormatException + "; failed to parse return type.");
 
 
         var namespace = namespaceMatcher.group(0);

--- a/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
+++ b/core/src/main/java/eu/fasten/core/utils/FastenUriUtils.java
@@ -100,15 +100,14 @@ public class FastenUriUtils {
 
 
         // Method Args: `({args})`
-        Pattern methodArgsPattern = Pattern.compile("(?<=" + methodNameMatcher.group(0) + "\\()(.*?)(?=\\))");
+        Pattern methodArgsPattern = Pattern.compile("(?<=" + Pattern.quote(methodNameMatcher.group(0)) + "\\()(.*?)(?=\\))");
         Matcher methodArgsMatcher = methodArgsPattern.matcher(partialFastenUri);
         if (!methodArgsMatcher.find())
             throw new IllegalArgumentException(partialUriFormatException + "; failed to parse method args.");
 
-
         // Method Return Type: `)/{type}`
         Pattern methodReturnPattern = Pattern.compile(
-                "(?<=" + methodNameMatcher.group(0) + "\\(" + methodArgsMatcher.group(0) + "\\))(.*)");
+                "(?<=" + Pattern.quote(methodNameMatcher.group(0)) + "\\(" + Pattern.quote(methodArgsMatcher.group(0)) + "\\))(.*)");
         Matcher methodReturnMatcher = methodReturnPattern.matcher(partialFastenUri);
         if (!methodReturnMatcher.find() || methodReturnMatcher.group(0).isEmpty())
             throw new IllegalArgumentException(partialUriFormatException + "; failed to parse return type.");

--- a/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
+++ b/core/src/test/java/eu/fasten/core/utils/FastenUriUtilsTest.java
@@ -1,16 +1,14 @@
 package eu.fasten.core.utils;
 
 import eu.fasten.core.data.FastenURI;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.net.URISyntaxException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FastenUriUtilsTest {
 
-    private String partialUriFormatException = "Invalid partial FASTEN URI. The format is corrupted.\nMust be: `/{namespace}/{class}.{method}({signature.args})/{signature.returnType}`";
+    private final String partialUriFormatException = "Invalid partial FASTEN URI. The format is corrupted.\nMust be: `/{namespace}/{class}.{method}({signature.args})/{signature.returnType}`";
 
     @Test
     void testGenerateFullFastenUriSuccess() {
@@ -102,6 +100,28 @@ public class FastenUriUtilsTest {
     }
 
     @Test
+    void testParsePartialFastenUriEscapeCharsSuccess1() {
+
+        var partialUri = "/nl.tudelft.jpacman.level/CollisionInteractionMap$InverseCollisionHandler.%3Cinit%3E(CollisionInteractionMap$CollisionHandler)%2Fjava.lang%2FVoidType";
+        var expectedNamespace = "nl.tudelft.jpacman.level";
+
+        var actual = FastenUriUtils.parsePartialFastenUri(partialUri);
+
+        assertEquals(expectedNamespace, actual.get(0));
+    }
+
+    @Test
+    void testParsePartialFastenUriEscapeCharsSuccess2() {
+
+        var partialUri = "/com.google.common.collect/ImmutableList.construct(%2Fjava.lang%2FObject%5B%5D)ImmutableList";
+        var expectedNamespace = "com.google.common.collect";
+
+        var actual = FastenUriUtils.parsePartialFastenUri(partialUri);
+
+        assertEquals(expectedNamespace, actual.get(0));
+    }
+
+    @Test
     void testParsePartialFastenEncodedUriSuccess() {
 
         var partialUri = "/com.sun.istack.localization/Localizer.%3Cinit%3E(%2Fjava.util%2FLocale)%2Fjava.lang%2FVoidType";
@@ -133,9 +153,7 @@ public class FastenUriUtilsTest {
     void testParsePartialFastenUriFailFullUri() {
         var fullUriException = "Invalid partial FASTEN URI. You may want to use parser for full FASTEN URI instead.";
         var partialUri = "fasten://forge!name$1.0/partial";
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            FastenUriUtils.parsePartialFastenUri(partialUri);
-        });
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> FastenUriUtils.parsePartialFastenUri(partialUri));
 
         String actualMessage = exception.getMessage();
         assertEquals(fullUriException, actualMessage);
@@ -145,45 +163,37 @@ public class FastenUriUtilsTest {
     @Test
     void testParsePartialFastenUriFailedModule() {
         var partialUri = "/junit.awtui/AboutDialog<init>(/java.awt/Frame)/java.lang/VoidType";  // missing trailing `.` after class name.
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            FastenUriUtils.parsePartialFastenUri(partialUri);
-        });
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> FastenUriUtils.parsePartialFastenUri(partialUri));
 
         String actualMessage = exception.getMessage();
-        assertEquals(partialUriFormatException, actualMessage);
+        Assertions.assertTrue(actualMessage.startsWith(partialUriFormatException));
     }
 
     @Test
     void testParsePartialFastenUriFailedMethodArgs() {
         var partialUri = "/junit.awtui/AboutDialog.<init>/java.awt/Frame)/java.lang/VoidType"; // missing leading `(`.
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            FastenUriUtils.parsePartialFastenUri(partialUri);
-        });
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> FastenUriUtils.parsePartialFastenUri(partialUri));
 
         String actualMessage = exception.getMessage();
-        assertEquals(partialUriFormatException, actualMessage);
+        Assertions.assertTrue(actualMessage.startsWith(partialUriFormatException));
     }
 
     @Test
     void testParsePartialFastenUriFailedMethodReturnT() {
         var partialUri = "/junit.awtui/AboutDialog.<init>(/java.awt/Frame)"; // missing return type.
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            FastenUriUtils.parsePartialFastenUri(partialUri);
-        });
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> FastenUriUtils.parsePartialFastenUri(partialUri));
 
         String actualMessage = exception.getMessage();
-        assertEquals(partialUriFormatException, actualMessage);
+        Assertions.assertTrue(actualMessage.startsWith(partialUriFormatException));
     }
 
     @Test
     void testParsePartialFastenUriFailedMissingNamespace() {
         var partialUri = "/AboutDialog.<init>(/java.awt/Frame)"; // missing namespace.
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            FastenUriUtils.parsePartialFastenUri(partialUri);
-        });
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> FastenUriUtils.parsePartialFastenUri(partialUri));
 
         String actualMessage = exception.getMessage();
-        assertEquals(partialUriFormatException, actualMessage);
+        Assertions.assertTrue(actualMessage.startsWith(partialUriFormatException));
     }
 
     @Test


### PR DESCRIPTION
Closes #280 

## Description
Implements character escaping in making up pattern matching.

## Motivation and context
Since some recent changes the method FastenUriUtils.parsePartialFastenUri throws unexpected errors on some valid partial URIs

## Testing
Test partial URIs with characters that require escaping in method arguments pattern matching.

## Task list  
- [x] Pattern quoting for method args
- [x] Pattern quoting for return type
- [x] Tests
