### PR TITLE
Added environment variable for the FASTEN API URL

### DIFF
--- a/analyzer/vulnerability-consumer/README.md
+++ b/analyzer/vulnerability-consumer/README.md
@@ -26,6 +26,8 @@ The FASTEN Vulnerability Consumer is used for inserting Vulnerability Informatio
 FASTEN_DBPASS=pass -d jdbc:postgresql:postgres -u postgres
 ```
 
+The Vulnerability Consumer will request the FASTEN server to ingest missing package-versions at the API specified by the environment variable `FASTEN_API_URL`. If undefined, the default `https://api.fasten.eu/api/` is used.
+
 ## Join the community
 
 The FASTEN software package management efficiency relies on an open community contributing to open technologies. Related research projects, R&D engineers, early users and open source contributors are welcome to join the [FASTEN community](https://www.fasten-project.eu/view/Main/Community), to try the tools, to participate in physical and remote worshops and to share our efforts using the project [community page](https://www.fasten-project.eu/view/Main/Community) and the social media buttons below.  

--- a/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
+++ b/analyzer/vulnerability-consumer/src/main/java/eu/fasten/analyzer/vulnerabilityconsumer/db/MetadataUtility.java
@@ -37,6 +37,8 @@ import java.util.*;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
+import static eu.fasten.core.data.Constants.fastenApiUrlDefault;
+import static eu.fasten.core.data.Constants.fastenApiUrlEnvVariable;
 import static eu.fasten.core.utils.FastenUriUtils.generateFullFastenUri;
 
 
@@ -446,7 +448,11 @@ public class MetadataUtility {
      */
     public void sendIngestRequest(String pkgCoord) {
         try {
-            var url = new URL("https://api.fasten.eu/api/" + pkgCoord);
+            var apiUrl = System.getenv(fastenApiUrlEnvVariable);
+            if(Objects.isNull(apiUrl)) {
+                apiUrl = fastenApiUrlDefault;
+            }
+            var url = new URL(apiUrl + pkgCoord);
             var con = (HttpURLConnection) url.openConnection();
             con.setRequestMethod("GET");
             int status = con.getResponseCode();

--- a/core/src/main/java/eu/fasten/core/data/Constants.java
+++ b/core/src/main/java/eu/fasten/core/data/Constants.java
@@ -26,4 +26,7 @@ public class Constants {
 
     public static final int MIN_COMPRESSED_GRAPH_SIZE = 100;
 
+    public static final String fastenApiUrlEnvVariable = "FASTEN_API_URL";
+
+    public static final String fastenApiUrlDefault = "https://api.fasten.eu/api/";
 }


### PR DESCRIPTION
Added environment variable for the FASTEN API URL and made the Vulnerability Consumer use it.

## Description
Added a FASTEN_API_URL environment variable and a default to the core constants.

With this change the Vulnerability Consumer can be configured with a environment variable FASTEN_API_URL to send its ingest requests to.

## Motivation and context
The central FASTEN KB was hard-coded to be the target of ingest requests; this is undesirable.
