### PR TITLE
Optimizing the output of POMAnalyzer

### DIFF
--- a/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
+++ b/analyzer/pom-analyzer/src/main/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPlugin.java
@@ -21,16 +21,10 @@ package eu.fasten.analyzer.pomanalyzer;
 import eu.fasten.analyzer.pomanalyzer.pom.DataExtractor;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
-import eu.fasten.core.maven.utils.MavenUtilities;
 import eu.fasten.core.maven.data.DependencyData;
+import eu.fasten.core.maven.utils.MavenUtilities;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
-import java.io.File;
-import java.sql.Timestamp;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -42,6 +36,13 @@ import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class POMAnalyzerPlugin extends Plugin {
 
@@ -284,7 +285,6 @@ public class POMAnalyzerPlugin extends Plugin {
             json.put("packagingType", packagingType);
             json.put("projectName", (projectName != null) ? projectName : "");
             json.put("parentCoordinate", (parentCoordinate != null) ? parentCoordinate : "");
-            json.put("dependencyData", dependencyData.toJSON());
             json.put("forge", Constants.mvnForge);
             json.put("artifactRepository", artifactRepository);
             return Optional.of(json.toString());

--- a/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPluginTest.java
+++ b/analyzer/pom-analyzer/src/test/java/eu/fasten/analyzer/pomanalyzer/POMAnalyzerPluginTest.java
@@ -18,15 +18,17 @@
 
 package eu.fasten.analyzer.pomanalyzer;
 
-import eu.fasten.core.maven.data.DependencyData;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.maven.data.DependencyData;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
 import java.util.Collections;
 import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,7 +55,7 @@ public class POMAnalyzerPluginTest {
         var output = pomAnalyzer.produce();
         assertTrue(output.isPresent());
         System.out.println(output.get());
-        var expected = "{\"date\":1569025448000,\"repoUrl\":\"http://source.android.com\",\"groupId\":\"android.arch.core\",\"version\":\"1.1.1\",\"parentCoordinate\":\"\",\"artifactRepository\":\"https://dl.google.com/android/maven2/\",\"forge\":\"mvn\",\"sourcesUrl\":\"https://dl.google.com/android/maven2/android/arch/core/common/1.1.1/common-1.1.1-sources.jar\",\"artifactId\":\"common\",\"dependencyData\":{\"dependencyManagement\":{\"dependencies\":[]},\"dependencies\":[{\"versionConstraints\":[{\"isUpperHardRequirement\":false,\"isLowerHardRequirement\":false,\"upperBound\":\"4.12\",\"lowerBound\":\"4.12\"}],\"groupId\":\"junit\",\"scope\":\"test\",\"classifier\":\"\",\"artifactId\":\"junit\",\"exclusions\":[],\"optional\":false,\"type\":\"\"},{\"versionConstraints\":[{\"isUpperHardRequirement\":false,\"isLowerHardRequirement\":false,\"upperBound\":\"2.7.6\",\"lowerBound\":\"2.7.6\"}],\"groupId\":\"org.mockito\",\"scope\":\"test\",\"classifier\":\"\",\"artifactId\":\"mockito-core\",\"exclusions\":[],\"optional\":false,\"type\":\"\"},{\"versionConstraints\":[{\"isUpperHardRequirement\":false,\"isLowerHardRequirement\":false,\"upperBound\":\"26.1.0\",\"lowerBound\":\"26.1.0\"}],\"groupId\":\"com.android.support\",\"scope\":\"compile\",\"classifier\":\"\",\"artifactId\":\"support-annotations\",\"exclusions\":[],\"optional\":false,\"type\":\"\"}]},\"projectName\":\"Android Arch-Common\",\"commitTag\":\"\",\"packagingType\":\"jar\"}";
+        var expected = "{\"date\":1569025448000,\"repoUrl\":\"http://source.android.com\",\"forge\":\"mvn\",\"groupId\":\"android.arch.core\",\"sourcesUrl\":\"https://dl.google.com/android/maven2/android/arch/core/common/1.1.1/common-1.1.1-sources.jar\",\"artifactId\":\"common\",\"projectName\":\"Android Arch-Common\",\"version\":\"1.1.1\",\"commitTag\":\"\",\"packagingType\":\"jar\",\"parentCoordinate\":\"\",\"artifactRepository\":\"https://dl.google.com/android/maven2/\"}";
         assertEquals(expected, output.get());
     }
 
@@ -69,34 +71,7 @@ public class POMAnalyzerPluginTest {
         var sourcesUrl = "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar";
         var packagingType = "jar";
         var projectName = "JUnit";
-        var dependencyData = DependencyData.fromJSON(new JSONObject("{\n" +
-                "   \"dependencyManagement\":{\n" +
-                "      \"dependencies\":[\n" +
-                "\n" +
-                "      ]\n" +
-                "   },\n" +
-                "   \"dependencies\":[\n" +
-                "      {\n" +
-                "         \"versionConstraints\":[\n" +
-                "            {\n" +
-                "               \"isUpperHardRequirement\":false,\n" +
-                "               \"isLowerHardRequirement\":false,\n" +
-                "               \"upperBound\":\"1.3\",\n" +
-                "               \"lowerBound\":\"1.3\"\n" +
-                "            }\n" +
-                "         ],\n" +
-                "         \"groupId\":\"org.hamcrest\",\n" +
-                "         \"scope\":\"\",\n" +
-                "         \"classifier\":\"\",\n" +
-                "         \"artifactId\":\"hamcrest-core\",\n" +
-                "         \"exclusions\":[\n" +
-                "\n" +
-                "         ],\n" +
-                "         \"optional\":false,\n" +
-                "         \"type\":\"\"\n" +
-                "      }\n" +
-                "   ]\n" +
-                "}"));
+
         pomAnalyzer.consume(record);
         var output = pomAnalyzer.produce();
         assertTrue(output.isPresent());
@@ -108,7 +83,6 @@ public class POMAnalyzerPluginTest {
         assertEquals(sourcesUrl, json.getString("sourcesUrl"));
         assertEquals(packagingType, json.getString("packagingType"));
         assertEquals(projectName, json.getString("projectName"));
-        assertEquals(dependencyData, DependencyData.fromJSON(json.getJSONObject("dependencyData")));
     }
 
     @Test

--- a/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
+++ b/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
@@ -321,7 +321,6 @@ public class VulnerabilityCacheProcessorPlugin extends Plugin {
                         logger.info("No Vulnerabilities Found. Skipping processing of revision.");
                         persistOutput(revision, "{}");
 //                        continue;
-                        return;
                     } else {
                         logger.info("Vulnerable IDs: " + vulnerableDependencies.toString());
                     }
@@ -329,18 +328,15 @@ public class VulnerabilityCacheProcessorPlugin extends Plugin {
                     depIds.add(revision.id);
                     var databaseMerger = new CGMerger(depIds, dbContext, graphDao);
                     var graph = databaseMerger.mergeAllDeps();
-
                     if (graph == null || graph.numNodes() == 0) {
                         logger.info("Empty Graph for: " + revision.toString());
                         persistOutput(revision, "{}");
-                        return;
 //                        continue;
                     } else {
                         logger.info("Graph exists for: " + revision.toString());
-                        logger.info(graph.nodes().toString());
-                        logger.info(graph.edgeSet().toString());
                     }
 
+                assert graph != null;
                 var vulnerabilities = kbDao.findVulnerableCallables(vulnerableDependencies, graph.nodes());
                     logger.info("Graph contains vulnerable callables: " + vulnerabilities.keySet().size());
 

--- a/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
+++ b/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
@@ -339,11 +339,9 @@ public class VulnerabilityCacheProcessorPlugin extends Plugin {
                 assert graph != null;
                 var vulnerabilities = kbDao.findVulnerableCallables(vulnerableDependencies, graph.nodes());
                     logger.info("Graph contains vulnerable callables: " + vulnerabilities.keySet().size());
-                    logger.info("First 20: " + vulnerabilities.keySet().stream().limit(20).collect(Collectors.toList()));
 
                     var internalCallables = kbDao.getPackageInternalCallableIDs(revision.product().toString(), revision.version.toString(), graph.nodes());
                     logger.info("Graph contains internal callable: " + internalCallables.size());
-                    logger.info("First 20: " + internalCallables.stream().limit(20).collect(Collectors.toList()));
 
 
                     // Find all paths between any internal node and any vulnerable node in the graph

--- a/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
+++ b/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
@@ -327,13 +327,15 @@ public class VulnerabilityCacheProcessorPlugin extends Plugin {
 
                     depIds.add(revision.id);
                     var databaseMerger = new CGMerger(depIds, dbContext, graphDao);
-                    var graph = databaseMerger.mergeAllDeps();
+                    var graph = databaseMerger.mergeWithCHA(revision.id);
                     if (graph == null || graph.numNodes() == 0) {
                         logger.info("Empty Graph for: " + revision.toString());
                         persistOutput(revision, "{}");
 //                        continue;
                     } else {
                         logger.info("Graph exists for: " + revision.toString());
+                        logger.info("Graph nodes: " + graph.numNodes());
+                        logger.info("Graph edges: " + graph.numArcs());
                     }
 
                 assert graph != null;

--- a/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
+++ b/analyzer/vulnerability-cache-processor-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheprocessorplugin/VulnerabilityCacheProcessorPlugin.java
@@ -339,9 +339,11 @@ public class VulnerabilityCacheProcessorPlugin extends Plugin {
                 assert graph != null;
                 var vulnerabilities = kbDao.findVulnerableCallables(vulnerableDependencies, graph.nodes());
                     logger.info("Graph contains vulnerable callables: " + vulnerabilities.keySet().size());
+                    logger.info("First 20: " + vulnerabilities.keySet().stream().limit(20).collect(Collectors.toList()));
 
                     var internalCallables = kbDao.getPackageInternalCallableIDs(revision.product().toString(), revision.version.toString(), graph.nodes());
                     logger.info("Graph contains internal callable: " + internalCallables.size());
+                    logger.info("First 20: " + internalCallables.stream().limit(20).collect(Collectors.toList()));
 
 
                     // Find all paths between any internal node and any vulnerable node in the graph


### PR DESCRIPTION
## Description
The dependency data is removed from the output message of POMAnlyzer.

## Motivation and context
Currently, the output messages of POM Analyzer can be large due to the dependency information. However, this information is not used by downstream plug-ins via Kafka and also the dependencies data are stored in the metadata DB.

## Testing
We need to make sure that the upstream plug-ins will not break if the dependency info is absent for the output messages of POM Analyzer.

## Task list  
- [x] Removed the dependency data from the output JSON of POMAnalyzer