### PR TITLE
Callable insertion fixes, request last vulnerable version from API

### DIFF
--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -21,11 +21,11 @@ package eu.fasten.analyzer.vulnerabilitypackageslistener;
 import com.google.gson.Gson;
 import eu.fasten.analyzer.vulnerabilitystatementsprocessor.VulnerabilityStatementsProcessor;
 import eu.fasten.analyzer.vulnerabilitystatementsprocessor.db.MetadataUtility;
+import eu.fasten.analyzer.vulnerabilitystatementsprocessor.utils.FastenApiClient;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.vulnerability.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
-import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jooq.DSLContext;
 import org.json.JSONObject;
 import org.pf4j.Extension;
@@ -42,8 +42,11 @@ import java.util.Optional;
 
 public class VulnerabilityPackagesListener extends Plugin {
 
+    private static VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin statementsProcessor = null;
+
     public VulnerabilityPackagesListener(PluginWrapper wrapper) {
         super(wrapper);
+        statementsProcessor = new VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin();
     }
 
     @Extension
@@ -54,8 +57,8 @@ public class VulnerabilityPackagesListener extends Plugin {
         private Exception pluginError = null;
         private final Gson gson = new Gson();
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityPackagesKafkaPlugin");
-        private final VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin statementsProcessor = new VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin();
         private MetadataUtility metadataUtility;
+        private final FastenApiClient fastenApiClient = new FastenApiClient();
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
@@ -80,10 +83,6 @@ public class VulnerabilityPackagesListener extends Plugin {
 
         @Override
         public void start() {
-            var fastenApiUrl = System.getenv("FASTEN_API_URL");
-            if (fastenApiUrl != null) {
-                statementsProcessor.setFastenApi(fastenApiUrl);
-            }
         }
 
         @Override
@@ -120,6 +119,7 @@ public class VulnerabilityPackagesListener extends Plugin {
             try {
                 refreshMetadataUtility();
                 statementsProcessor.setMetadataUtility(metadataUtility);
+                statementsProcessor.setFastenApiClient(fastenApiClient);
                 var jsonRecord = new JSONObject(record);
                 var payload = findPayload(jsonRecord);
                 if(payload != null) {

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -80,6 +80,10 @@ public class VulnerabilityPackagesListener extends Plugin {
 
         @Override
         public void start() {
+            var fastenApiUrl = System.getenv("FASTEN_API_URL");
+            if (fastenApiUrl != null) {
+                statementsProcessor.setFastenApi(fastenApiUrl);
+            }
         }
 
         @Override

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/Main.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/Main.java
@@ -72,6 +72,10 @@ public class Main implements Runnable {
                     PostgresConnector.getDSLContext(dbUrls.get(forge), dbUser, true));
             }
             kafkaPlugin.setDBConnection(contexts);
+            var fastenApiUrl = System.getenv("FASTEN_API_URL");
+            if (fastenApiUrl != null) {
+                kafkaPlugin.setFastenApi(fastenApiUrl);
+            }
             var reader = new FileReader(inputFile);
             final var vulnsJson = new JSONArray(new JSONTokener(reader));
             vulnsJson.forEach(v -> kafkaPlugin.consume(v.toString()));

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/Main.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/Main.java
@@ -72,10 +72,6 @@ public class Main implements Runnable {
                     PostgresConnector.getDSLContext(dbUrls.get(forge), dbUser, true));
             }
             kafkaPlugin.setDBConnection(contexts);
-            var fastenApiUrl = System.getenv("FASTEN_API_URL");
-            if (fastenApiUrl != null) {
-                kafkaPlugin.setFastenApi(fastenApiUrl);
-            }
             var reader = new FileReader(inputFile);
             final var vulnsJson = new JSONArray(new JSONTokener(reader));
             vulnsJson.forEach(v -> kafkaPlugin.consume(v.toString()));

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -60,7 +60,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         private MetadataUtility metadataUtility;
         public final static String[] extensions = new String[]{".java", ".py", ".pyw", ".c", ".cpp", ".h"};
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityStatementsKafkaPlugin");
-        private FastenApiClient fastenApi = null;
+        private FastenApiClient fastenApiClient = new FastenApiClient();
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
@@ -125,10 +125,6 @@ public class VulnerabilityStatementsProcessor extends Plugin {
 
         @Override
         public void start() {
-            var fastenApiUrl = System.getenv("FASTEN_API_URL");
-            if (fastenApiUrl != null) {
-                setFastenApi(fastenApiUrl);
-            }
         }
 
         @Override
@@ -156,8 +152,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             this.metadataUtility = metadataUtility;
         }
 
-        public void setFastenApi(String fastenApiUrl) {
-            fastenApi = new FastenApiClient(fastenApiUrl);
+        public void setFastenApiClient(FastenApiClient client) {
+            this.fastenApiClient = client;
         }
 
         /**
@@ -235,7 +231,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
             else {
                 logger.info(v.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl + ", skipping callables.");
-                if(fastenApi != null) {
+                if(fastenApiClient.getApiUrl() != null) {
                     requestPurlIngestion(v, lastVulnerablePurl);
                 }
             }
@@ -245,13 +241,13 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         private void requestPurlIngestion(Vulnerability v, Purl p) {
             try {
                 logger.info(v.getId() + ": calling FASTEN API to ingest package-version for purl: " + p);
-                var response = fastenApi.requestPackageVersion(v.getEcosystem(), p.getPackageName(), p.getVersion().toString());
+                var response = fastenApiClient.requestPackageVersion(v.getEcosystem(), p.getPackageName(), p.getVersion().toString());
                 var code = response.statusCode();
                 if(code != 201) {
                     logger.warn(v.getId() + ": unexpected response " + code + " to ingest request for purl" + p);
                 }
             } catch (Exception e) {
-                logger.warn(v.getId() + ": there was a problem calling FASTEN API for purl" + p + " : " + e);
+                logger.warn(v.getId() + ": there was a problem calling FASTEN API for purl " + p + " : " + e);
             }
         }
 

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -24,7 +24,6 @@ import eu.fasten.core.data.vulnerability.Purl;
 import eu.fasten.core.data.vulnerability.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
-import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jooq.DSLContext;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -37,12 +36,10 @@ import java.text.ParseException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class VulnerabilityStatementsProcessor extends Plugin {
 
@@ -174,18 +171,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         }
 
         public void updateCallablesAndPackageVersions(Vulnerability v) {
-            updateCallablesAndPackageVersions(v, v.getValidatedPurls());
-        }
-
-        public void updateCallablesAndPackageVersions(Vulnerability v, String packageName, ComparableVersion version) {
-            var purls = v.getValidatedPurls().stream()
-                    .filter(purl -> purl.getPackageName().equals(packageName) && purl.getVersion().equals(version))
-                    .collect(Collectors.toList());
-            updateCallablesAndPackageVersions(v, new LinkedHashSet<>(purls));
-        }
-
-        public void updateCallablesAndPackageVersions(Vulnerability v, LinkedHashSet<Purl> purls) {
             var context = getDBContext(v);
+            var purls = v.getValidatedPurls();
             var pkgIds = metadataUtility.getPackageIds(context, purls);
             if (pkgIds.size() == 0) {
                 logger.info(v.getId() + ": No matching packages found in database.");
@@ -199,7 +186,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
 
             var vulnerableFastenUris = new HashSet<String>();
-            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(v, vulnerablePackageVersionIds, context));
+            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(v, pkgIds, context));
             vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(v, pkgIds, context));
             var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds, context);
             var vulnerableCallableIds = vulnerableCallables.keySet();
@@ -225,37 +212,64 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return context;
         }
 
-        private HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, List<Long> pkgVersionVulnIds, DSLContext context) {
-            var lastVulnVersionId = pkgVersionVulnIds.get(pkgVersionVulnIds.size() - 1);
+        private HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {
+            var lastVulnerablePurl = getLastVulnerablePurl(v);
+            var lastVulnVersionId = findIdForPurl(lastVulnerablePurl, pkgIds, context);
             var fastenUris = new HashSet<String>();
-            v.getPatches().forEach(p -> {
-                logger.info(v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + lastVulnVersionId);
-                fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
-                        p.getOriginalChangedLineNumbers(),
-                        lastVulnVersionId, context));
-            });
+            if(lastVulnVersionId != -1L) {
+                v.getPatches().forEach(p -> {
+                    logger.info(v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + lastVulnVersionId);
+                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
+                            p.getOriginalChangedLineNumbers(),
+                            lastVulnVersionId, context));
+                });
+            }
+            else {
+                logger.info(v.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl);
+            }
             return fastenUris;
+        }
+
+        private Purl getLastVulnerablePurl(Vulnerability v) {
+            Purl[] purls = new Purl[v.getValidatedPurls().size()];
+            if (purls.length > 0) {
+                purls = v.getValidatedPurls().toArray(purls);
+                return purls[purls.length - 1];
+            }
+            return null;
         }
 
         private HashSet<String> findFastenUrisInFirstPatchedVersion(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {
-            var firstPatchedVersionId = findFirstPatchedVersionId(v, pkgIds, context);
+            var firstPatchedVersionId = findIdForPurl(getFirstPatchedPurl(v), pkgIds, context);
             var fastenUris = new HashSet<String>();
-            v.getPatches().forEach(p -> {
-                logger.info(v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
-                fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
-                        p.getNewChangedLineNumbers(),
-                        firstPatchedVersionId, context));
-            });
+            if(firstPatchedVersionId != -1L) {
+                v.getPatches().forEach(p -> {
+                    logger.info(v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
+                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
+                            p.getNewChangedLineNumbers(),
+                            firstPatchedVersionId, context));
+                });
+            }
             return fastenUris;
         }
 
-        private Long findFirstPatchedVersionId(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {
-            var pkgVersionPatchedIds = metadataUtility.getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds, null);
-            if (pkgVersionPatchedIds.size() > 0) {
-                return pkgVersionPatchedIds.get(pkgVersionPatchedIds.size() - 1);
-            } else {
-                return -1L;
+        private Purl getFirstPatchedPurl(Vulnerability v) {
+            Purl[] purls = new Purl[v.getValidatedFirstPatchedPurls().size()];
+            if (purls.length > 0) {
+                purls = v.getValidatedFirstPatchedPurls().toArray(purls);
+                return purls[0];
             }
+            return null;
+        }
+
+        private Long findIdForPurl(Purl purl, HashMap<String, Long> pkgIds, DSLContext context) {
+            if (purl != null) {
+                var purlPkdId = pkgIds.get(purl.getPackageName());
+                if(purlPkdId != null) {
+                    return metadataUtility.getPackageVersionId(purl, context, purlPkdId);
+                }
+            }
+            return -1L;
         }
 
         private HashMap<Long, String> findVulnerableCallables(HashSet<String> vulnerableFastenUris, List<Long> vulnPkgVersionIds, DSLContext context) {

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.vulnerabilitystatementsprocessor;
 
 import com.google.gson.Gson;
 import eu.fasten.analyzer.vulnerabilitystatementsprocessor.db.MetadataUtility;
+import eu.fasten.analyzer.vulnerabilitystatementsprocessor.utils.FastenApiClient;
 import eu.fasten.core.data.vulnerability.Purl;
 import eu.fasten.core.data.vulnerability.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
@@ -59,6 +60,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         private MetadataUtility metadataUtility;
         public final static String[] extensions = new String[]{".java", ".py", ".pyw", ".c", ".cpp", ".h"};
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityStatementsKafkaPlugin");
+        private FastenApiClient fastenApi = null;
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
@@ -123,6 +125,10 @@ public class VulnerabilityStatementsProcessor extends Plugin {
 
         @Override
         public void start() {
+            var fastenApiUrl = System.getenv("FASTEN_API_URL");
+            if (fastenApiUrl != null) {
+                setFastenApi(fastenApiUrl);
+            }
         }
 
         @Override
@@ -148,6 +154,10 @@ public class VulnerabilityStatementsProcessor extends Plugin {
 
         public void setMetadataUtility(MetadataUtility metadataUtility) {
             this.metadataUtility = metadataUtility;
+        }
+
+        public void setFastenApi(String fastenApiUrl) {
+            fastenApi = new FastenApiClient(fastenApiUrl);
         }
 
         /**
@@ -179,7 +189,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 return;
             }
 
-            var vulnerablePackageVersionIds = metadataUtility.getPackageVersionIds(purls, context, pkgIds, v);
+            var vulnerablePackageVersionIds = metadataUtility.getPackageVersionIds(purls, context, pkgIds);
             if (vulnerablePackageVersionIds.size() == 0) {
                 logger.info(v.getId() + ": No matching package-versions found in database.");
                 return;
@@ -191,7 +201,6 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds, context);
             var vulnerableCallableIds = vulnerableCallables.keySet();
             v.setFastenUris(new HashSet<>(vulnerableCallables.values()));
-
 
             var vulnerabilityId = metadataUtility.getVulnerabilityId(v.getId(), context);
             logger.info(v.getId() + ": Inserting data for " + vulnerablePackageVersionIds.size() + " vulnerable package-versions into the database.");
@@ -225,18 +234,32 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 });
             }
             else {
-                logger.info(v.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl);
+                logger.info(v.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl + ", skipping callables.");
+                if(fastenApi != null) {
+                    requestPurlIngestion(v, lastVulnerablePurl);
+                }
             }
             return fastenUris;
         }
 
+        private void requestPurlIngestion(Vulnerability v, Purl p) {
+            try {
+                logger.info(v.getId() + ": calling FASTEN API to ingest package-version for purl: " + p);
+                var response = fastenApi.requestPackageVersion(v.getEcosystem(), p.getPackageName(), p.getVersion().toString());
+                var code = response.statusCode();
+                if(code != 201) {
+                    logger.warn(v.getId() + ": unexpected response " + code + " to ingest request for purl" + p);
+                }
+            } catch (Exception e) {
+                logger.warn(v.getId() + ": there was a problem calling FASTEN API for purl" + p + " : " + e);
+            }
+        }
+
         private Purl getLastVulnerablePurl(Vulnerability v) {
             Purl[] purls = new Purl[v.getValidatedPurls().size()];
-            if (purls.length > 0) {
-                purls = v.getValidatedPurls().toArray(purls);
-                return purls[purls.length - 1];
-            }
-            return null;
+            assert purls.length > 0;
+            purls = v.getValidatedPurls().toArray(purls);
+            return purls[purls.length - 1];
         }
 
         private HashSet<String> findFastenUrisInFirstPatchedVersion(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
@@ -88,26 +88,21 @@ public class MetadataUtility {
      * @param purls   - List of PURLS
      * @param context - DSL Context
      * @param pkgIds  - List of package version IDs
-     * @param v - Vulnerability Object to inject PURLs of
      */
     public List<Long> getPackageVersionIds(LinkedHashSet<Purl> purls,
                                            DSLContext context,
-                                           HashMap<String, Long> pkgIds,
-                                           Vulnerability v) {
+                                           HashMap<String, Long> pkgIds) {
         var pkgVersionIds = new ArrayList<Long>();
-        var verifiedPurls = new LinkedHashSet<String>();
         for (var purl : purls) {
             var pkgId = pkgIds.get(purl.getPackageName());
             var pkgVersionId = getPackageVersionId(purl, context, pkgId);
             if (pkgVersionId > 0L) {
-                verifiedPurls.add(purl.toString());
                 pkgVersionIds.add(pkgVersionId);
                 cache.pkgVsnToName.put(purl.getVersion(), cache.pkgIdToName.get(pkgId));
                 cache.pkgNameToForge.put(cache.pkgIdToName.get(pkgId), purl.getType());
                 cache.pkgVsnIdToVsn.put(pkgVersionId, purl.getVersion());
             }
         }
-        if (v != null)  v.setPurls(verifiedPurls);
         return pkgVersionIds;
     }
 

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/utils/FastenApiClient.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/utils/FastenApiClient.java
@@ -1,0 +1,44 @@
+package eu.fasten.analyzer.vulnerabilitystatementsprocessor.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public class FastenApiClient {
+    private final String fastenApiUrl;
+    private final static Logger logger = LoggerFactory.getLogger("FastenApiClient");
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+            .version(HttpClient.Version.HTTP_2)
+            .build();
+
+    public FastenApiClient() {
+        this.fastenApiUrl = System.getenv("FASTEN_API_URL");
+    }
+
+    public FastenApiClient(String fastenApiUrl) {
+        this.fastenApiUrl = fastenApiUrl;
+    }
+
+    public HttpResponse<String> requestPackageVersion(String forge, String packageName, String version) throws URISyntaxException, IOException, InterruptedException {
+        var uri = new URI(fastenApiUrl + forge + "/packages/" + packageName + "/" + version);
+        return get(uri);
+    }
+
+    private HttpResponse<String> get(URI uri) throws IOException, InterruptedException {
+        logger.info("Sending GET request to: " + uri);
+        var builder = HttpRequest.newBuilder()
+                .GET()
+                .uri(uri)
+                .timeout(Duration.ofSeconds(5));
+
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/utils/FastenApiClient.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/utils/FastenApiClient.java
@@ -27,6 +27,10 @@ public class FastenApiClient {
         this.fastenApiUrl = fastenApiUrl;
     }
 
+    public String getApiUrl() {
+        return fastenApiUrl;
+    }
+
     public HttpResponse<String> requestPackageVersion(String forge, String packageName, String version) throws URISyntaxException, IOException, InterruptedException {
         var uri = new URI(fastenApiUrl + forge + "/packages/" + packageName + "/" + version);
         return get(uri);

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -22,6 +22,7 @@ import eu.fasten.analyzer.vulnerabilitystatementsprocessor.VulnerabilityStatemen
 import eu.fasten.analyzer.vulnerabilitystatementsprocessor.db.MetadataUtility;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.vulnerability.Patch;
+import eu.fasten.core.data.vulnerability.Purl;
 import eu.fasten.core.data.vulnerability.Severity;
 import eu.fasten.core.data.vulnerability.Vulnerability;
 import org.jooq.DSLContext;
@@ -58,7 +59,8 @@ public class VulnerabilityStatementsProcessorTest {
         v.setScoreCVSS3(5.0);
         v.setPublishedDate("12-11-2019");
         v.setLastModifiedDate("08-31-2020");
-        v.addPurl("pkg:maven/org.testing/mock@1.0.1");
+        var lastVulnerablePurl = Purl.of("pkg:maven/org.testing/mock@1.0.1");
+        v.addPurl(lastVulnerablePurl.toString());
         var patch = new Patch();
         patch.setPatchDate("04-04-2004");
         patch.setNewChangedLineNumbers(Collections.singletonList(33));
@@ -69,10 +71,10 @@ public class VulnerabilityStatementsProcessorTest {
         var metadataUtility = Mockito.mock(MetadataUtility.class);
         kafkaPlugin.setMetadataUtility(metadataUtility);
         // MOCKITO WHEN
-        var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
+        var pkgIds = new HashMap<String, Long>(); pkgIds.put("org.testing:mock", 1L);
         when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(LinkedHashSet.class))).thenReturn(pkgIds);
+        when(metadataUtility.getPackageVersionId(Mockito.eq(lastVulnerablePurl), Mockito.any(DSLContext.class), Mockito.eq(1L))).thenReturn(1L);
         when(metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v)).thenReturn(Collections.singletonList(1L));
-        when(metadataUtility.getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds, null)).thenReturn(new ArrayList<>());
 
         var fasten_uri = "/java/net/GenericClass.%3Cclinit%3E()%2Fjava.lang%2FVoidType";
         var fastenUris = new HashSet<>(Collections.singletonList(fasten_uri));
@@ -90,8 +92,8 @@ public class VulnerabilityStatementsProcessorTest {
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
+        Mockito.verify(metadataUtility).getPackageVersionId(lastVulnerablePurl, context, 1L);
         Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v);
-        Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds, null);
         Mockito.verify(metadataUtility).getFastenUrisForPatch(patch.getFileName(),
                 patch.getNewChangedLineNumbers(),
                 1L, context);
@@ -151,8 +153,10 @@ public class VulnerabilityStatementsProcessorTest {
         v.setScoreCVSS3(5.0);
         v.setPublishedDate("12-11-2019");
         v.setLastModifiedDate("08-31-2020");
-        v.addPurl("pkg:maven/org.testing/mock@1.0.1");
-        v.addFirstPatchedPurl("pkg:maven/org.testing/mock@1.0.2");
+        var lastVulnerablePurl = Purl.of("pkg:maven/org.testing/mock@1.0.1");
+        v.addPurl(lastVulnerablePurl.toString());
+        var firstPatchedPurl = Purl.of("pkg:maven/org.testing/mock@1.0.2");
+        v.addFirstPatchedPurl(firstPatchedPurl.toString());
         var patch = new Patch();
         patch.setPatchDate("04-04-2004");
         patch.setNewChangedLineNumbers(Collections.singletonList(36));
@@ -164,8 +168,10 @@ public class VulnerabilityStatementsProcessorTest {
         kafkaPlugin.setMetadataUtility(metadataUtility);
 
         // MOCKITO WHEN
-        var pkgIds = new HashMap<String, Long>(); pkgIds.put("pkg:maven/org.testing/mock", 1L);
+        var pkgIds = new HashMap<String, Long>(); pkgIds.put("org.testing:mock", 1L);
         when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(LinkedHashSet.class))).thenReturn(pkgIds);
+        when(metadataUtility.getPackageVersionId(Mockito.eq(lastVulnerablePurl), Mockito.any(DSLContext.class), Mockito.eq(1L))).thenReturn(1L);
+        when(metadataUtility.getPackageVersionId(Mockito.eq(firstPatchedPurl), Mockito.any(DSLContext.class), Mockito.eq(1L))).thenReturn(2L);
         when(metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v)).thenReturn(Collections.singletonList(1L));
         when(metadataUtility.getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds, null)).thenReturn(Collections.singletonList(2L));
 
@@ -190,7 +196,8 @@ public class VulnerabilityStatementsProcessorTest {
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
         Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v);
-        Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds, null);
+        Mockito.verify(metadataUtility).getPackageVersionId(lastVulnerablePurl, context, 1L);
+        Mockito.verify(metadataUtility).getPackageVersionId(firstPatchedPurl, context, 1L);
         Mockito.verify(metadataUtility).getFastenUrisForPatch(patch.getFileName(),
                 patch.getOriginalChangedLineNumbers(),
                 1L, context);

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -74,7 +74,7 @@ public class VulnerabilityStatementsProcessorTest {
         var pkgIds = new HashMap<String, Long>(); pkgIds.put("org.testing:mock", 1L);
         when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(LinkedHashSet.class))).thenReturn(pkgIds);
         when(metadataUtility.getPackageVersionId(Mockito.eq(lastVulnerablePurl), Mockito.any(DSLContext.class), Mockito.eq(1L))).thenReturn(1L);
-        when(metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v)).thenReturn(Collections.singletonList(1L));
+        when(metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds)).thenReturn(Collections.singletonList(1L));
 
         var fasten_uri = "/java/net/GenericClass.%3Cclinit%3E()%2Fjava.lang%2FVoidType";
         var fastenUris = new HashSet<>(Collections.singletonList(fasten_uri));
