### PR TITLE
Handling RuntimeExceptions and UnrecoverableErrors in the FASTEN server

### DIFF
--- a/core/src/main/java/eu/fasten/core/exceptions/UnrecoverableError.java
+++ b/core/src/main/java/eu/fasten/core/exceptions/UnrecoverableError.java
@@ -4,7 +4,7 @@ package eu.fasten.core.exceptions;
  * This exception is defined for rare circumstances where we need to deliberately crash a plug-in and
  * cause Kubernetes to restart the pod. Otherwise, RuntimeExceptions are normally catched and handled by the FASTEN server.
  */
-public class UnrecoverableError extends RuntimeException {
+public class UnrecoverableError extends Error {
     public UnrecoverableError(String errorMsg, Throwable err) {
         super(errorMsg, err);
     }

--- a/core/src/main/java/eu/fasten/core/exceptions/UnrecoverableError.java
+++ b/core/src/main/java/eu/fasten/core/exceptions/UnrecoverableError.java
@@ -1,0 +1,11 @@
+package eu.fasten.core.exceptions;
+
+/**
+ * This exception is defined for rare circumstances where we need to deliberately crash a plug-in and
+ * cause Kubernetes to restart the pod. Otherwise, RuntimeExceptions are normally catched and handled by the FASTEN server.
+ */
+public class UnrecoverableError extends RuntimeException {
+    public UnrecoverableError(String errorMsg, Throwable err) {
+        super(errorMsg, err);
+    }
+}

--- a/core/src/main/java/eu/fasten/core/maven/utils/MavenUtilities.java
+++ b/core/src/main/java/eu/fasten/core/maven/utils/MavenUtilities.java
@@ -19,6 +19,7 @@
 package eu.fasten.core.maven.utils;
 
 import eu.fasten.core.data.Constants;
+import eu.fasten.core.exceptions.UnrecoverableError;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -146,7 +147,7 @@ public class MavenUtilities {
             // After downloading ~50-60K POMs, there will be a lot of CLOSE_WAIT connections,
             // at some point the plug-in runs out of source ports to use. Therefore, we need to crash so that
             // Kubernetes will restart the plug-in to kill CLOSE_WAIT connections.
-            throw new Error("Failing execution, typically due to many CLOSE_WAIT connections", e);
+            throw new UnrecoverableError("Failing execution, typically due to many CLOSE_WAIT connections", e);
         } catch (IOException e) {
             logger.error("Error getting file from URL: " + url, e);
             throw e;

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -294,12 +294,11 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
                     plugin.consume(record.value());
                 }
             }
-        } catch (RuntimeException e) {
+        } catch (UnrecoverableError e) {
             // In rare circumstances, plug-ins throw UnrecoverableError to crash and therefore K8s will restart the plug-in.
-            if (e instanceof UnrecoverableError) {
-                logger.error("Forced to stop the plug-in due to ", e);
-                throw e;
-            }
+            logger.error("Forced to stop the plug-in due to ", e);
+            throw e;
+        } catch (RuntimeException e) {
             logger.error("An error occurred in " + plugin.getClass().getCanonicalName(), e);
             plugin.setPluginError(e);
         }

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -298,7 +298,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             // In rare circumstances, plug-ins throw UnrecoverableError to crash and therefore K8s will restart the plug-in.
             logger.error("Forced to stop the plug-in due to ", e);
             throw e;
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             logger.error("An error occurred in " + plugin.getClass().getCanonicalName(), e);
             plugin.setPluginError(e);
         }


### PR DESCRIPTION
## Description
This PR makes the following changes:
- A custom exception, `UnrecoverableError`, is defined for rare cases where we deliberately want to crash a plug-in and cause K8s to restart the pod (E.g. see #321)
- The FASTEN server handles both `Exception` and `UnrecoverableError` thrown by the plug-ins.

## Motivation and context
To avoid swallowing exceptions, the FASTEN plug-ins can now handle exceptions in two ways:
- For the sake of backward compatibility, plug-ins can still use the `setPluginError` method, which is handled by the FASTEN server.
- Unhandled `Exception` in the plug-ins are now handled by the FASTEN server and the error is sent to the `*.err` Kafka topic.

## Testing
It's tested with `DummyPlugin`. It works as expected for all four cases: (1) successful processing of records (2) handled exceptions in the plug-in, i.e. `setPluginError` (3) Unhandled exceptions in the plug-in (4) Throwing `UnrecoverableError`

## Task list  
- [x] Define the `UnrecoverableError` exception.
- [x] Handle both `Exception` and `UnrecoverableError` in the FASTEN server
