### PR TITLE
Extend vulnerability packages listener to benefit from multiple topics

### DIFF
--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -178,7 +178,8 @@ public class VulnerabilityPackagesListener extends Plugin {
                 } else {
                     var other = json.get(key);
                     if (other instanceof JSONObject) {
-                        return findPayload((JSONObject) other);
+                        var otherPayload = findPayload((JSONObject) other);
+                        if(otherPayload != null) return otherPayload;
                     }
                 }
             }

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -117,20 +117,25 @@ public class VulnerabilityPackagesListener extends Plugin {
                 refreshMetadataUtility();
                 statementsProcessor.setMetadataUtility(metadataUtility);
                 var jsonRecord = new JSONObject(record);
-                var payload = (JSONObject) jsonRecord.query("/input/input/input/payload");
-                var ecosystem = payload.getString("forge");
-                var context = findContextForEcosystem(ecosystem);
-                var packageName = getPackageName(payload);
-                var version = payload.getString("version");
-                logger.info("Processing package update for forge \"" + ecosystem + "\": " + packageName + ":" + version);
-                var vulnerabilities = metadataUtility.getVulnerabilitiesForPurl(ecosystem, packageName, version, context);
-                logger.info("Found the following vulnerabilities for " + packageName + ":" + version + ": " + vulnerabilities.toString());
-                if(vulnerabilities.size() > 0) {
-                    vulnerabilities.forEach(vulnerabilityId -> {
-                        var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
-                        var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
-                        statementsProcessor.updateCallablesAndPackageVersions(vulnerability, packageName, new ComparableVersion(version));
-                    });
+                var payload = findPayload(jsonRecord);
+                if(payload != null) {
+                    var ecosystem = payload.getString("forge");
+                    var context = findContextForEcosystem(ecosystem);
+                    var packageName = getPackageName(payload);
+                    var version = payload.getString("version");
+                    logger.info("Processing package update for forge \"" + ecosystem + "\": " + packageName + ":" + version);
+                    var vulnerabilities = metadataUtility.getVulnerabilitiesForPurl(ecosystem, packageName, version, context);
+                    logger.info("Found the following vulnerabilities for " + packageName + ":" + version + ": " + vulnerabilities.toString());
+                    if(vulnerabilities.size() > 0) {
+                        vulnerabilities.forEach(vulnerabilityId -> {
+                            var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
+                            var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
+                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, packageName, new ComparableVersion(version));
+                        });
+                    }
+                }
+                else {
+                    logger.error("Could not parse payload in message: " + record);
                 }
             }
             catch (Exception e) {
@@ -161,6 +166,23 @@ public class VulnerabilityPackagesListener extends Plugin {
                     return payload.getString("product");
                 default: throw new UnsupportedOperationException("Unsupported forge: \"" + ecosystem + "\"");
             }
+        }
+
+        static JSONObject findPayload(JSONObject json) {
+            for (var key : json.keySet()) {
+                if (key.equals("payload")) {
+                    var candidatePayload = json.getJSONObject(key);
+                    if (candidatePayload.has("forge")) {
+                        return candidatePayload;
+                    }
+                } else {
+                    var other = json.get(key);
+                    if (other instanceof JSONObject) {
+                        return findPayload((JSONObject) other);
+                    }
+                }
+            }
+            return null;
         }
 
         @Override

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -130,7 +130,7 @@ public class VulnerabilityPackagesListener extends Plugin {
                         vulnerabilities.forEach(vulnerabilityId -> {
                             var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
                             var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
-                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, packageName, new ComparableVersion(version));
+                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability);
                         });
                     }
                 }

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -25,6 +25,7 @@ import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.vulnerability.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jooq.DSLContext;
 import org.json.JSONObject;
 import org.pf4j.Extension;
