### PR TITLE
Added `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,198 @@
+**/.bettercodehub.yml
+**/checkstyle.xml
+**/LICENSE
+**/.gitignore
+**/*.md
+
+### Java ###
+
+# Compiled class file
+**/*.class
+
+# Log file
+**/*.log
+
+# BlueJ files
+**/*.ctxt
+
+# Mobile Tools for Java (J2ME)
+**/.mtj.tmp/
+
+# Package Files #
+**/*.jar
+**/*.war
+**/*.nar
+**/*.ear
+**/*.zip
+**/*.tar.gz
+**/*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+**/hs_err_pid*
+
+### Maven ###
+**/target/
+**/pom.xml.tag
+**/pom.xml.releaseBackup
+**/pom.xml.versionsBackup
+**/pom.xml.next
+**/release.properties
+**/dependency-reduced-pom.xml
+**/buildNumber.properties
+**/.mvn/timing.properties
+**/.mvn/wrapper/maven-wrapper.jar
+**/.classpath
+**/.project
+**/.settings
+**/.checkstyle
+
+### Vim ###
+# Swap
+**/[._]*.s[a-v][a-z]
+**/[._]*.sw[a-p]
+**/[._]s[a-rt-v][a-z]
+**/[._]ss[a-gi-z]
+**/[._]sw[a-p]
+
+# Session
+**/Session.vim
+
+# Temporary
+**/.netrwhist
+**/*~
+# Auto-generated tag files
+**/tags
+# Persistent undo
+**/[._]*.un~
+
+### macOS ###
+# General
+**/.DS_Store
+**/.AppleDouble
+**/.LSOverride
+
+# Icon must end with two \r
+**/Icon
+
+# Thumbnails
+**/._*
+
+# Files that might appear in the root of a volume
+**/.DocumentRevisions-V100
+**/.fseventsd
+**/.Spotlight-V100
+**/.TemporaryItems
+**/.Trashes
+**/.VolumeIcon.icns
+**/.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+**/.AppleDB
+**/.AppleDesktop
+**/Network Trash Folder
+**/Temporary Items
+**/.apdisk
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+**/.idea/**/workspace.xml
+**/.idea/**/tasks.xml
+**/.idea/**/usage.statistics.xml
+**/.idea/**/dictionaries
+**/.idea/**/shelf
+
+# Generated files
+**/.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+**/.idea/**/dataSources/
+**/.idea/**/dataSources.ids
+**/.idea/**/dataSources.local.xml
+**/.idea/**/sqlDataSources.xml
+**/.idea/**/dynamic.xml
+**/.idea/**/uiDesigner.xml
+**/.idea/**/dbnavigator.xml
+
+# Gradle
+**/.idea/**/gradle.xml
+**/.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+**/cmake-build-*/
+
+# Mongo Explorer plugin
+**/.idea/**/mongoSettings.xml
+
+# File-based project format
+**/*.iws
+
+# IntelliJ
+**/out/
+**/.idea/
+
+# mpeltonen/sbt-idea plugin
+**/.idea_modules/
+
+# JIRA plugin
+**/atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+**/.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+**/com_crashlytics_export_strings.xml
+**/crashlytics.properties
+**/crashlytics-build.properties
+**/fabric.properties
+
+# Editor-based Rest Client
+**/.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+**/.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+**/.idea/sonarlint
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+**/.idea/*
+**/.idea/modules.xml
+**/.idea/*.iml
+**/.idea/modules
+**/*.iml
+**/*.ipr
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+**/modules.xml
+**/.idea/misc.xml
+
+# End of https://www.gitignore.io/api/intellij
+
+!/analyzer/javacg-wala/src/test/resources/*.jar
+!/analyzer/javacg-opal/lib/**/*.jar
+!/analyzer/javacg-opal/src/test/resources/*.class
+/analyzer/license-detector/**/tmp-*.xml


### PR DESCRIPTION
## How was it generated

```shell script
# Adding new files manually
cat <<EOT >> .dockerignore
**/.bettercodehub.yml
**/checkstyle.xml
**/LICENSE
**/.gitignore
**/*.md

EOT

# This `.dockerignore` is a superset of `.gitignore`.
# Here I'm prepending `**/` to all the rows that do NOT begin with:
# - `#` (comments)
# - `/` (absolute paths, there used to be some in older commits)
# - `!` (inclusions)
# - `\n` (new lines, i.e., empty rows)
perl -p -e 's-^(?![#/!\n])-**/-g' .gitignore >> .dockerignore
```

## Why

Container optimization.

## To-do's

- Test this on all images
  - [x] [`license-detector`](https://github.com/fasten-project/fasten/tree/endocode/compliancePlugin/analyzer/license-detector)
  - [x] [`license-feeder`](https://github.com/fasten-project/fasten/tree/endocode/compliancePlugin/analyzer/license-feeder)
  - [ ] Others