### PR TITLE
Added top-level dependencies to JSON metadata.

### DIFF
--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.pf4j.Extension;
@@ -229,6 +230,9 @@ public class POMAnalyzerPlugin extends Plugin {
             packageVersionMetadata.put("dependencyManagement",
                     (dependencyData.dependencyManagement != null)
                             ? dependencyData.dependencyManagement.toJSON() : null);
+            packageVersionMetadata.put("dependencies",
+                    (dependencyData.dependencies != null)
+                            ? new JSONArray(dependencyData.dependencies) : null);
             packageVersionMetadata.put("commitTag", (commitTag != null) ? commitTag : "");
             packageVersionMetadata.put("sourcesUrl", (sourcesUrl != null) ? sourcesUrl : "");
             packageVersionMetadata.put("packagingType", (packagingType != null)


### PR DESCRIPTION
## Description
POM Analyzer simply did not put the top-level dependencies of a Maven POM in the JSON metadata. It did put them in the DB as package-versions.

## Motivation and context
Partial fix for #311.
@vigna 

## Testing
Unit tests still pass. The tests did not signal the bug however, since the testing is done using only a trivial mock.

## Task list 
- [x] Test and deploy asap