@@ -33,7 +34,11 @@ import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class VulnerabilityPackagesListener extends Plugin {
 
@@ -50,6 +55,7 @@ public class VulnerabilityPackagesListener extends Plugin {
         private final Gson gson = new Gson();
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityPackagesKafkaPlugin");
         private final VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin statementsProcessor = new VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin();
+        private MetadataUtility metadataUtility;
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
@@ -108,7 +114,8 @@ public class VulnerabilityPackagesListener extends Plugin {
         public void consume(String record) {
             setPluginError(null);
             try {
-                var metadataUtility = new MetadataUtility();
+                refreshMetadataUtility();
+                statementsProcessor.setMetadataUtility(metadataUtility);
                 var jsonRecord = new JSONObject(record);
                 var payload = (JSONObject) jsonRecord.query("/input/input/input/payload");
                 var ecosystem = payload.getString("forge");
@@ -122,7 +129,7 @@ public class VulnerabilityPackagesListener extends Plugin {
                     vulnerabilities.forEach(vulnerabilityId -> {
                         var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
                         var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
-                        statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId, metadataUtility);
+                        statementsProcessor.updateCallablesAndPackageVersions(vulnerability, packageName, new ComparableVersion(version));
                     });
                 }
             }
@@ -131,6 +138,10 @@ public class VulnerabilityPackagesListener extends Plugin {
                 logger.error(error);
                 setPluginError(e);
             }
+        }
+
+        private void refreshMetadataUtility() {
+            this.metadataUtility = new MetadataUtility();
         }
 
         private DSLContext findContextForEcosystem(String ecosystem) {

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -64,7 +64,7 @@ public class VulnerabilityPackagesListener extends Plugin {
 
         @Override
         public String description() {
-            return "Listens to package updates from the (graph) database and triggers re-processing of vulnerabilties";
+            return "Listens to package updates from the (graph) database and triggers re-processing of vulnerabilities";
         }
 
         @Override
@@ -119,10 +119,10 @@ public class VulnerabilityPackagesListener extends Plugin {
                 var vulnerabilities = metadataUtility.getVulnerabilitiesForPurl(ecosystem, packageName, version, context);
                 logger.info("Found the following vulnerabilities for " + packageName + ":" + version + ": " + vulnerabilities.toString());
                 if(vulnerabilities.size() > 0) {
-                    vulnerabilities.forEach(v -> {
-                        var statement = metadataUtility.getVulnerabilityStatement(v, context);
-                        var statementJson = gson.fromJson(statement, Vulnerability.class);
-                        statementsProcessor.injectVulnerabilityIntoDB(statementJson, metadataUtility);
+                    vulnerabilities.forEach(vulnerabilityId -> {
+                        var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
+                        var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
+                        statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId, metadataUtility);
                     });
                 }
             }

--- a/analyzer/vulnerability-packages-listener/src/test/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListenerTest.java
+++ b/analyzer/vulnerability-packages-listener/src/test/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListenerTest.java
@@ -15,8 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class VulnerabilityPackagesListenerTest {
     @Test
     void findPayloadInCallableIndexMessage() throws IOException {
-        var callableIndexMessageFile = TestUtils.getTestResource("callable-index-message.json");
-        var jsonTokener = new JSONTokener(new FileReader(callableIndexMessageFile));
+        var messageFile = TestUtils.getTestResource("callable-index-message.json");
+        var jsonTokener = new JSONTokener(new FileReader(messageFile));
         var json = new JSONObject(jsonTokener);
         var payload = findPayload(json);
         assertNotNull(payload);
@@ -28,8 +28,8 @@ class VulnerabilityPackagesListenerTest {
 
     @Test
     void findPayloadInPOMAnalyzerMessage() throws IOException {
-        var callableIndexMessageFile = TestUtils.getTestResource("pom-analyzer-message.json");
-        var jsonTokener = new JSONTokener(new FileReader(callableIndexMessageFile));
+        var messageFile = TestUtils.getTestResource("pom-analyzer-message.json");
+        var jsonTokener = new JSONTokener(new FileReader(messageFile));
         var json = new JSONObject(jsonTokener);
         var payload = findPayload(json);
         assertNotNull(payload);
@@ -37,5 +37,31 @@ class VulnerabilityPackagesListenerTest {
         assertEquals("io.netty", payload.getString("groupId"));
         assertEquals("netty-codec-http2", payload.getString("artifactId"));
         assertEquals("4.1.0.Beta5", payload.getString("version"));
+    }
+
+    @Test
+    void findPayloadInRealCallableIndexMessage() throws IOException {
+        var messageFile = TestUtils.getTestResource("real-callable-index-message.json");
+        var jsonTokener = new JSONTokener(new FileReader(messageFile));
+        var json = new JSONObject(jsonTokener);
+        var payload = findPayload(json);
+        assertNotNull(payload);
+        assertEquals("mvn", payload.getString("forge"));
+        assertEquals("org.apache.pdfbox", payload.getString("groupId"));
+        assertEquals("pdfbox", payload.getString("artifactId"));
+        assertEquals("2.0.8", payload.getString("version"));
+    }
+
+    @Test
+    void findPayloadInRealPOMAnalyzerMessage() throws IOException {
+        var messageFile = TestUtils.getTestResource("real-pom-analyzer-message.json");
+        var jsonTokener = new JSONTokener(new FileReader(messageFile));
+        var json = new JSONObject(jsonTokener);
+        var payload = findPayload(json);
+        assertNotNull(payload);
+        assertEquals("mvn", payload.getString("forge"));
+        assertEquals("org.apache.pdfbox", payload.getString("groupId"));
+        assertEquals("pdfbox", payload.getString("artifactId"));
+        assertEquals("2.0.8", payload.getString("version"));
     }
 }

--- a/analyzer/vulnerability-packages-listener/src/test/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListenerTest.java
+++ b/analyzer/vulnerability-packages-listener/src/test/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListenerTest.java
@@ -1,0 +1,41 @@
+package eu.fasten.analyzer.vulnerabilitypackageslistener;
+
+import eu.fasten.core.utils.TestUtils;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileReader;
+import java.io.IOException;
+
+import static eu.fasten.analyzer.vulnerabilitypackageslistener.VulnerabilityPackagesListener.VulnerabilityPackagesKafkaPlugin.findPayload;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class VulnerabilityPackagesListenerTest {
+    @Test
+    void findPayloadInCallableIndexMessage() throws IOException {
+        var callableIndexMessageFile = TestUtils.getTestResource("callable-index-message.json");
+        var jsonTokener = new JSONTokener(new FileReader(callableIndexMessageFile));
+        var json = new JSONObject(jsonTokener);
+        var payload = findPayload(json);
+        assertNotNull(payload);
+        assertEquals("mvn", payload.getString("forge"));
+        assertEquals("io.netty", payload.getString("groupId"));
+        assertEquals("netty-codec-http2", payload.getString("artifactId"));
+        assertEquals("4.1.0.Beta5", payload.getString("version"));
+    }
+
+    @Test
+    void findPayloadInPOMAnalyzerMessage() throws IOException {
+        var callableIndexMessageFile = TestUtils.getTestResource("pom-analyzer-message.json");
+        var jsonTokener = new JSONTokener(new FileReader(callableIndexMessageFile));
+        var json = new JSONObject(jsonTokener);
+        var payload = findPayload(json);
+        assertNotNull(payload);
+        assertEquals("mvn", payload.getString("forge"));
+        assertEquals("io.netty", payload.getString("groupId"));
+        assertEquals("netty-codec-http2", payload.getString("artifactId"));
+        assertEquals("4.1.0.Beta5", payload.getString("version"));
+    }
+}

--- a/analyzer/vulnerability-packages-listener/src/test/resources/callable-index-message.json
+++ b/analyzer/vulnerability-packages-listener/src/test/resources/callable-index-message.json
@@ -1,0 +1,14 @@
+{
+  "input": {
+    "input": {
+      "input": {
+        "payload" : {
+          "groupId": "io.netty",
+          "version": "4.1.0.Beta5",
+          "forge": "mvn",
+          "artifactId": "netty-codec-http2"
+        }
+      }
+    }
+  }
+}

--- a/analyzer/vulnerability-packages-listener/src/test/resources/pom-analyzer-message.json
+++ b/analyzer/vulnerability-packages-listener/src/test/resources/pom-analyzer-message.json
@@ -1,0 +1,10 @@
+{
+  "input": {
+    "payload": {
+      "groupId": "io.netty",
+      "version": "4.1.0.Beta5",
+      "forge": "mvn",
+      "artifactId": "netty-codec-http2"
+    }
+  }
+}

--- a/analyzer/vulnerability-packages-listener/src/test/resources/real-callable-index-message.json
+++ b/analyzer/vulnerability-packages-listener/src/test/resources/real-callable-index-message.json
@@ -1,0 +1,214 @@
+{
+  "input": {
+    "input": {
+      "input": {
+        "input": {
+          "groupId": "org.apache.pdfbox",
+          "artifactId": "pdfbox",
+          "version": "2.0.8"
+        },
+        "plugin_version": "0.1.2",
+        "consumed_at": 1637247842,
+        "payload": {
+          "date": 1509388371000,
+          "repoUrl": "",
+          "groupId": "org.apache.pdfbox",
+          "version": "2.0.8",
+          "parentCoordinate": "org.apache.pdfbox:pdfbox-parent:2.0.8",
+          "artifactRepository": "https://repo.maven.apache.org/maven2/",
+          "forge": "mvn",
+          "sourcesUrl": "https://repo.maven.apache.org/maven2/org/apache/pdfbox/pdfbox/2.0.8/pdfbox-2.0.8-sources.jar",
+          "artifactId": "pdfbox",
+          "dependencyData": {
+            "dependencyManagement": {
+              "dependencies": []
+            },
+            "dependencies": [
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "2.0.8",
+                    "lowerBound": "2.0.8"
+                  }
+                ],
+                "groupId": "org.apache.pdfbox",
+                "scope": "",
+                "classifier": "",
+                "artifactId": "fontbox",
+                "exclusions": [],
+                "optional": false,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "1.2",
+                    "lowerBound": "1.2"
+                  }
+                ],
+                "groupId": "commons-logging",
+                "scope": "",
+                "classifier": "",
+                "artifactId": "commons-logging",
+                "exclusions": [],
+                "optional": false,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "1.54",
+                    "lowerBound": "1.54"
+                  }
+                ],
+                "groupId": "org.bouncycastle",
+                "scope": "",
+                "classifier": "",
+                "artifactId": "bcmail-jdk15on",
+                "exclusions": [],
+                "optional": true,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "1.54",
+                    "lowerBound": "1.54"
+                  }
+                ],
+                "groupId": "org.bouncycastle",
+                "scope": "",
+                "classifier": "",
+                "artifactId": "bcprov-jdk15on",
+                "exclusions": [],
+                "optional": true,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "4.12",
+                    "lowerBound": "4.12"
+                  }
+                ],
+                "groupId": "junit",
+                "scope": "test",
+                "classifier": "",
+                "artifactId": "junit",
+                "exclusions": [],
+                "optional": false,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "1.3.0",
+                    "lowerBound": "1.3.0"
+                  }
+                ],
+                "groupId": "com.googlecode.java-diff-utils",
+                "scope": "test",
+                "classifier": "",
+                "artifactId": "diffutils",
+                "exclusions": [],
+                "optional": false,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "1.6.5",
+                    "lowerBound": "1.6.5"
+                  }
+                ],
+                "groupId": "com.levigo.jbig2",
+                "scope": "test",
+                "classifier": "",
+                "artifactId": "levigo-jbig2-imageio",
+                "exclusions": [],
+                "optional": false,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "1.3.1",
+                    "lowerBound": "1.3.1"
+                  }
+                ],
+                "groupId": "com.github.jai-imageio",
+                "scope": "test",
+                "classifier": "",
+                "artifactId": "jai-imageio-core",
+                "exclusions": [],
+                "optional": false,
+                "type": ""
+              },
+              {
+                "versionConstraints": [
+                  {
+                    "isUpperHardRequirement": false,
+                    "isLowerHardRequirement": false,
+                    "upperBound": "1.3.0",
+                    "lowerBound": "1.3.0"
+                  }
+                ],
+                "groupId": "com.github.jai-imageio",
+                "scope": "test",
+                "classifier": "",
+                "artifactId": "jai-imageio-jpeg2000",
+                "exclusions": [],
+                "optional": false,
+                "type": ""
+              }
+            ]
+          },
+          "projectName": "Apache PDFBox",
+          "commitTag": "",
+          "packagingType": "bundle"
+        },
+        "host": "48936e40e4be",
+        "created_at": 1637247843,
+        "plugin_name": "POMAnalyzer"
+      },
+      "plugin_version": "0.1.2",
+      "consumed_at": 1637247878,
+      "payload": {
+        "dir": "/mnt/fasten/revision-callgraphs/mvn/p/pdfbox/pdfbox_org.apache.pdfbox_2.0.8.json"
+      },
+      "host": "d9bb4ee8f13b",
+      "created_at": 1637247881,
+      "plugin_name": "OPAL"
+    },
+    "plugin_version": "0.1.2",
+    "consumed_at": 1637247893,
+    "payload": {
+      "dir": "/mnt/fasten/global-callgraphs/mvn/p/org.apache.pdfbox/pdfbox_org.apache.pdfbox_2.0.8.json"
+    },
+    "host": "e38a3015f1e4",
+    "created_at": 1637247896,
+    "plugin_name": "MetadataDBJavaExtension"
+  },
+  "plugin_version": "0.0.1",
+  "consumed_at": 1637247896,
+  "payload": "",
+  "host": "84dc68cb50db",
+  "created_at": 1637247897,
+  "plugin_name": "CallableIndexFastenPlugin"
+}

