### PR TITLE
License detection for C & Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ buildNumber.properties
 .project
 .settings
 .checkstyle
+.factorypath
 
 ### Vim ###
 # Swap

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/AbstractLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/AbstractLicenseDetector.java
@@ -1,0 +1,168 @@
+package eu.fasten.analyzer.licensedetector;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.fasten.analyzer.licensedetector.exceptions.LicenseDetectorException;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicense;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenseSource;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
+import eu.fasten.analyzer.licensedetector.utils.Scancode;
+
+public abstract class AbstractLicenseDetector implements ILicenseDetector {
+	
+    private final Logger logger = LoggerFactory.getLogger(AbstractLicenseDetector.class.getName());
+
+	@Override
+	public abstract DetectedLicenses detect(String repoPath, String repoUrl) throws LicenseDetectorException;
+	
+	
+	protected JSONArray detectFileLicenses(String repoPath) throws LicenseDetectorException {
+		try {
+			String resultPath = Scancode.scanProject(repoPath);
+			JSONArray files = Scancode.parseScanResult(resultPath);
+			return files;
+		} catch (IOException | InterruptedException | RuntimeException e) {
+			e.printStackTrace();
+			throw new LicenseDetectorException(e);
+		}
+	}
+
+	protected Set<DetectedLicense> detectOutboundLicenses(String repoPath, List<String> licenseFileNames, JSONArray files) {
+		for( String licenseFile : licenseFileNames) {
+			Set<DetectedLicense> outbound =  getOutboundLicenses(repoPath, licenseFile, files);
+			if(outbound != null && !outbound.isEmpty())
+				return outbound;
+		}
+		return null;
+	}
+	
+	// FIXME: DetectedLicenseSource.LOCAL_POM
+	protected Set<DetectedLicense> getOutboundLicenses(String repoPath, String licenseFileName, JSONArray files) {
+		String outFile = Paths.get(repoPath, licenseFileName).toString();
+		var it = files.iterator();
+		while(it.hasNext()) {
+			JSONObject f = (JSONObject)it.next();
+			if(outFile.equalsIgnoreCase(f.getString("path"))) {
+				JSONArray licenses = f.getJSONArray("licenses");
+				Set<DetectedLicense> result = licenses.toList().stream().map( l -> {
+					@SuppressWarnings("unchecked")
+					Map<String,Object> o = (Map<String,Object>)l;
+					return new DetectedLicense(o.get("spdx_license_key").toString(), DetectedLicenseSource.LOCAL_POM);
+				}).collect(Collectors.toSet());
+				return result;
+			}
+		}
+		return null;
+	}		
+	
+	
+    protected Set<DetectedLicense> detectOutboundLicensesFromGitHub(String repoUrl) {
+		try {
+			DetectedLicense outboundLicense = getLicenseFromGitHub(repoUrl);
+			Set<DetectedLicense> outbound = new HashSet<DetectedLicense>();
+			outbound.add(outboundLicense);
+			return outbound;
+		} catch (IllegalArgumentException | IOException e) {
+			e.printStackTrace();
+		}
+		return null;
+    }
+	
+    /**
+     * Retrieves the outbound license of a GitHub project using its API.
+     *
+     * @param repoUrl the repository URL whose license is of interest.
+     * @return the outbound license retrieved from GitHub's API.
+     * @throws IllegalArgumentException in case the repository is not hosted on GitHub.
+     * @throws IOException              in case there was a problem contacting the GitHub API.
+     */
+    protected DetectedLicense getLicenseFromGitHub(String repoUrl)
+            throws IllegalArgumentException, IOException {
+
+        // Adding "https://" in case it's missing
+        if (!Pattern.compile(Pattern.quote("http"), Pattern.CASE_INSENSITIVE).matcher(repoUrl).find()) {
+            repoUrl = "https://" + repoUrl;
+        }
+
+        // Checking whether the repo URL is a valid URL or not
+        URL parsedRepoUrl;
+        try {
+            parsedRepoUrl = new URL(repoUrl);
+        } catch (MalformedURLException e) {
+            throw new MalformedURLException("Repo URL " + repoUrl + " is not a valid URL: " + e.getMessage());
+        }
+
+        // Checking whether the repo is hosted on GitHub
+        if (!Pattern.compile(Pattern.quote("github"), Pattern.CASE_INSENSITIVE).matcher(repoUrl).find()) {
+            throw new IllegalArgumentException("Repo URL " + repoUrl + " is not hosted on GitHub.");
+        }
+
+        // Parsing the GitHub repo URL
+        String path = parsedRepoUrl.getPath();
+        String[] splitPath = path.split("/");
+        if (splitPath.length < 3) { // should be: ["/", "owner", "repo"]
+            throw new MalformedURLException(
+                    "Repo URL " + repoUrl + " has no valid path: " + Arrays.toString(splitPath));
+        }
+        String owner = splitPath[1];
+        String repo = splitPath[2].replaceAll(".git", "");
+        logger.info("Retrieving outbound license from GitHub. Owner: " + owner + ", repo: " + repo + ".");
+
+        // Result
+        DetectedLicense repoLicense;
+
+        // Querying the GitHub API
+        try {
+
+            // Format: "https://api.github.com/repos/`owner`/`repo`/license"
+            URL url = new URL("https://api.github.com/repos/" + owner + "/" + repo + "/license");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Accept", "application/json");
+            if (conn.getResponseCode() != 200) {
+                throw new RuntimeException("HTTP query failed. Error code: " + conn.getResponseCode());
+            }
+            InputStreamReader in = new InputStreamReader(conn.getInputStream());
+            BufferedReader br = new BufferedReader(in);
+            String jsonOutput = br.lines().collect(Collectors.joining());
+
+            // Retrieving the license SDPX ID
+            var jsonOutputPayload = new JSONObject(jsonOutput);
+            if (jsonOutputPayload.has("license")) {
+                jsonOutputPayload = jsonOutputPayload.getJSONObject("license");
+            }
+            repoLicense = new DetectedLicense(jsonOutputPayload.getString("spdx_id"), DetectedLicenseSource.GITHUB);
+
+            conn.disconnect();
+        } catch (ProtocolException e) {
+            throw new ProtocolException(
+                    "Couldn't set the GET method while retrieving an outbound license from GitHub: " +
+                            e.getMessage());
+        } catch (IOException e) {
+            throw new IOException(
+                    "Couldn't get data from the HTTP response returned by GitHub's API: " + e.getMessage(),
+                    e.getCause());
+        }
+
+        return repoLicense;
+    }
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/AbstractLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/AbstractLicenseDetector.java
@@ -41,7 +41,7 @@ public abstract class AbstractLicenseDetector implements ILicenseDetector {
 			JSONArray files = Scancode.parseScanResult(resultPath);
 			return files;
 		} catch (IOException | InterruptedException | RuntimeException e) {
-			e.printStackTrace();
+			logger.error("Error executing Scancode", e);
 			throw new LicenseDetectorException(e);
 		}
 	}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/CLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/CLicenseDetector.java
