### PR TITLE
Update default consumer topic for quality-analyser

### DIFF
--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/QualityAnalyzerPlugin.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/QualityAnalyzerPlugin.java
@@ -48,7 +48,7 @@ public class QualityAnalyzerPlugin extends Plugin {
     public static class QualityAnalyzer implements KafkaPlugin, DBConnector {
 
         private final Logger logger = LoggerFactory.getLogger(QualityAnalyzer.class.getName());
-        private String consumerTopic = "fasten.RapidPlugin.out";
+        private String consumerTopic = "fasten.RapidPlugin.callable.out";
         private static MetadataUtils utils = null;
         private Exception pluginError = null;
 


### PR DESCRIPTION
Set default quality-analyser consumer topic to `fasten.RapidPlugin.callable.out` in order to use the same value as k8s and Docker Compose deployments.