--- a/analyzer/vulnerability-packages-listener/src/test/resources/real-pom-analyzer-message.json
+++ b/analyzer/vulnerability-packages-listener/src/test/resources/real-pom-analyzer-message.json
@@ -1,0 +1,186 @@
+{
+  "input": {
+    "groupId": "org.apache.pdfbox",
+    "artifactId": "pdfbox",
+    "version": "2.0.8"
+  },
+  "plugin_version": "0.1.2",
+  "consumed_at": 1637269420,
+  "payload": {
+    "date": 1509388371000,
+    "repoUrl": "",
+    "groupId": "org.apache.pdfbox",
+    "version": "2.0.8",
+    "parentCoordinate": "org.apache.pdfbox:pdfbox-parent:2.0.8",
+    "artifactRepository": "https://repo.maven.apache.org/maven2/",
+    "forge": "mvn",
+    "sourcesUrl": "https://repo.maven.apache.org/maven2/org/apache/pdfbox/pdfbox/2.0.8/pdfbox-2.0.8-sources.jar",
+    "artifactId": "pdfbox",
+    "dependencyData": {
+      "dependencyManagement": {
+        "dependencies": []
+      },
+      "dependencies": [
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "2.0.8",
+              "lowerBound": "2.0.8"
+            }
+          ],
+          "groupId": "org.apache.pdfbox",
+          "scope": "",
+          "classifier": "",
+          "artifactId": "fontbox",
+          "exclusions": [],
+          "optional": false,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "1.2",
+              "lowerBound": "1.2"
+            }
+          ],
+          "groupId": "commons-logging",
+          "scope": "",
+          "classifier": "",
+          "artifactId": "commons-logging",
+          "exclusions": [],
+          "optional": false,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "1.54",
+              "lowerBound": "1.54"
+            }
+          ],
+          "groupId": "org.bouncycastle",
+          "scope": "",
+          "classifier": "",
+          "artifactId": "bcmail-jdk15on",
+          "exclusions": [],
+          "optional": true,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "1.54",
+              "lowerBound": "1.54"
+            }
+          ],
+          "groupId": "org.bouncycastle",
+          "scope": "",
+          "classifier": "",
+          "artifactId": "bcprov-jdk15on",
+          "exclusions": [],
+          "optional": true,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "4.12",
+              "lowerBound": "4.12"
+            }
+          ],
+          "groupId": "junit",
+          "scope": "test",
+          "classifier": "",
+          "artifactId": "junit",
+          "exclusions": [],
+          "optional": false,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "1.3.0",
+              "lowerBound": "1.3.0"
+            }
+          ],
+          "groupId": "com.googlecode.java-diff-utils",
+          "scope": "test",
+          "classifier": "",
+          "artifactId": "diffutils",
+          "exclusions": [],
+          "optional": false,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "1.6.5",
+              "lowerBound": "1.6.5"
+            }
+          ],
+          "groupId": "com.levigo.jbig2",
+          "scope": "test",
+          "classifier": "",
+          "artifactId": "levigo-jbig2-imageio",
+          "exclusions": [],
+          "optional": false,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "1.3.1",
+              "lowerBound": "1.3.1"
+            }
+          ],
+          "groupId": "com.github.jai-imageio",
+          "scope": "test",
+          "classifier": "",
+          "artifactId": "jai-imageio-core",
+          "exclusions": [],
+          "optional": false,
+          "type": ""
+        },
+        {
+          "versionConstraints": [
+            {
+              "isUpperHardRequirement": false,
+              "isLowerHardRequirement": false,
+              "upperBound": "1.3.0",
+              "lowerBound": "1.3.0"
+            }
+          ],
+          "groupId": "com.github.jai-imageio",
+          "scope": "test",
+          "classifier": "",
+          "artifactId": "jai-imageio-jpeg2000",
+          "exclusions": [],
+          "optional": false,
+          "type": ""
+        }
+      ]
+    },
+    "projectName": "Apache PDFBox",
+    "commitTag": "",
+    "packagingType": "bundle"
+  },
+  "host": "48936e40e4be",
+  "created_at": 1637269421,
+  "plugin_name": "POMAnalyzer"
+}

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -241,7 +241,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             var firstPatchedVersionId = findFirstPatchedVersionId(v, pkgIds, context);
             var fastenUris = new HashSet<String>();
             v.getPatches().forEach(p -> {
-                logger.info(v.getId() + v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
+                logger.info(v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
                 fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
                         p.getNewChangedLineNumbers(),
                         firstPatchedVersionId, context));

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -47,7 +47,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         private String outputPath;
         private static Map<String, DSLContext> contexts;
         private Exception pluginError = null;
-        private String lastProcessedVulnerability = null;
+        private Vulnerability lastProcessedVulnerability = null;
         private final Gson gson = new Gson();
         public final static String[] extensions = new String[]{".java", ".py", ".pyw", ".c", ".cpp", ".h"};
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityStatementsKafkaPlugin");
@@ -74,7 +74,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 var vulnerability = gson.fromJson(record, Vulnerability.class);
                 logger.info("Read vulnerability statement " + vulnerability.getId() + " from " + consumeTopics.toString());
                 var metadataUtility = new MetadataUtility();
-                lastProcessedVulnerability = injectVulnerabilityIntoDB(vulnerability, metadataUtility);
+                lastProcessedVulnerability = insertVulnerability(vulnerability, metadataUtility);
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
             } catch (Exception e) {
                 logger.error("Error processing vulnerability statement: " + e);
@@ -87,7 +87,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             if (lastProcessedVulnerability == null) {
                 return Optional.empty();
             } else {
-                return Optional.of(lastProcessedVulnerability);
+                return Optional.of(gson.toJson(lastProcessedVulnerability));
             }
         }
 
@@ -139,12 +139,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
          * @param v               - Vulnerability Object
          * @param metadataUtility - Metadata DAO
          */
-        public String injectVulnerabilityIntoDB(Vulnerability v, MetadataUtility metadataUtility)  {
-            var ecosystem = v.getEcosystem();
-            var context = ecosystem.equals("") ? null : contexts.get(ecosystem);
-            if (context == null) {
-                throw new UnsupportedOperationException(v.getId() + ": Malformed ecosystem data or unsupported ecosystem \"" + ecosystem + "\"");
-            }
+        public Vulnerability insertVulnerability(Vulnerability v, MetadataUtility metadataUtility)  {
+            var context = getDBContext(v);
 
             v.filterUnsupportedPatches(extensions);
             try {
@@ -153,19 +149,24 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 logger.warn(v.getId() + ": Error updating patch date, continuing: " + e);
             }
 
-            logger.info(v.getId() + ": Inserting vulnerability into the database for ecosystem " + "\"" + ecosystem + "\".");
+            logger.info(v.getId() + ": Inserting vulnerability into the database for ecosystem " + "\"" + v.getEcosystem() + "\".");
             var vulnerabilityId = metadataUtility.insertVulnerability(v, context);
+            v = updateCallablesAndPackageVersions(v, vulnerabilityId, metadataUtility);
+            return v;
+        }
 
+        public Vulnerability updateCallablesAndPackageVersions(Vulnerability v, Long vulnerabilityId, MetadataUtility metadataUtility) {
+            var context = getDBContext(v);
             var pkgIds = metadataUtility.getPackageIds(context, v.getValidatedPurls());
             if (pkgIds.size() == 0) {
                 logger.info(v.getId() + ": No matching packages found in database.");
-                return gson.toJson(v);
+                return v;
             }
 
             var vulnerablePackageVersionIds = metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v);
             if (vulnerablePackageVersionIds.size() == 0) {
                 logger.info(v.getId() + ": No matching package-versions found in database.");
-                return gson.toJson(v);
+                return v;
             }
 
             var vulnerableFastenUris = new HashSet<String>();
@@ -175,15 +176,23 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             var vulnerableCallableIds = vulnerableCallables.keySet();
             v.setFastenUris(new HashSet<>(vulnerableCallables.values()));
 
-            logger.info(v.getId() + ": Inserting data for " + vulnerableCallableIds.size() + " vulnerable callables into the database.");
-            vulnerableCallableIds.forEach(id -> metadataUtility.injectCallableVulnerability(v, id, context));
-            metadataUtility.insertVulnerabilityToCallables(vulnerabilityId, vulnerableCallableIds, context);
-
             logger.info(v.getId() + ": Inserting data for " + vulnerablePackageVersionIds.size() + " vulnerable package-versions into the database.");
             vulnerablePackageVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(v, id, context));
             metadataUtility.insertVulnerabilityToPackageVersions(vulnerabilityId, vulnerablePackageVersionIds, context);
 
-            return gson.toJson(v);
+            logger.info(v.getId() + ": Inserting data for " + vulnerableCallableIds.size() + " vulnerable callables into the database.");
+            vulnerableCallableIds.forEach(id -> metadataUtility.injectCallableVulnerability(v, id, context));
+            metadataUtility.insertVulnerabilityToCallables(vulnerabilityId, vulnerableCallableIds, context);
+            return v;
+        }
+
+        public DSLContext getDBContext(Vulnerability v) {
+            var ecosystem = v.getEcosystem();
+            var context = ecosystem.equals("") ? null : contexts.get(ecosystem);
+            if (context == null) {
+                throw new UnsupportedOperationException(v.getId() + ": Malformed ecosystem data or unsupported ecosystem \"" + ecosystem + "\"");
+            }
+            return context;
         }
 
         HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, List<Long> pkgVersionVulnIds, MetadataUtility metadataUtility, DSLContext context) {

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -20,9 +20,11 @@ package eu.fasten.analyzer.vulnerabilitystatementsprocessor;
 
 import com.google.gson.Gson;
 import eu.fasten.analyzer.vulnerabilitystatementsprocessor.db.MetadataUtility;
+import eu.fasten.core.data.vulnerability.Purl;
 import eu.fasten.core.data.vulnerability.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jooq.DSLContext;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -32,7 +34,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.text.ParseException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class VulnerabilityStatementsProcessor extends Plugin {
 
@@ -49,6 +59,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         private Exception pluginError = null;
         private Vulnerability lastProcessedVulnerability = null;
         private final Gson gson = new Gson();
+        private MetadataUtility metadataUtility;
         public final static String[] extensions = new String[]{".java", ".py", ".pyw", ".c", ".cpp", ".h"};
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityStatementsKafkaPlugin");
 
@@ -73,9 +84,10 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             try {
                 var vulnerability = gson.fromJson(record, Vulnerability.class);
                 logger.info("Read vulnerability statement " + vulnerability.getId() + " from " + consumeTopics.toString());
-                var metadataUtility = new MetadataUtility();
-                lastProcessedVulnerability = insertVulnerability(vulnerability, metadataUtility);
+                refreshMetadataUtility();
+                insertVulnerability(vulnerability);
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
+                lastProcessedVulnerability = vulnerability;
             } catch (Exception e) {
                 logger.error("Error processing vulnerability statement: " + e);
                 setPluginError(e);
@@ -133,13 +145,20 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         public void freeResource() {
         }
 
+        public void refreshMetadataUtility() {
+            metadataUtility = new MetadataUtility();
+        }
+
+        public void setMetadataUtility(MetadataUtility metadataUtility) {
+            this.metadataUtility = metadataUtility;
+        }
+
         /**
          * Method to inject the information contained in a Vulnerability Object.
          *
          * @param v               - Vulnerability Object
-         * @param metadataUtility - Metadata DAO
          */
-        public Vulnerability insertVulnerability(Vulnerability v, MetadataUtility metadataUtility)  {
+        public void insertVulnerability(Vulnerability v)  {
             var context = getDBContext(v);
 
             v.filterUnsupportedPatches(extensions);
@@ -150,32 +169,44 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
 
             logger.info(v.getId() + ": Inserting vulnerability into the database for ecosystem " + "\"" + v.getEcosystem() + "\".");
-            var vulnerabilityId = metadataUtility.insertVulnerability(v, context);
-            v = updateCallablesAndPackageVersions(v, vulnerabilityId, metadataUtility);
-            return v;
+            metadataUtility.insertVulnerability(v, context);
+            updateCallablesAndPackageVersions(v);
         }
 
-        public Vulnerability updateCallablesAndPackageVersions(Vulnerability v, Long vulnerabilityId, MetadataUtility metadataUtility) {
+        public void updateCallablesAndPackageVersions(Vulnerability v) {
+            updateCallablesAndPackageVersions(v, v.getValidatedPurls());
+        }
+
+        public void updateCallablesAndPackageVersions(Vulnerability v, String packageName, ComparableVersion version) {
+            var purls = v.getValidatedPurls().stream()
+                    .filter(purl -> purl.getPackageName().equals(packageName) && purl.getVersion().equals(version))
+                    .collect(Collectors.toList());
+            updateCallablesAndPackageVersions(v, new LinkedHashSet<>(purls));
+        }
+
+        public void updateCallablesAndPackageVersions(Vulnerability v, LinkedHashSet<Purl> purls) {
             var context = getDBContext(v);
-            var pkgIds = metadataUtility.getPackageIds(context, v.getValidatedPurls());
+            var pkgIds = metadataUtility.getPackageIds(context, purls);
             if (pkgIds.size() == 0) {
                 logger.info(v.getId() + ": No matching packages found in database.");
-                return v;
+                return;
             }
 
-            var vulnerablePackageVersionIds = metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v);
+            var vulnerablePackageVersionIds = metadataUtility.getPackageVersionIds(purls, context, pkgIds, v);
             if (vulnerablePackageVersionIds.size() == 0) {
                 logger.info(v.getId() + ": No matching package-versions found in database.");
-                return v;
+                return;
             }
 
             var vulnerableFastenUris = new HashSet<String>();
-            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(v, vulnerablePackageVersionIds, metadataUtility, context));
-            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(v, pkgIds, metadataUtility, context));
-            var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds, metadataUtility, context);
+            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(v, vulnerablePackageVersionIds, context));
+            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(v, pkgIds, context));
+            var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds, context);
             var vulnerableCallableIds = vulnerableCallables.keySet();
             v.setFastenUris(new HashSet<>(vulnerableCallables.values()));
 