@@ -13,7 +13,6 @@ import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
 
 public class CLicenseDetector extends AbstractLicenseDetector {
 
-	// TODO: verify the list
 	private static final List<String> LICENSE_FILES = Arrays.asList("LICENSE", "LICENSE.md", "LICENSE.txt", "Readme.md",
 			"Readme.txt");
 	

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/CLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/CLicenseDetector.java
@@ -25,7 +25,7 @@ public class CLicenseDetector extends AbstractLicenseDetector {
 		
 		Set<DetectedLicense> outbound = detectOutboundLicenses(repoPath, LICENSE_FILES, files);
 
-		// TDOO: check if is necessary for C projects
+		// TODO: check if is necessary for C projects
 		if ((outbound == null || outbound.isEmpty()) && StringUtils.isNotBlank(repoUrl)) {
 			outbound = detectOutboundLicensesFromGitHub(repoUrl);
 		}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/CLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/CLicenseDetector.java
@@ -1,0 +1,39 @@
+package eu.fasten.analyzer.licensedetector;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+
+import eu.fasten.analyzer.licensedetector.exceptions.LicenseDetectorException;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicense;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
+
+public class CLicenseDetector extends AbstractLicenseDetector {
+
+	// TODO: verify the list
+	private static final List<String> LICENSE_FILES = Arrays.asList("LICENSE", "LICENSE.md", "LICENSE.txt", "Readme.md",
+			"Readme.txt");
+	
+	@Override
+	public DetectedLicenses detect(String repoPath, String repoUrl) throws LicenseDetectorException {
+		DetectedLicenses result = new DetectedLicenses();
+		
+		JSONArray files = detectFileLicenses(repoPath);
+		result.setFiles(files);
+		
+		Set<DetectedLicense> outbound = detectOutboundLicenses(repoPath, LICENSE_FILES, files);
+
+		// TDOO: check if is necessary for C projects
+		if ((outbound == null || outbound.isEmpty()) && StringUtils.isNotBlank(repoUrl)) {
+			outbound = detectOutboundLicensesFromGitHub(repoUrl);
+		}
+		
+		result.setOutbound(outbound);
+		
+		return result;
+	}
+
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/ILicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/ILicenseDetector.java
@@ -1,0 +1,12 @@
+package eu.fasten.analyzer.licensedetector;
+
+import javax.annotation.Nullable;
+
+import eu.fasten.analyzer.licensedetector.exceptions.LicenseDetectorException;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
+
+public interface ILicenseDetector {
+
+	DetectedLicenses detect(String repoPath, @Nullable String repoUrl) throws LicenseDetectorException;
+
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/JavaMavenLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/JavaMavenLicenseDetector.java
@@ -1,0 +1,16 @@
+package eu.fasten.analyzer.licensedetector;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+import eu.fasten.analyzer.licensedetector.exceptions.LicenseDetectorException;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
+
+//TODO: to be implemented
+public class JavaMavenLicenseDetector extends AbstractLicenseDetector {
+	
+	@Override
+	public DetectedLicenses detect(String repoPath, String repoUrl) throws LicenseDetectorException {
+		throw new LicenseDetectorException(new NotImplementedException());
+	}
+
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/JavaMavenLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/JavaMavenLicenseDetector.java
@@ -1,16 +1,187 @@
 package eu.fasten.analyzer.licensedetector;
 
-import org.apache.commons.lang3.NotImplementedException;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
+import javax.annotation.Nullable;
+
+import org.apache.maven.model.License;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.json.JSONArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
+
+import eu.fasten.analyzer.licensedetector.LicenseDetectorPlugin.LicenseDetector;
 import eu.fasten.analyzer.licensedetector.exceptions.LicenseDetectorException;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicense;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenseSource;
 import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
 
-//TODO: to be implemented
 public class JavaMavenLicenseDetector extends AbstractLicenseDetector {
+	
+    private final Logger logger = LoggerFactory.getLogger(LicenseDetector.class.getName());
+    
+	// TODO: verify if this approach is valid also for java
+	// private static final List<String> LICENSE_FILES = Arrays.asList("pom.xml");
 	
 	@Override
 	public DetectedLicenses detect(String repoPath, String repoUrl) throws LicenseDetectorException {
-		throw new LicenseDetectorException(new NotImplementedException());
+		DetectedLicenses result = new DetectedLicenses();
+		
+		JSONArray files = detectFileLicenses(repoPath);
+		result.setFiles(files);
+		
+		// Set<DetectedLicense> outbound = detectOutboundLicenses(repoPath, LICENSE_FILES, files);
+
+		Set<DetectedLicense> outbound = getOutboundLicenses(result, repoPath, repoUrl);
+		result.setOutbound(outbound);
+		
+		return result;
 	}
+
+	 /**
+     * Retrieves the outbound license(s) of the input project.
+     *
+     * @param repoPath the repository path whose outbound license(s) is(are) of interest.
+     * @param repoUrl  the input repository URL. Might be `null`.
+     * @return the set of detected outbound licenses.
+     */
+		protected Set<DetectedLicense> getOutboundLicenses(DetectedLicenses detectedLicenses, String repoPath,
+				@Nullable String repoUrl) {
+
+        try {
+
+            // Retrieving the `pom.xml` file
+            File pomFile = retrievePomFile(repoPath);
+
+            // Retrieving the outbound license(s) from the `pom.xml` file
+            return getLicensesFromPomFile(pomFile);
+
+        } catch (FileNotFoundException | RuntimeException | XmlPullParserException e) {
+
+            // In case retrieving the outbound license from the local `pom.xml` file was not possible
+            logger.warn(e.getMessage(), e.getCause()); // why wasn't it possible
+            logger.info("Retrieving outbound license from GitHub...");
+            if ((detectedLicenses.getOutbound() == null || detectedLicenses.getOutbound().isEmpty())
+                    && repoUrl != null) {
+
+                // Retrieving licenses from the GitHub API
+                try {
+                    DetectedLicense licenseFromGitHub = getLicenseFromGitHub(repoUrl);
+                    if (licenseFromGitHub != null) {
+                        return Sets.newHashSet(licenseFromGitHub);
+                    } else {
+                        logger.warn("Couldn't retrieve the outbound license from GitHub.");
+                    }
+                } catch (IllegalArgumentException | IOException ex) { // not a valid GitHub repo URL
+                    logger.warn(e.getMessage(), e.getCause());
+                } catch (RuntimeException ex) {
+                    logger.warn(e.getMessage(), e.getCause()); // could not contact GitHub API
+                }
+            }
+        }
+
+        return Collections.emptySet();
+    }
+
+    /**
+     * Retrieves all licenses declared in a `pom.xml` file.
+     *
+     * @param pomFile the `pom.xml` file to be analyzed.
+     * @return the detected licenses.
+     * @throws XmlPullParserException in case the `pom.xml` file couldn't be parsed as an XML file.
+     */
+    protected Set<DetectedLicense> getLicensesFromPomFile(File pomFile) throws XmlPullParserException {
+
+        // Result
+        List<License> licenses;
+
+        // Maven `pom.xml` file parser
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try (FileReader fileReader = new FileReader(pomFile)) {
+
+            // Parsing and retrieving the `licenses` XML tag
+            Model model = reader.read(fileReader);
+            licenses = model.getLicenses();
+
+            // If the pom file contains at least a license tag
+            if (!licenses.isEmpty()) {
+
+                // Logging
+                logger.trace("Found " + licenses.size() + " outbound license" + (licenses.size() == 1 ? "" : "s") +
+                        " in " + pomFile.getAbsolutePath() + ":");
+                for (int i = 0; i < licenses.size(); i++) {
+                    logger.trace("License number " + i + ": " + licenses.get(i).getName());
+                }
+
+                // Returning the set of discovered licenses
+                Set<DetectedLicense> result = new HashSet<>(Collections.emptySet());
+                licenses.forEach(license -> result.add(new DetectedLicense(
+                        license.getName(),
+                        DetectedLicenseSource.LOCAL_POM)));
+
+                return result;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Pom file " + pomFile.getAbsolutePath() +
+                    " exists but couldn't instantiate a FileReader object..", e.getCause());
+        } catch (XmlPullParserException e) {
+            throw new XmlPullParserException("Pom file " + pomFile.getAbsolutePath() +
+                    " exists but couldn't be parsed as a Maven pom XML file: " + e.getMessage());
+        }
+
+        // No licenses were detected
+        return Collections.emptySet();
+    }
+
+    /**
+     * Retrieves the pom.xml file given a repository path.
+     *
+     * @param repoPath the repository path whose pom.xml file must be retrieved.
+     * @return the pom.xml file of the repository.
+     * @throws FileNotFoundException in case no pom.xml file could be found in the repository.
+     */
+    protected File retrievePomFile(String repoPath) throws FileNotFoundException {
+
+        // Result
+        Optional<File> pomFile = Optional.empty();
+
+        // Repository folder
+        File repoFolder = new File(repoPath);
+
+        // Retrieving all repository's pom files
+        File[] pomFiles = repoFolder.listFiles((dir, name) -> name.equalsIgnoreCase("pom.xml"));
+        if (pomFiles == null) {
+            throw new RuntimeException("Path " + repoPath + " does not denote a directory.");
+        }
+        logger.trace("Found " + pomFiles.length + " pom.xml file" +
+                ((pomFiles.length == 1) ? "" : "s") + ": " + Arrays.toString(pomFiles));
+        if (pomFiles.length == 1) {
+            pomFile = Optional.ofNullable(pomFiles[0]);
+        } else if (pomFiles.length > 1) {
+            // Retrieving the pom.xml file having the shortest path (closest to it repository's root path)
+            pomFile = Arrays.stream(pomFiles).min(Comparator.comparingInt(f -> f.getAbsolutePath().length()));
+            logger.info("Multiple pom.xml files found. Using " + pomFile.get());
+        }
+
+        if (pomFile.isEmpty()) {
+            throw new FileNotFoundException("No file named pom.xml found in " + repoPath + ".");
+        }
+
+        return pomFile.get();
+    }
 
 }

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LanguageType.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LanguageType.java
@@ -1,0 +1,5 @@
+package eu.fasten.analyzer.licensedetector;
+
+public enum LanguageType {
+	JAVA, PYTHON, C
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LicenseDetectorFactory.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LicenseDetectorFactory.java
@@ -1,0 +1,18 @@
+package eu.fasten.analyzer.licensedetector;
+
+public class LicenseDetectorFactory {
+
+	public static ILicenseDetector create (LanguageType language) {
+    	switch (language) {
+		case JAVA:
+			return new JavaMavenLicenseDetector();
+		case PYTHON:
+			return new PythonLicenseDetector();
+		case C:
+			return new CLicenseDetector();
+		default:
+			throw new NullPointerException("LanguageType cannot be null");
+		}
+	}
+	
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LicenseDetectorPlugin.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LicenseDetectorPlugin.java
@@ -1,16 +1,10 @@
 package eu.fasten.analyzer.licensedetector;
 
-import com.google.common.collect.Sets;
-import eu.fasten.core.data.metadatadb.license.DetectedLicense;
-import eu.fasten.core.data.metadatadb.license.DetectedLicenseSource;
-import eu.fasten.core.data.metadatadb.license.DetectedLicenses;
-import eu.fasten.core.plugins.KafkaPlugin;
-import org.apache.maven.model.License;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.json.JSONArray;
-import org.json.JSONException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -18,17 +12,10 @@ import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import eu.fasten.analyzer.licensedetector.exceptions.LicenseDetectorException;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
+import eu.fasten.analyzer.licensedetector.utils.JSONUtils;
+import eu.fasten.core.plugins.KafkaPlugin;
 
 
 public class LicenseDetectorPlugin extends Plugin {
@@ -40,449 +27,95 @@ public class LicenseDetectorPlugin extends Plugin {
     @Extension
     public static class LicenseDetector implements KafkaPlugin {
 
-        private final Logger logger = LoggerFactory.getLogger(LicenseDetector.class.getName());
+        private static final String PLUGIN_VERSION = "0.1.0";
+        private static final DetectedLicenses EMPTY_DETECTED_LICENSES = new DetectedLicenses();
+
+		private final Logger logger = LoggerFactory.getLogger(LicenseDetector.class.getName());
 
         protected Exception pluginError = null;
 
-        /**
-         * The topic this plugin consumes.
-         */
-        protected String consumerTopic = "fasten.SyncJava.out";
+        protected DetectedLicenses detectedLicenses;
+        
+        protected List<String> consumeTopics;
+        
+        protected JSONObject payload;
+        
+        protected String javaRepoPathKey;
+        protected String javaRepoUrlKey;
+        protected String pythonRepoPathKey;
+        protected String pythonRepoUrlKey;
+        protected String cRepoPathKey;
+        protected String cRepoUrlKey;
+        protected String pathReplace;
 
-        /**
-         * TODO
-         */
-        protected DetectedLicenses detectedLicenses = new DetectedLicenses();
-
-        @Override
-        public Optional<List<String>> consumeTopic() {
-            return Optional.of(Collections.singletonList(consumerTopic));
+        public LicenseDetector() {
+        	this.javaRepoPathKey = defaultEnv("JAVA_REPO_PATH_KEY", "fasten.RepoCloner.out/payload/repoPath");
+        	this.javaRepoUrlKey = defaultEnv("JAVA_REPO_URL_KEY", "fasten.RepoCloner.out/payload/repoUrl");
+        	this.pythonRepoPathKey = defaultEnv("PYTHON_REPO_PATH_KEY", "fasten.PyCG.out/payload/sourcePath");
+        	this.pythonRepoUrlKey = defaultEnv("PYTHON_REPO_URL_KEY", "fasten.PyCG.out/payload/repoUrl");
+        	this.cRepoPathKey = defaultEnv("C_REPO_PATH_KEY", "fasten.cscout.out/payload/sourcePath");
+        	this.pathReplace = StringUtils.removeEnd(defaultEnv("FASTEN_MNT_REPLACE", ""), "/");
+		}
+        
+        private String defaultEnv(String name, String def) {
+        	String v = System.getenv(name);
+        	return v == null ? def : v;
         }
 
+		@Override
+        public Optional<List<String>> consumeTopic() {
+            return Optional.of(consumeTopics);
+        }
+        
         @Override
         public void setTopic(String topicName) {
-            this.consumerTopic = topicName;
+        	this.consumeTopics = Arrays.asList(topicName.trim().split("\\s*;\\s*"));
         }
-
-        /**
-         * Resets the internal state of this plugin.
-         */
-        protected void reset() {
-            pluginError = null;
-            detectedLicenses = new DetectedLicenses();
-        }
+       
 
         @Override
         public void consume(String record) {
-            try { // Fasten error-handling guidelines
-
-                reset();
-
-                logger.info("License detector started.");
-
+            try {
+                pluginError = null;
+                detectedLicenses = null;
+                payload = new JSONObject(record);
+            	LanguageType lang = detectLanguage();
+            	ILicenseDetector licenseDetector = LicenseDetectorFactory.create(lang);
+            	RepoCoords repoCoords = extractRepoCoords(lang);
                 // TODO Checking whether the repository has already been scanned (by querying the KB)
-
-                // Retrieving the repository path on the shared volume
-                String repoPath = extractRepoPath(record);
-
-                // Retrieving the repo URL
-                String repoUrl = extractRepoURL(record);
-
-                // Outbound license detection
-                detectedLicenses.setOutbound(getOutboundLicenses(repoPath, repoUrl));
-                if (detectedLicenses.getOutbound() == null || detectedLicenses.getOutbound().isEmpty()) {
-                    logger.warn("No outbound licenses were detected.");
-                } else {
-                    logger.info(
-                            detectedLicenses.getOutbound().size() + " outbound license" +
-                                    (detectedLicenses.getOutbound().size() == 1 ? "" : "s") + " detected: " +
-                                    detectedLicenses.getOutbound()
-                    );
-                }
-
-                // Detecting inbound licenses by scanning the project
-                String scanResultPath = scanProject(repoPath);
-
-                // Parsing the result
-                JSONArray fileLicenses = parseScanResult(scanResultPath);
-                if (fileLicenses != null && !fileLicenses.isEmpty()) {
-                    detectedLicenses.addFiles(fileLicenses);
-                } else {
-                    logger.warn("Scanner hasn't detected any licenses in " + scanResultPath + ".");
-                }
-
+            	detectedLicenses = licenseDetector.detect(repoCoords.path, repoCoords.url);
             } catch (Exception e) { // Fasten error-handling guidelines
                 logger.error(e.getMessage(), e.getCause());
                 setPluginError(e);
             }
         }
-
-        /**
-         * Retrieves the outbound license(s) of the input project.
-         *
-         * @param repoPath the repository path whose outbound license(s) is(are) of interest.
-         * @param repoUrl  the input repository URL. Might be `null`.
-         * @return the set of detected outbound licenses.
-         */
-        protected Set<DetectedLicense> getOutboundLicenses(String repoPath, @Nullable String repoUrl) {
-
-            try {
-
-                // Retrieving the `pom.xml` file
-                File pomFile = retrievePomFile(repoPath);
-
-                // Retrieving the outbound license(s) from the `pom.xml` file
-                return getLicensesFromPomFile(pomFile);
-
-            } catch (FileNotFoundException | RuntimeException | XmlPullParserException e) {
-
-                // In case retrieving the outbound license from the local `pom.xml` file was not possible
-                logger.warn(e.getMessage(), e.getCause()); // why wasn't it possible
-                logger.info("Retrieving outbound license from GitHub...");
-                if ((detectedLicenses.getOutbound() == null || detectedLicenses.getOutbound().isEmpty())
-                        && repoUrl != null) {
-
-                    // Retrieving licenses from the GitHub API
-                    try {
-                        DetectedLicense licenseFromGitHub = getLicenseFromGitHub(repoUrl);
-                        if (licenseFromGitHub != null) {
-                            return Sets.newHashSet(licenseFromGitHub);
-                        } else {
-                            logger.warn("Couldn't retrieve the outbound license from GitHub.");
-                        }
-                    } catch (IllegalArgumentException | IOException ex) { // not a valid GitHub repo URL
-                        logger.warn(e.getMessage(), e.getCause());
-                    } catch (@SuppressWarnings({"TryWithIdenticalCatches", "RedundantSuppression"})
-                            RuntimeException ex) {
-                        logger.warn(e.getMessage(), e.getCause()); // could not contact GitHub API
-                    }
-                }
-            }
-
-            return Collections.emptySet();
+        
+        private LanguageType detectLanguage() {
+        	String pluginName = payload.optString("plugin_name");
+        	if (payload.has("fasten.cscout.out") || "CScoutKafkaPlugin".equals(pluginName))
+        		return LanguageType.C;
+        	if (payload.has("fasten.PyCG.out") || "PyCG".equals(pluginName))
+        		return LanguageType.PYTHON;
+        	if (payload.has("fasten.RepoCloner.out") ||  "RepoCloner".equals(pluginName))
+				return LanguageType.JAVA;
+			throw new LicenseDetectorException("Unable to detect language from the received record");
+        	
         }
-
-        /**
-         * Retrieves all licenses declared in a `pom.xml` file.
-         *
-         * @param pomFile the `pom.xml` file to be analyzed.
-         * @return the detected licenses.
-         * @throws XmlPullParserException in case the `pom.xml` file couldn't be parsed as an XML file.
-         */
-        protected Set<DetectedLicense> getLicensesFromPomFile(File pomFile) throws XmlPullParserException {
-
-            // Result
-            List<License> licenses;
-
-            // Maven `pom.xml` file parser
-            MavenXpp3Reader reader = new MavenXpp3Reader();
-            try (FileReader fileReader = new FileReader(pomFile)) {
-
-                // Parsing and retrieving the `licenses` XML tag
-                Model model = reader.read(fileReader);
-                licenses = model.getLicenses();
-
-                // If the pom file contains at least a license tag
-                if (!licenses.isEmpty()) {
-
-                    // Logging
-                    logger.trace("Found " + licenses.size() + " outbound license" + (licenses.size() == 1 ? "" : "s") +
-                            " in " + pomFile.getAbsolutePath() + ":");
-                    for (int i = 0; i < licenses.size(); i++) {
-                        logger.trace("License number " + i + ": " + licenses.get(i).getName());
-                    }
-
-                    // Returning the set of discovered licenses
-                    Set<DetectedLicense> result = new HashSet<>(Collections.emptySet());
-                    licenses.forEach(license -> result.add(new DetectedLicense(
-                            license.getName(),
-                            DetectedLicenseSource.LOCAL_POM)));
-
-                    return result;
-                }
-            } catch (IOException e) {
-                throw new RuntimeException("Pom file " + pomFile.getAbsolutePath() +
-                        " exists but couldn't instantiate a FileReader object..", e.getCause());
-            } catch (XmlPullParserException e) {
-                throw new XmlPullParserException("Pom file " + pomFile.getAbsolutePath() +
-                        " exists but couldn't be parsed as a Maven pom XML file: " + e.getMessage());
-            }
-
-            // No licenses were detected
-            return Collections.emptySet();
-        }
-
-        /**
-         * Retrieves the outbound license of a GitHub project using its API.
-         *
-         * @param repoUrl the repository URL whose license is of interest.
-         * @return the outbound license retrieved from GitHub's API.
-         * @throws IllegalArgumentException in case the repository is not hosted on GitHub.
-         * @throws IOException              in case there was a problem contacting the GitHub API.
-         */
-        protected DetectedLicense getLicenseFromGitHub(String repoUrl)
-                throws IllegalArgumentException, IOException {
-
-            // Adding "https://" in case it's missing
-            if (!Pattern.compile(Pattern.quote("http"), Pattern.CASE_INSENSITIVE).matcher(repoUrl).find()) {
-                repoUrl = "https://" + repoUrl;
-            }
-
-            // Checking whether the repo URL is a valid URL or not
-            URL parsedRepoUrl;
-            try {
-                parsedRepoUrl = new URL(repoUrl);
-            } catch (MalformedURLException e) {
-                throw new MalformedURLException("Repo URL " + repoUrl + " is not a valid URL: " + e.getMessage());
-            }
-
-            // Checking whether the repo is hosted on GitHub
-            if (!Pattern.compile(Pattern.quote("github"), Pattern.CASE_INSENSITIVE).matcher(repoUrl).find()) {
-                throw new IllegalArgumentException("Repo URL " + repoUrl + " is not hosted on GitHub.");
-            }
-
-            // Parsing the GitHub repo URL
-            String path = parsedRepoUrl.getPath();
-            String[] splitPath = path.split("/");
-            if (splitPath.length < 3) { // should be: ["/", "owner", "repo"]
-                throw new MalformedURLException(
-                        "Repo URL " + repoUrl + " has no valid path: " + Arrays.toString(splitPath));
-            }
-            String owner = splitPath[1];
-            String repo = splitPath[2].replaceAll(".git", "");
-            logger.info("Retrieving outbound license from GitHub. Owner: " + owner + ", repo: " + repo + ".");
-
-            // Result
-            DetectedLicense repoLicense;
-
-            // Querying the GitHub API
-            try {
-
-                // Format: "https://api.github.com/repos/`owner`/`repo`/license"
-                URL url = new URL("https://api.github.com/repos/" + owner + "/" + repo + "/license");
-                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-                conn.setRequestMethod("GET");
-                conn.setRequestProperty("Accept", "application/json");
-                if (conn.getResponseCode() != 200) {
-                    throw new RuntimeException("HTTP query failed. Error code: " + conn.getResponseCode());
-                }
-                InputStreamReader in = new InputStreamReader(conn.getInputStream());
-                BufferedReader br = new BufferedReader(in);
-                String jsonOutput = br.lines().collect(Collectors.joining());
-
-                // Retrieving the license SDPX ID
-                var jsonOutputPayload = new JSONObject(jsonOutput);
-                if (jsonOutputPayload.has("license")) {
-                    jsonOutputPayload = jsonOutputPayload.getJSONObject("license");
-                }
-                repoLicense = new DetectedLicense(jsonOutputPayload.getString("spdx_id"), DetectedLicenseSource.GITHUB);
-
-                conn.disconnect();
-            } catch (ProtocolException e) {
-                throw new ProtocolException(
-                        "Couldn't set the GET method while retrieving an outbound license from GitHub: " +
-                                e.getMessage());
-            } catch (IOException e) {
-                throw new IOException(
-                        "Couldn't get data from the HTTP response returned by GitHub's API: " + e.getMessage(),
-                        e.getCause());
-            }
-
-            return repoLicense;
-        }
-
-        /**
-         * Retrieves the cloned repository path on the shared volume from the input record.
-         *
-         * @param record the input record containing repository information.
-         * @return the repository path on the shared volume
-         * @throws IllegalArgumentException in case the function couldn't find the repository path in the input record.
-         */
-        protected String extractRepoPath(String record) throws IllegalArgumentException {
-            var payload = new JSONObject(record);
-            if (payload.has("fasten.RepoCloner.out")) {
-                payload = payload.getJSONObject("fasten.RepoCloner.out");
-            }
-            if (payload.has("payload")) {
-                payload = payload.getJSONObject("payload");
-            }
-            String repoPath = payload.getString("repoPath");
-            if (repoPath == null) {
-                throw new IllegalArgumentException("Invalid repository information: missing repository path.");
-            }
-            return repoPath;
-        }
-
-        /**
-         * Retrieves the repository URL from the input record.
-         *
-         * @param record the input record containing repository information.
-         * @return the input repository URL.
-         */
-        @Nullable
-        protected String extractRepoURL(String record) {
-            var payload = new JSONObject(record);
-            if (payload.has("fasten.RepoCloner.out")) {
-                payload = payload.getJSONObject("fasten.RepoCloner.out");
-            }
-            if (payload.has("payload")) {
-                payload = payload.getJSONObject("payload");
-            }
-            return payload.getString("repoUrl");
-        }
-
-        /**
-         * Retrieves the pom.xml file given a repository path.
-         *
-         * @param repoPath the repository path whose pom.xml file must be retrieved.
-         * @return the pom.xml file of the repository.
-         * @throws FileNotFoundException in case no pom.xml file could be found in the repository.
-         */
-        protected File retrievePomFile(String repoPath) throws FileNotFoundException {
-
-            // Result
-            Optional<File> pomFile = Optional.empty();
-
-            // Repository folder
-            File repoFolder = new File(repoPath);
-
-            // Retrieving all repository's pom files
-            File[] pomFiles = repoFolder.listFiles((dir, name) -> name.equalsIgnoreCase("pom.xml"));
-            if (pomFiles == null) {
-                throw new RuntimeException("Path " + repoPath + " does not denote a directory.");
-            }
-            logger.trace("Found " + pomFiles.length + " pom.xml file" +
-                    ((pomFiles.length == 1) ? "" : "s") + ": " + Arrays.toString(pomFiles));
-            if (pomFiles.length == 1) {
-                pomFile = Optional.ofNullable(pomFiles[0]);
-            } else if (pomFiles.length > 1) {
-                // Retrieving the pom.xml file having the shortest path (closest to it repository's root path)
-                pomFile = Arrays.stream(pomFiles).min(Comparator.comparingInt(f -> f.getAbsolutePath().length()));
-                logger.info("Multiple pom.xml files found. Using " + pomFile.get());
-            }
-
-            if (pomFile.isEmpty()) {
-                throw new FileNotFoundException("No file named pom.xml found in " + repoPath + ".");
-            }
-
-            return pomFile.get();
-        }
-
-        /**
-         * Scans a repository looking for license text in files with scancode.
-         *
-         * @param repoPath the repository path whose pom.xml file must be retrieved.
-         * @return the path of the file containing the result.
-         * @throws IOException          in case scancode couldn't start.
-         * @throws InterruptedException in case this function couldn't wait for scancode to complete.
-         * @throws RuntimeException     in case scancode returns with an error code != 0.
-         */
-        protected String scanProject(String repoPath) throws IOException, InterruptedException, RuntimeException {
-
-            // Where is the result stored
-            String resultPath = repoPath + "/scancode.json";
-
-            // `scancode` command to be executed
-            List<String> cmd = Arrays.asList(
-                    "/bin/bash",
-                    "-c",
-                    "scancode " +
-                    // Scan for licenses
-                    "--license " +
-                    // Report full, absolute paths
-                    "--full-root " +
-                    // Scan using n parallel processes
-                    "--processes " + "$(nproc) " +
-                    // Write scan output as a compact JSON file
-                    "--json " + resultPath + " " +
-                    // SPDX RDF file
-                    // "--spdx-rdf " + repoPath + "/scancode.spdx.rdf" + " " +
-                    // SPDX tag/value file
-                    // "--spdx-tv " + repoPath + "/scancode.spdx.tv " + " " +
-                    /*  Only return files or directories with findings for the requested scans.
-                        Files and directories without findings are omitted
-                        (file information is not treated as findings). */
-                    "--only-findings " +
-                    // TODO Scancode timeout?
-                    // "--timeout " + "600.0 " +
-                    // Repository directory
-                    repoPath
-            );
-
-            // Start scanning
-            logger.info("Scanning project in " + repoPath + "...");
-            ProcessBuilder pb = new ProcessBuilder(cmd);
-            pb.inheritIO();
-            Process p = null;
-            int exitCode = Integer.MIN_VALUE;
-            try {
-                p = pb.start(); // start scanning the project
-                exitCode = p.waitFor();// synchronous call
-            } catch (IOException e) {
-                if (p != null) {
-                    p.destroy();
-                }
-                throw new IOException("Couldn't start the scancode analyzer: " + e.getMessage(), e.getCause());
-            } catch (InterruptedException e) {
-                if (p != null) {
-                    p.destroy();
-                }
-                throw new InterruptedException("Couldn't wait for scancode to complete: " + e.getMessage());
-            }
-            if (exitCode != 0) {
-                throw new RuntimeException("Scancode returned with exit code " + exitCode + ".");
-            }
-
-            logger.info("...project in " + repoPath + " scanned successfully.");
-
-            return resultPath;
-        }
-
-        /**
-         * Parses the scan result file and returns file licenses.
-         *
-         * @param scanResultPath the path of the file containing the scan results.
-         * @return the list of licenses that have been detected by scanning files.
-         * @throws IOException   in case the JSON scan result couldn't be read.
-         * @throws JSONException in case the root object of the JSON scan result couldn't have been retrieved.
-         */
-        protected JSONArray parseScanResult(String scanResultPath) throws IOException, JSONException {
-
-            try {
-                // Retrieving the root element of the scan result file
-                JSONObject root = new JSONObject(Files.readString(Paths.get(scanResultPath)));
-                if (root.isEmpty()) {
-                    throw new JSONException("Couldn't retrieve the root object of the JSON scan result file " +
-                            "at " + scanResultPath + ".");
-                }
-
-                // Returning file licenses
-                if (root.has("files") && !root.isNull("files")) {
-                    return root.getJSONArray("files");
-                }
-            } catch (IOException e) {
-                throw new IOException("Couldn't read the JSON scan result file at " + scanResultPath +
-                        ": " + e.getMessage(), e.getCause());
-            }
-
-            // In case nothing could have been found
-            return null;
-        }
-
+        
         @Override
         public Optional<String> produce() {
-            if (detectedLicenses == null ||
-                    (detectedLicenses.getOutbound().isEmpty() && detectedLicenses.getFiles().isEmpty())
-            ) {
-                return Optional.empty();
+            if (detectedLicenses == null){
+                return Optional.of(new JSONObject(EMPTY_DETECTED_LICENSES).toString());
             } else {
-                return Optional.of(new JSONObject(detectedLicenses).toString());
+            	String json = new JSONObject(detectedLicenses).toString();
+            	logger.info("producing -> {}", json);
+                return Optional.of(json);
             }
         }
-
+       
         @Override
         public String getOutputPath() {
-            return null; // FIXME
+            return null; 
         }
 
         @Override
@@ -497,11 +130,12 @@ public class LicenseDetectorPlugin extends Plugin {
 
         @Override
         public String version() {
-            return "0.1.0";
+            return PLUGIN_VERSION;
         }
 
         @Override
         public void start() {
+
         }
 
         @Override
@@ -525,5 +159,53 @@ public class LicenseDetectorPlugin extends Plugin {
         public long getMaxConsumeTimeout() {
             return 30 * 60 * 1000; // 30 minutes
         }
+        
+		protected RepoCoords extractRepoCoords(LanguageType lang) {
+            String repoPath, repoUrl;
+			switch (lang) {
+			case JAVA:
+                repoPath = JSONUtils.optStringByPath(payload, javaRepoPathKey, "");
+                repoUrl =  JSONUtils.optStringByPath(payload, javaRepoUrlKey, "");
+                break;
+			case PYTHON:
+                repoPath = JSONUtils.optStringByPath(payload, pythonRepoPathKey, "");
+                repoUrl =  JSONUtils.optStringByPath(payload, pythonRepoUrlKey, "");
+                break;
+			case C:
+                repoPath = JSONUtils.optStringByPath(payload, cRepoPathKey, "");
+                repoUrl =  JSONUtils.optStringByPath(payload, cRepoUrlKey, "");
+                break;
+			default:
+				throw new IllegalArgumentException("Invalid LanguageType");
+			}
+            return new RepoCoords(repoPath, lang, repoUrl);
+    	}        
+		
+        public class RepoCoords {
+        	String path;
+        	String url;
+        	
+        	private RepoCoords(String path, LanguageType lang, String url) {
+        		boolean hasPath = StringUtils.isNotBlank(path);
+        		if (hasPath) {
+	        		path = StringUtils.removeStart(path, "/mnt/fasten/");
+	        		if (StringUtils.isNotBlank(pathReplace)) {
+	        			path = pathReplace + "/" + lang.name().toLowerCase() + "/" + path;
+	        		} else {
+	        			path = "/mnt/fasten/" + lang.name().toLowerCase() + "/" + path;	
+	        		}
+        		}
+				this.path = path;
+				this.url = url;
+			}
+
+			@Override
+			public String toString() {
+				return "RepoCoords [path=" + path + ", url=" + url + "]";
+			}
+
+        	
+        }
+        
     }
 }

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LicenseDetectorPlugin.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/LicenseDetectorPlugin.java
@@ -54,6 +54,7 @@ public class LicenseDetectorPlugin extends Plugin {
         	this.pythonRepoPathKey = defaultEnv("PYTHON_REPO_PATH_KEY", "fasten.PyCG.out/payload/sourcePath");
         	this.pythonRepoUrlKey = defaultEnv("PYTHON_REPO_URL_KEY", "fasten.PyCG.out/payload/repoUrl");
         	this.cRepoPathKey = defaultEnv("C_REPO_PATH_KEY", "fasten.cscout.out/payload/sourcePath");
+        	this.cRepoUrlKey = defaultEnv("C_REPO_URL_KEY", "fasten.cscout.out/payload/repoUrl");
         	this.pathReplace = StringUtils.removeEnd(defaultEnv("FASTEN_MNT_REPLACE", ""), "/");
 		}
         

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/PythonLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/PythonLicenseDetector.java
@@ -1,0 +1,39 @@
+package eu.fasten.analyzer.licensedetector;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+
+import eu.fasten.analyzer.licensedetector.exceptions.LicenseDetectorException;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicense;
+import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
+
+public class PythonLicenseDetector extends AbstractLicenseDetector {
+
+	// TODO: verify the list
+	private static final List<String> LICENSE_FILES = Arrays.asList("setup.py", "LICENSE", "LICENSE.md", "LICENSE.txt",
+			"Readme.md", "Readme.txt");
+	
+	@Override
+	public DetectedLicenses detect(String repoPath, String repoUrl) throws LicenseDetectorException {
+		DetectedLicenses result = new DetectedLicenses();
+		
+		JSONArray files = detectFileLicenses(repoPath);
+		result.setFiles(files);
+		
+		Set<DetectedLicense> outbound = detectOutboundLicenses(repoPath, LICENSE_FILES, files);
+
+		// TDOO: check if is necessary for Python projects
+		if ((outbound == null || outbound.isEmpty()) && StringUtils.isNotBlank(repoUrl)) {
+			outbound = detectOutboundLicensesFromGitHub(repoUrl);
+		}
+		
+		result.setOutbound(outbound);
+		
+		return result;
+	}
+
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/PythonLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/PythonLicenseDetector.java
@@ -13,7 +13,6 @@ import eu.fasten.analyzer.licensedetector.license.DetectedLicenses;
 
 public class PythonLicenseDetector extends AbstractLicenseDetector {
 
-	// TODO: verify the list
 	private static final List<String> LICENSE_FILES = Arrays.asList("setup.py", "LICENSE", "LICENSE.md", "LICENSE.txt",
 			"Readme.md", "Readme.txt");
 	

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/PythonLicenseDetector.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/PythonLicenseDetector.java
@@ -25,7 +25,7 @@ public class PythonLicenseDetector extends AbstractLicenseDetector {
 		
 		Set<DetectedLicense> outbound = detectOutboundLicenses(repoPath, LICENSE_FILES, files);
 
-		// TDOO: check if is necessary for Python projects
+		// TODO: check if is necessary for Python projects
 		if ((outbound == null || outbound.isEmpty()) && StringUtils.isNotBlank(repoUrl)) {
 			outbound = detectOutboundLicensesFromGitHub(repoUrl);
 		}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/exceptions/LicenseDetectorException.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/exceptions/LicenseDetectorException.java
@@ -1,0 +1,28 @@
+package eu.fasten.analyzer.licensedetector.exceptions;
+
+public class LicenseDetectorException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public LicenseDetectorException() {
+		super();
+	}
+
+	public LicenseDetectorException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public LicenseDetectorException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public LicenseDetectorException(String message) {
+		super(message);
+	}
+
+	public LicenseDetectorException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/JSONUtils.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/JSONUtils.java
@@ -1,0 +1,24 @@
+package eu.fasten.analyzer.licensedetector.utils;
+
+import org.json.JSONObject;
+
+public class JSONUtils {
+	
+	public static String optStringByPath(JSONObject jo, String path) {
+		return optStringByPath(jo, path, null);
+	}
+	
+	public static String optStringByPath(JSONObject jo, String path, String def) {
+		if (path == null) return def;
+		String[] apath = path.trim().split("[/]");
+		for (int i = 0; i < apath.length; i++) {
+			if (i == apath.length - 1) {
+				return jo.optString(apath[i], def);
+			}
+			jo = jo.optJSONObject(apath[i]);
+			if (jo == null) return def;
+		}
+		return def;
+	}
+
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/ProcessUtils.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/ProcessUtils.java
@@ -1,0 +1,26 @@
+package eu.fasten.analyzer.licensedetector.utils;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ProcessUtils {
+
+	public static int exec(List<String> cmd) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.inheritIO();
+        Process p = null;
+        int exitCode = Integer.MIN_VALUE;
+        try {
+            p = pb.start(); // start executing command
+            exitCode = p.waitFor();// synchronous call
+        } catch (IOException e) {
+            throw new IOException("Couldn't start the external process: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            if (p != null) {
+                p.destroy();
+            }
+            throw new InterruptedException("Couldn't wait for external process to complete: " + e.getMessage());
+        }
+        return exitCode;
+	}
+}

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/Scancode.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/Scancode.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -15,6 +16,7 @@ import org.slf4j.LoggerFactory;
 public class Scancode {
 
     private final static Logger logger = LoggerFactory.getLogger(Scancode.class.getName());
+    private static final String SCANCODE_CMD = StringUtils.firstNonBlank(System.getenv("SCANCODE_CMD"), "scancode");
 
     /**
      * Scans a repository looking for license text in files with scancode.
@@ -34,7 +36,7 @@ public class Scancode {
         List<String> cmd = Arrays.asList(
                 "/bin/bash",
                 "-c",
-                "scancode " +
+                SCANCODE_CMD + " " +
                 // Scan for licenses
                 "--license " +
                 // Report full, absolute paths

--- a/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/Scancode.java
+++ b/analyzer/license-detector/src/main/java/eu/fasten/analyzer/licensedetector/utils/Scancode.java
@@ -1,0 +1,101 @@
+package eu.fasten.analyzer.licensedetector.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Scancode {
+
+    private final static Logger logger = LoggerFactory.getLogger(Scancode.class.getName());
+
+    /**
+     * Scans a repository looking for license text in files with scancode.
+     *
+     * @param repoPath the repository path whose pom.xml file must be retrieved.
+     * @return the path of the file containing the result.
+     * @throws IOException          in case scancode couldn't start.
+     * @throws InterruptedException in case this function couldn't wait for scancode to complete.
+     * @throws RuntimeException     in case scancode returns with an error code != 0.
+     */
+    public static String scanProject(String repoPath) throws IOException, InterruptedException, RuntimeException {
+
+        // Where is the result stored
+        String resultPath = repoPath + "/scancode.json";
+
+        // `scancode` command to be executed
+        List<String> cmd = Arrays.asList(
+                "/bin/bash",
+                "-c",
+                "scancode " +
+                // Scan for licenses
+                "--license " +
+                // Report full, absolute paths
+                "--full-root " +
+                // Scan using n parallel processes
+                "--processes " + "$(nproc) " +
+                // Write scan output as a compact JSON file
+                "--json " + resultPath + " " +
+                // SPDX RDF file
+                // "--spdx-rdf " + repoPath + "/scancode.spdx.rdf" + " " +
+                // SPDX tag/value file
+                // "--spdx-tv " + repoPath + "/scancode.spdx.tv " + " " +
+                /*  Only return files or directories with findings for the requested scans.
+                    Files and directories without findings are omitted
+                    (file information is not treated as findings). */
+                "--only-findings " +
+                // TODO Scancode timeout?
+                // "--timeout " + "600.0 " +
+                // Repository directory
+                repoPath
+        );
+
+        // Start scanning
+		logger.info("Scanning project in " + repoPath + "...");
+		int exitCode = ProcessUtils.exec(cmd);
+		if (exitCode != 0) {
+		    throw new RuntimeException("Scancode returned with exit code " + exitCode + ".");
+		}
+		logger.info("...project in " + repoPath + " scanned successfully.");
+		
+		return resultPath;
+    }
+
+    /**
+     * Parses the scan result file and returns file licenses.
+     *
+     * @param scanResultPath the path of the file containing the scan results.
+     * @return the list of licenses that have been detected by scanning files.
+     * @throws IOException   in case the JSON scan result couldn't be read.
+     * @throws JSONException in case the root object of the JSON scan result couldn't have been retrieved.
+     */
+    public static JSONArray parseScanResult(String scanResultPath) throws IOException, JSONException {
+
+        try {
+            // Retrieving the root element of the scan result file
+            JSONObject root = new JSONObject(Files.readString(Paths.get(scanResultPath)));
+            if (root.isEmpty()) {
+                throw new JSONException("Couldn't retrieve the root object of the JSON scan result file " +
+                        "at " + scanResultPath + ".");
+            }
+
+            // Returning file licenses
+            if (root.has("files") && !root.isNull("files")) {
+                return root.getJSONArray("files");
+            }
+        } catch (IOException e) {
+            throw new IOException("Couldn't read the JSON scan result file at " + scanResultPath +
+                    ": " + e.getMessage(), e.getCause());
+        }
+
+        // In case nothing could have been found
+        return null;
+    }    
+}


### PR DESCRIPTION
## Description
Extending the license detector plugin, currently working for Java/Maven projects, to detect licenses for Python and C projects too.

## Motivation and context
This change is required to fulfill the project requirements 

## Testing
To test the new added features some additional open source Python and C projects will be identified to be used in the license detection unit tests

## Task list  
- [ ] Extract some reusable code from the LicenseDetectorPlugin
- [ ] Create license detector classes specialized for Python and C projects
- [ ] Integrate the new code with the main LicenseDetectorPlugin class

