### PR TITLE
Fixing CommitFailedException in the FASTEN server

### DIFF
--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -228,9 +228,15 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             doCommitSync(KafkaRecordKind.PRIORITY);
         }
 
-        if (!normTopics.isEmpty() && (!hasConsumedPriorityRecord || shouldNormPollBeCalled())) {
+        if (!normTopics.isEmpty()) {
+            // Pause the normal consumer if there are priority records to process.
+            if (hasConsumedPriorityRecord) {
+                connNorm.pause(connNorm.assignment());
+            } else {
+                connNorm.resume(connNorm.assignment());
+            }
             ConsumerRecords<String, String> records = connNorm.poll(this.pollTimeout);
-            this.lastTimeNormPollCalled = new Date();
+            //this.lastTimeNormPollCalled = new Date();
             Long consumeTimestamp = System.currentTimeMillis() / 1000L;
 
             // Keep a list of all records and offsets we processed (by default this is only 1).
@@ -488,7 +494,6 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             logger.error("Commit failed", e);
         }
     }
-
 
     /**
      * This method adds one to the offset of all the partitions of a topic.

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -44,7 +44,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -70,8 +69,6 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
     private final String outputTopic;
 
     private enum KafkaRecordKind {NORMAL, PRIORITY}
-
-    private Date lastTimeNormPollCalled;
 
     private final int skipOffsets;
 
@@ -199,18 +196,6 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
     }
 
     /**
-     * Whether the poll() method of the normal Kafka connection should be called to avoid CommitFailedException considering
-     * the `max.poll.interval.ms` time, i.e., consumeTimeout value,
-     */
-    private boolean shouldNormPollBeCalled() {
-        if (this.lastTimeNormPollCalled != null) {
-            return (new Date().getTime() - this.lastTimeNormPollCalled.getTime()) > (getConsumeTimeout() - 10000);
-        }
-        // To call the poll() method for the first time and initialize lastTimeNormPollCalled
-        return true;
-    }
-
-    /**
      * Consumes a message from a Kafka topics and passes it to a plugin.
      */
     public void handleConsuming() {
@@ -236,7 +221,6 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
                 connNorm.resume(connNorm.assignment());
             }
             ConsumerRecords<String, String> records = connNorm.poll(this.pollTimeout);
-            //this.lastTimeNormPollCalled = new Date();
             Long consumeTimestamp = System.currentTimeMillis() / 1000L;
 
             // Keep a list of all records and offsets we processed (by default this is only 1).

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -175,10 +175,8 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             }
 
         } catch (WakeupException e) {
+            // Wakeup exception is rethrown after handling shutdown signals, i.e., deleting deployments in Kubernetes.
             if (!closed.get()) throw e;
-
-//        } catch (Exception e) {
-//            logger.error("Error occurred while processing call graphs", e);
         } finally {
             connNorm.close();
             connPrio.close();

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -133,6 +133,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
         this.consumeTimeoutEnabled = consumeTimeoutEnabled;
         this.consumeTimeout = consumeTimeout;
         this.exitOnTimeout = exitOnTimeout;
+        registerShutDownHook();
         logger.debug("Constructed a Kafka plugin for " + plugin.getClass().getCanonicalName());
     }
 
@@ -578,5 +579,16 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      */
     public long getConsumeTimeout() {
         return consumeTimeout;
+    }
+
+    /**
+     * It cleans up resources after receiving the SIGTERM signal. E.g. closing Kafka connections
+     */
+    private void registerShutDownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            this.connNorm.close();
+            this.connPrio.close();
+            logger.info("Cleaned up resources before shutting down the JVM");
+        }));
     }
 }

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -173,8 +173,12 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
                     handleProducing(null, System.currentTimeMillis() / 1000L, KafkaRecordKind.NORMAL);
                 }
             }
-        } catch (Exception e) {
-            logger.error("Error occurred while processing call graphs", e);
+
+        } catch (WakeupException e) {
+            if (!closed.get()) throw e;
+
+//        } catch (Exception e) {
+//            logger.error("Error occurred while processing call graphs", e);
         } finally {
             connNorm.close();
             connPrio.close();
@@ -603,8 +607,8 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      */
     private void registerShutDownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            this.connNorm.close();
-            this.connPrio.close();
+            this.stop();
+            this.connNorm.wakeup();
             logger.info("Cleaned up resources before shutting down the JVM");
         }));
     }


### PR DESCRIPTION
## Description
This PR addresses Kafka's `CommitFailedException` by making the following changes:
- Storing The last time the normal consumer's `poll()` method is called and compare it to the value of ` getMaxConsumeTimeout()`. Using this comparison, we call the `poll()` method of the normal consumer at least one periodically depending on the value of ` getMaxConsumeTimeout()`. This should prevent `CommitFailedException` .
- To handle process signals such as `SIGTERM`, register a shutdown hook to wake up the consumer and finally close the Kafka connections gracefully.

## Motivation and context
With recent changes to the FASTEN server (see #330), two Kafka consumers, namely, normal and priority are introduced. Given that the priority consumer has precedence over the normal consumer, the poll() method of the normal consumer may not be called after `max.poll.interval.ms`, which causes Kafka's `CommitFailedException`.
Also, deleting K8s deployments sends SIGTERM signal, which was not previously handled in the FASTEN server and again it may cause Kafka's `CommitFailedException`

## Testing
Using `DummyPlugin`, I have managed to reproduce the issue and also tested the fix. 

## Task list  
- [x] Register shutdown hook to gracefully close Kafka connections
- [x] Fix `CommitFailedException` by calling the poll method of the normal consumer periodically. 
