### PR TITLE
Update default topic name: CallableIndexExtension

### DIFF
--- a/analyzer/vulnerability-cache-invalidation-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheinvalidationplugin/VulnerabilityCacheInvalidationPlugin.java
+++ b/analyzer/vulnerability-cache-invalidation-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheinvalidationplugin/VulnerabilityCacheInvalidationPlugin.java
@@ -52,7 +52,7 @@ public class VulnerabilityCacheInvalidationPlugin extends Plugin {
 
         private final Logger logger = LoggerFactory.getLogger(VulnerabilityCacheInvalidationExtension.class.getName());
 
-        private String consumerTopic = "fasten.GraphDBExtension.out";
+        private String consumerTopic = "fasten.CallableIndexExtension.out";
 
         private static GraphMavenResolver graphResolver;
         private static String baseDir;
@@ -157,7 +157,7 @@ public class VulnerabilityCacheInvalidationPlugin extends Plugin {
             this.depSet = null;
             this.setPluginError(null);
 
-            // Parse JSON object from kafka topic of GraphDBExtension.
+            // Parse JSON object from kafka topic of CallableIndexExtension.
             // Although it doesn't have output payload, the plugin serializes the graph for its input.
             // And we can use the input copy from this topic and the serialized graph to process our caching.
             var json = new JSONObject(record);


### PR DESCRIPTION
## Description
Adjusting the default consume Kafka topic name from `fasten.GraphDBExtension.out` to `fasten.CallableIndexExtension.out`.

## Motivation and context
Extension was renamed from `GraphDBExtension` to `CallableIndexExtension` in commit bd90e78b3ef902d76fcb24e62239f159239b51df.

## Testing
No particular testing done.