+
+            var vulnerabilityId = metadataUtility.getVulnerabilityId(v.getId(), context);
             logger.info(v.getId() + ": Inserting data for " + vulnerablePackageVersionIds.size() + " vulnerable package-versions into the database.");
             vulnerablePackageVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(v, id, context));
             metadataUtility.insertVulnerabilityToPackageVersions(vulnerabilityId, vulnerablePackageVersionIds, context);
@@ -183,7 +214,6 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             logger.info(v.getId() + ": Inserting data for " + vulnerableCallableIds.size() + " vulnerable callables into the database.");
             vulnerableCallableIds.forEach(id -> metadataUtility.injectCallableVulnerability(v, id, context));
             metadataUtility.insertVulnerabilityToCallables(vulnerabilityId, vulnerableCallableIds, context);
-            return v;
         }
 
         public DSLContext getDBContext(Vulnerability v) {
@@ -195,7 +225,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return context;
         }
 
-        HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, List<Long> pkgVersionVulnIds, MetadataUtility metadataUtility, DSLContext context) {
+        private HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, List<Long> pkgVersionVulnIds, DSLContext context) {
             var lastVulnVersionId = pkgVersionVulnIds.get(pkgVersionVulnIds.size() - 1);
             var fastenUris = new HashSet<String>();
             v.getPatches().forEach(p -> {
@@ -207,8 +237,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return fastenUris;
         }
 
-        HashSet<String> findFastenUrisInFirstPatchedVersion(Vulnerability v, HashMap<String, Long> pkgIds, MetadataUtility metadataUtility, DSLContext context) {
-            var firstPatchedVersionId = findFirstPatchedVersionId(v, pkgIds, metadataUtility, context);
+        private HashSet<String> findFastenUrisInFirstPatchedVersion(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {
+            var firstPatchedVersionId = findFirstPatchedVersionId(v, pkgIds, context);
             var fastenUris = new HashSet<String>();
             v.getPatches().forEach(p -> {
                 logger.info(v.getId() + v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
@@ -219,7 +249,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return fastenUris;
         }
 
-        Long findFirstPatchedVersionId(Vulnerability v, HashMap<String, Long> pkgIds, MetadataUtility metadataUtility, DSLContext context) {
+        private Long findFirstPatchedVersionId(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {
             var pkgVersionPatchedIds = metadataUtility.getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds, null);
             if (pkgVersionPatchedIds.size() > 0) {
                 return pkgVersionPatchedIds.get(pkgVersionPatchedIds.size() - 1);
@@ -228,7 +258,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
         }
 
-        HashMap<Long, String> findVulnerableCallables(HashSet<String> vulnerableFastenUris, List<Long> vulnPkgVersionIds, MetadataUtility metadataUtility, DSLContext context) {
+        private HashMap<Long, String> findVulnerableCallables(HashSet<String> vulnerableFastenUris, List<Long> vulnPkgVersionIds, DSLContext context) {
             var vulnerableCallables = new HashMap<Long, String>();
             vulnerableFastenUris.forEach(uri -> {
                 var callIds = metadataUtility.getCallableIdsForFastenUri(uri, new HashSet<>(vulnPkgVersionIds), context);

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
@@ -467,4 +467,23 @@ public class MetadataUtility {
             return null;
         }
     }
+
+    /**
+     * Returns vulnerability statement given id
+     *
+     * @param externalId - external id of the vulnerability, eg. CVE-2019-1234
+     * @return Id of the vulnerability in the DB
+     */
+    public Long getVulnerabilityId(String externalId, DSLContext context) {
+        var pkgRecord = context.select(Vulnerabilities.VULNERABILITIES.ID)
+                .from(Vulnerabilities.VULNERABILITIES)
+                .where(Vulnerabilities.VULNERABILITIES.EXTERNAL_ID.equal(externalId))
+                .fetchOne();
+        if (pkgRecord != null) {
+            return pkgRecord.component1();
+        }
+        else {
+            return null;
+        }
+    }
 }

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -86,7 +86,7 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        kafkaPlugin.injectVulnerabilityIntoDB(v, metadataUtility);
+        kafkaPlugin.insertVulnerability(v, metadataUtility);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
@@ -184,7 +184,7 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        kafkaPlugin.injectVulnerabilityIntoDB(v, metadataUtility);
+        kafkaPlugin.insertVulnerability(v, metadataUtility);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -67,7 +67,7 @@ public class VulnerabilityStatementsProcessorTest {
         v.setPatches(new HashSet<>(Collections.singletonList(patch)));
 
         var metadataUtility = Mockito.mock(MetadataUtility.class);
-
+        kafkaPlugin.setMetadataUtility(metadataUtility);
         // MOCKITO WHEN
         var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
         when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(LinkedHashSet.class))).thenReturn(pkgIds);
@@ -86,7 +86,7 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        kafkaPlugin.insertVulnerability(v, metadataUtility);
+        kafkaPlugin.insertVulnerability(v);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
@@ -161,6 +161,7 @@ public class VulnerabilityStatementsProcessorTest {
         v.setPatches(new HashSet<>(Collections.singletonList(patch)));
 
         var metadataUtility = Mockito.mock(MetadataUtility.class);
+        kafkaPlugin.setMetadataUtility(metadataUtility);
 
         // MOCKITO WHEN
         var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
@@ -184,7 +185,7 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        kafkaPlugin.insertVulnerability(v, metadataUtility);
+        kafkaPlugin.insertVulnerability(v);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());


### PR DESCRIPTION
## Description

Vulnerability packages listener can be pointed to several topics. This is useful for package-versions that are processed by eg. POM Analyzer correctly, but not OPAL. That can happen if artefacts (JARs) are missing on Maven central. But we would still like to have package-version level vulnerability info.

## Testing
Added some unit tests.
Ran with Main methods.
Ran in local docker deployment.