### PR TITLE
Remove default consume topic from MetadataDBExtension

### DIFF
--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -51,9 +51,9 @@ import java.sql.BatchUpdateException;
 import java.sql.Timestamp;
 import java.util.*;
 
-public class MetadataDBExtension implements KafkaPlugin, DBConnector {
+public abstract class MetadataDBExtension implements KafkaPlugin, DBConnector {
 
-    protected List<String> consumeTopics = new LinkedList<>(Collections.singletonList("fasten.OPAL.out"));
+    protected List<String> consumeTopics = null;
     private static DSLContext dslContext;
     protected boolean processedRecord = false;
     protected Exception pluginError = null;

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabaseJavaPlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabaseJavaPlugin.java
@@ -47,6 +47,10 @@ public class MetadataDatabaseJavaPlugin extends Plugin {
     public static class MetadataDBJavaExtension extends MetadataDBExtension {
         private static DSLContext dslContext;
 
+        public MetadataDBJavaExtension() {
+            super.consumeTopics = new LinkedList<>(Collections.singletonList("fasten.OPAL.out"));
+        }
+
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
             MetadataDBJavaExtension.dslContext = dslContexts.get(Constants.mvnForge);


### PR DESCRIPTION
## Description
Remove default value for the topic to consume from in `MetadataDBExtension` class. Add default value in `MetadataDBJavaExtension` class.
Also make `MetadataDBExtension` abstract to avoid accidental direct usage.

## Motivation and context
Default value for the topic to consume from make sense only in actual plugin implementation (i.e. C, Java and Python).
It was already set for C and Python, adding it to Java.

## Testing
Build project and run unit test. No extra tests added.