@@ -93,7 +93,7 @@ public class VulnerabilityStatementsProcessorTest {
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
         Mockito.verify(metadataUtility).getPackageVersionId(lastVulnerablePurl, context, 1L);
-        Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v);
+        Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedPurls(), context, pkgIds);
         Mockito.verify(metadataUtility).getFastenUrisForPatch(patch.getFileName(),
                 patch.getNewChangedLineNumbers(),
                 1L, context);
@@ -172,8 +172,8 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getPackageIds(Mockito.any(DSLContext.class), Mockito.any(LinkedHashSet.class))).thenReturn(pkgIds);
         when(metadataUtility.getPackageVersionId(Mockito.eq(lastVulnerablePurl), Mockito.any(DSLContext.class), Mockito.eq(1L))).thenReturn(1L);
         when(metadataUtility.getPackageVersionId(Mockito.eq(firstPatchedPurl), Mockito.any(DSLContext.class), Mockito.eq(1L))).thenReturn(2L);
-        when(metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v)).thenReturn(Collections.singletonList(1L));
-        when(metadataUtility.getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds, null)).thenReturn(Collections.singletonList(2L));
+        when(metadataUtility.getPackageVersionIds(v.getValidatedPurls(), context, pkgIds)).thenReturn(Collections.singletonList(1L));
+        when(metadataUtility.getPackageVersionIds(v.getValidatedFirstPatchedPurls(), context, pkgIds)).thenReturn(Collections.singletonList(2L));
 
         var fasten_uri = "/java/net/GenericClass.%3Cclinit%3E()%2Fjava.lang%2FVoidType";
         var fastenUris = new HashSet<>(Collections.singletonList(fasten_uri));
@@ -195,7 +195,7 @@ public class VulnerabilityStatementsProcessorTest {
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
-        Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedPurls(), context, pkgIds, v);
+        Mockito.verify(metadataUtility).getPackageVersionIds(v.getValidatedPurls(), context, pkgIds);
         Mockito.verify(metadataUtility).getPackageVersionId(lastVulnerablePurl, context, 1L);
         Mockito.verify(metadataUtility).getPackageVersionId(firstPatchedPurl, context, 1L);
         Mockito.verify(metadataUtility).getFastenUrisForPatch(patch.getFileName(),


### PR DESCRIPTION
## Description
The existing vulnerability consumer and vulnerability statements processor do not check if the last vulnerable version is actually in the DB. This can lead to callables being matched against older versions that were not the origin of the actual vulnerability patches, potentially leading to both false positives and negatives.

This is fixed by checking if the last vulnerable version is in the DB. If not, callable matching is skipped for the moment. The REST API is then requested to ingest the last vulnerable version. Once that is done, the vulnerability packages listener should pick up that package version and complete the callables matching.
