### PR TITLE
Don't loose externals when merging

### DIFF
--- a/core/src/main/java/eu/fasten/core/data/MergedDirectedGraph.java
+++ b/core/src/main/java/eu/fasten/core/data/MergedDirectedGraph.java
@@ -14,6 +14,8 @@ import org.jgrapht.graph.DefaultEdge;
 
 public class MergedDirectedGraph extends DefaultDirectedGraph<Long, LongLongPair> implements DirectedGraph, Serializable {
 
+    private final LongSet externalNodes = new LongOpenHashSet();
+
     public MergedDirectedGraph() {
         this(MergedEdge.class);
     }
@@ -51,7 +53,16 @@ public class MergedDirectedGraph extends DefaultDirectedGraph<Long, LongLongPair
 
     @Override
     public LongSet externalNodes() {
-        return LongSet.of();
+        return this.externalNodes;
+    }
+
+    public boolean addExternalNode(long node) {
+        boolean result = addVertex(node);
+        if (result) {
+            this.externalNodes.add(node);
+        }
+
+        return result;
     }
 
     @Override
@@ -61,9 +72,8 @@ public class MergedDirectedGraph extends DefaultDirectedGraph<Long, LongLongPair
 
     @Override
     public boolean isExternal(long node) {
-        return false;
+        return this.externalNodes.contains(node);
     }
-
 
     @Override
     public LongIterator iterator() {
@@ -76,7 +86,12 @@ public class MergedDirectedGraph extends DefaultDirectedGraph<Long, LongLongPair
     }
 
     public boolean removeVertex(long node) {
-        return super.removeVertex(node);
+        boolean result = super.removeVertex(node);
+        if (result) {
+            this.externalNodes.remove(node);
+        }
+
+        return result;
     }
 
     public static class MergedEdge extends DefaultEdge implements LongLongPair {

--- a/core/src/main/java/eu/fasten/core/merge/CGMerger.java
+++ b/core/src/main/java/eu/fasten/core/merge/CGMerger.java
@@ -84,6 +84,7 @@ public class CGMerger {
     private BiMap<Long, String> allUris;
 
     private Map<String, Map<String, String>> externalUris;
+    private long externalGlobaIds = 0;
 
     public BiMap<Long, String> getAllUris() {
         return this.allUris;
@@ -102,7 +103,8 @@ public class CGMerger {
      * Creates instance of callgraph merger.
      *
      * @param dependencySet all artifacts present in a resolution
-     * @param withExternals true if unresolved external calls should be kept in the generated graph
+     * @param withExternals true if unresolved external calls should be kept in the generated graph, they will be
+     *            assigned negative ids
      */
     public CGMerger(final List<ExtendedRevisionJavaCallGraph> dependencySet, boolean withExternals) {
 
@@ -442,7 +444,7 @@ public class CGMerger {
                     Long target = this.allUris.inverse().get(nodeURI);
                     if (target == null) {
                         // Allocate a global id to the external node
-                        target = this.allUris.keySet().stream().max(Long::compareTo).orElse(0L) + 1;
+                        target = --this.externalGlobaIds;
 
                         // Add the external node to the graph if not already there
                         this.allUris.put(target, nodeURI);

--- a/core/src/test/java/eu/fasten/core/merge/CGMergerTest.java
+++ b/core/src/test/java/eu/fasten/core/merge/CGMergerTest.java
@@ -350,6 +350,7 @@ public class CGMergerTest {
             ".simpleImport/Importer.sourceMethod()%2Fjava.lang%2FVoidType");
         final var external = uris.inverse().get("/java.lang/Object.%3Cinit%3E()VoidType");
 
+        assertEquals(-1L, external);
         assertEquals(LongSet.of(external), cg.externalNodes());
 
         assertEquals(

--- a/core/src/test/java/eu/fasten/core/merge/CGMergerTest.java
+++ b/core/src/test/java/eu/fasten/core/merge/CGMergerTest.java
@@ -334,9 +334,9 @@ public class CGMergerTest {
 
     @Test
     public void mergeAllDepsWithExternalsTest() {
-        merger = new CGMerger(Arrays.asList(imported, importer));
+        merger = new CGMerger(Arrays.asList(imported, importer), true);
 
-        final var cg = merger.mergeAllDeps(true);
+        final var cg = merger.mergeAllDeps();
         final var uris = merger.getAllUris();
         assertEquals(4, cg.edgeSet().size());
         assertEquals(5, uris.size());


### PR DESCRIPTION
The FASTEN Maven plugin need to have also the external node in the graph to do binary compatibility analysis. Unfortunately those are currently wiped by CGMerge.

I did a first version where external node were never wiped and finally made this optional in case there was a need for this cleanup in other use cases.