### PR TITLE
Use fasten.POMAnalyzer.out as default topic name

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/OPALPlugin.java
@@ -50,7 +50,7 @@ public class OPALPlugin extends Plugin {
 
         private final Logger logger = LoggerFactory.getLogger(getClass());
 
-        private String consumeTopic = "fasten.maven.pkg";
+        private String consumeTopic = "fasten.POMAnalyzer.out";
         private Exception pluginError;
         private ExtendedRevisionJavaCallGraph graph;
         private String outputPath;

--- a/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/OPALPluginTest.java
+++ b/analyzer/javacg-opal/src/test/java/eu/fasten/analyzer/javacgopal/OPALPluginTest.java
@@ -42,7 +42,7 @@ class OPALPluginTest {
     @Test
     public void testConsumerTopic() {
         assertTrue(plugin.consumeTopic().isPresent());
-        assertEquals("fasten.maven.pkg", plugin.consumeTopic().get().get(0));
+        assertEquals("fasten.POMAnalyzer.out", plugin.consumeTopic().get().get(0));
     }
 
     @Test

--- a/server/README.md
+++ b/server/README.md
@@ -20,7 +20,7 @@ The FASTEN-server is a component necessary for running [FASTEN-specific plugins]
 - `-h` `--help` Show this help message and exit;
 - `-k` `--kafka_server` Kafka server to connect to. Use multiple times for clusters;
     - `-ks` `--skip_offsets` Adds one to offset of all the partitions of the consumers;
-    - `-kt` `--topic` Kay-value pairs of Plugin and topic to consume from. Example: `OPAL=fasten.maven.pkg`;
+    - `-kt` `--topic` Kay-value pairs of Plugin and topic to consume from. Example: `OPAL=fasten.OPAL.out`;
 - `-la` `--list_all` List all values and extensions;
 - `-m` `--mode` Deployment or Development mode
 - `-p` `--plugin_dir` Directory to load plugins from.

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -86,7 +86,7 @@ public class FastenServer implements Runnable {
     @Option(names = {"-kt", "--topic"},
             paramLabel = "topic",
             description = "Kay-value pairs of Plugin and topic to consume from. Example - "
-                    + "OPAL=fasten.maven.pkg",
+                    + "OPAL=fasten.OPAL.out",
             split = ",")
     Map<String, String> pluginTopic;
 


### PR DESCRIPTION
## Description

Default topic to consume from in the OPAL plugin has been changed from `fasten.mvn.pkg` to `fasten.POMAnalyzer.out`.

## Motivation and context

OPAL plugin consumes from POM analyzer topic. Default name of POM analyzer topic is `fasten.POMAnalyzer.out`.
This modification allow to have a default value aligned with value used in Kubernetes or Docker compose deployment descriptors.

## Testing
No specific test has been done.
