### PR TITLE
Improved purl list handling in the vulnerability-statement-processor

### DIFF
--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -134,7 +134,7 @@ public class VulnerabilityPackagesListener extends Plugin {
                         vulnerabilities.forEach(vulnerabilityId -> {
                             var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
                             var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
-                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability);
+                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId);
                         });
                     }
                 }

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -115,8 +115,8 @@ public class VulnerabilityPackagesListener extends Plugin {
         public void consume(String record) {
             setPluginError(null);
             try {
-                refreshMetadataUtility();
-                statementsProcessor.setMetadataUtility(metadataUtility);
+                setMetadataUtility();
+                statementsProcessor.setDBConnection(contexts);
                 statementsProcessor.setFastenApiClient(fastenApiClient);
                 var jsonRecord = new JSONObject(record);
                 var payload = findPayload(jsonRecord);
@@ -132,7 +132,7 @@ public class VulnerabilityPackagesListener extends Plugin {
                         vulnerabilities.forEach(vulnerabilityId -> {
                             var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
                             var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
-                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId, context);
+                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId);
                         });
                     }
                 }
@@ -148,7 +148,7 @@ public class VulnerabilityPackagesListener extends Plugin {
             }
         }
 
-        private void refreshMetadataUtility() {
+        private void setMetadataUtility() {
             this.metadataUtility = new MetadataUtility();
         }
 

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -132,7 +132,7 @@ public class VulnerabilityPackagesListener extends Plugin {
                         vulnerabilities.forEach(vulnerabilityId -> {
                             var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
                             var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
-                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId);
+                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId, context);
                         });
                     }
                 }
@@ -144,6 +144,7 @@ public class VulnerabilityPackagesListener extends Plugin {
                 var error = "Error processing package update: " + e;
                 logger.error(error);
                 setPluginError(e);
+                throw(e);
             }
         }
 

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -18,12 +18,9 @@
 
 package eu.fasten.analyzer.vulnerabilitypackageslistener;
 
-import com.google.gson.Gson;
 import eu.fasten.analyzer.vulnerabilitystatementsprocessor.VulnerabilityStatementsProcessor;
-import eu.fasten.analyzer.vulnerabilitystatementsprocessor.db.MetadataUtility;
 import eu.fasten.analyzer.vulnerabilitystatementsprocessor.utils.FastenApiClient;
 import eu.fasten.core.data.Constants;
-import eu.fasten.core.data.vulnerability.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
 import org.jooq.DSLContext;
@@ -52,9 +49,7 @@ public class VulnerabilityPackagesListener extends Plugin {
         private static Map<String, DSLContext> contexts;
         private List<String> consumeTopics = new LinkedList<>(Collections.singletonList("fasten.CallableIndexFastenPlugin.out"));
         private Exception pluginError = null;
-        private final Gson gson = new Gson();
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityPackagesKafkaPlugin");
-        private MetadataUtility metadataUtility;
         private final FastenApiClient fastenApiClient = new FastenApiClient();
         private static final VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin statementsProcessor = new VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin();
 
@@ -115,26 +110,16 @@ public class VulnerabilityPackagesListener extends Plugin {
         public void consume(String record) {
             setPluginError(null);
             try {
-                setMetadataUtility();
                 statementsProcessor.setDBConnection(contexts);
                 statementsProcessor.setFastenApiClient(fastenApiClient);
                 var jsonRecord = new JSONObject(record);
                 var payload = findPayload(jsonRecord);
                 if(payload != null) {
                     var ecosystem = payload.getString("forge");
-                    var context = findContextForEcosystem(ecosystem);
                     var packageName = getPackageName(payload);
                     var version = payload.getString("version");
                     logger.info("Processing package update for forge \"" + ecosystem + "\": " + packageName + ":" + version);
-                    var vulnerabilities = metadataUtility.getVulnerabilitiesForPurl(ecosystem, packageName, version, context);
-                    logger.info("Found the following vulnerabilities for " + packageName + ":" + version + ": " + vulnerabilities.toString());
-                    if(vulnerabilities.size() > 0) {
-                        vulnerabilities.forEach(vulnerabilityId -> {
-                            var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
-                            var vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
-                            statementsProcessor.updateCallablesAndPackageVersions(vulnerability, vulnerabilityId);
-                        });
-                    }
+                    statementsProcessor.updatePackageVersionAndCallables(ecosystem, packageName, version);
                 }
                 else {
                     logger.error("Could not parse payload in message: " + record);
@@ -146,18 +131,6 @@ public class VulnerabilityPackagesListener extends Plugin {
                 setPluginError(e);
                 throw(e);
             }
-        }
-
-        private void setMetadataUtility() {
-            this.metadataUtility = new MetadataUtility();
-        }
-
-        private DSLContext findContextForEcosystem(String ecosystem) {
-            var context = ecosystem.equals("") ? null : contexts.get(ecosystem);
-            if (context == null) {
-                throw new UnsupportedOperationException("Malformed ecosystem data or unsupported ecosystem \"" + ecosystem + "\"");
-            }
-            return context;
         }
 
         private String getPackageName(JSONObject payload) {

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -42,11 +42,8 @@ import java.util.Optional;
 
 public class VulnerabilityPackagesListener extends Plugin {
 
-    private static VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin statementsProcessor = null;
-
     public VulnerabilityPackagesListener(PluginWrapper wrapper) {
         super(wrapper);
-        statementsProcessor = new VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin();
     }
 
     @Extension
@@ -59,6 +56,7 @@ public class VulnerabilityPackagesListener extends Plugin {
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityPackagesKafkaPlugin");
         private MetadataUtility metadataUtility;
         private final FastenApiClient fastenApiClient = new FastenApiClient();
+        private static final VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin statementsProcessor = new VulnerabilityStatementsProcessor.VulnerabilityStatementsKafkaPlugin();
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {

--- a/analyzer/vulnerability-packages-listener/src/test/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListenerTest.java
+++ b/analyzer/vulnerability-packages-listener/src/test/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListenerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import java.io.FileReader;
 import java.io.IOException;
 
-import static eu.fasten.analyzer.vulnerabilitypackageslistener.VulnerabilityPackagesListener.VulnerabilityPackagesKafkaPlugin.findPayload;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -18,7 +17,7 @@ class VulnerabilityPackagesListenerTest {
         var messageFile = TestUtils.getTestResource("callable-index-message.json");
         var jsonTokener = new JSONTokener(new FileReader(messageFile));
         var json = new JSONObject(jsonTokener);
-        var payload = findPayload(json);
+        var payload = VulnerabilityPackagesListener.VulnerabilityPackagesKafkaPlugin.findPayload(json);
         assertNotNull(payload);
         assertEquals("mvn", payload.getString("forge"));
         assertEquals("io.netty", payload.getString("groupId"));
@@ -31,7 +30,7 @@ class VulnerabilityPackagesListenerTest {
         var messageFile = TestUtils.getTestResource("pom-analyzer-message.json");
         var jsonTokener = new JSONTokener(new FileReader(messageFile));
         var json = new JSONObject(jsonTokener);
-        var payload = findPayload(json);
+        var payload = VulnerabilityPackagesListener.VulnerabilityPackagesKafkaPlugin.findPayload(json);
         assertNotNull(payload);
         assertEquals("mvn", payload.getString("forge"));
         assertEquals("io.netty", payload.getString("groupId"));
@@ -44,7 +43,7 @@ class VulnerabilityPackagesListenerTest {
         var messageFile = TestUtils.getTestResource("real-callable-index-message.json");
         var jsonTokener = new JSONTokener(new FileReader(messageFile));
         var json = new JSONObject(jsonTokener);
-        var payload = findPayload(json);
+        var payload = VulnerabilityPackagesListener.VulnerabilityPackagesKafkaPlugin.findPayload(json);
         assertNotNull(payload);
         assertEquals("mvn", payload.getString("forge"));
         assertEquals("org.apache.pdfbox", payload.getString("groupId"));
@@ -57,7 +56,7 @@ class VulnerabilityPackagesListenerTest {
         var messageFile = TestUtils.getTestResource("real-pom-analyzer-message.json");
         var jsonTokener = new JSONTokener(new FileReader(messageFile));
         var json = new JSONObject(jsonTokener);
-        var payload = findPayload(json);
+        var payload = VulnerabilityPackagesListener.VulnerabilityPackagesKafkaPlugin.findPayload(json);
         assertNotNull(payload);
         assertEquals("mvn", payload.getString("forge"));
         assertEquals("org.apache.pdfbox", payload.getString("groupId"));

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -92,9 +92,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             try {
                 vulnerability = gson.fromJson(record, Vulnerability.class);
                 logger.info("Read vulnerability statement " + vulnerability.getId() + " from " + consumeTopics.toString());
-                setDbContext();
-                setMetadataUtility();
-                updatePackageVersionsAndCallables(vulnerability, updateVulnerability());
+                updatePackageVersionsAndCallables(vulnerability, updateVulnerability(vulnerability));
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
                 lastProcessedVulnerability = vulnerability;
             } catch (Exception e) {
@@ -259,8 +257,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         private void updateVulnerableCallables(LinkedHashSet<Purl> purls, Long pkgId, List<Long> vulnerablePackageVersionIds) {
             var vulnerableFastenUris = new HashSet<String>();
             vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(purls, pkgId));
-            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(pkgId));
-            var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds);
+            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersions(pkgId));
+            var vulnerableCallables = findVulnerableCallableIds(vulnerableFastenUris, vulnerablePackageVersionIds);
             var vulnerableCallableIds = vulnerableCallables.keySet();
             vulnerability.setFastenUris(new HashSet<>(vulnerableCallables.values()));
 
@@ -325,27 +323,21 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return purlsArray[purlsArray.length - 1];
         }
 
-        private HashSet<String> findFastenUrisInFirstPatchedVersion(Long pkgId) {
-            var firstPatchedVersionId = findIdForPurl(getFirstPatchedPurl(), pkgId);
+        private HashSet<String> findFastenUrisInFirstPatchedVersions(Long pkgId) {
             var fastenUris = new HashSet<String>();
-            if(firstPatchedVersionId != -1L) {
-                vulnerability.getPatches().forEach(p -> {
-                    logger.info(vulnerability.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
-                    fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
-                            p.getNewChangedLineNumbers(),
-                            firstPatchedVersionId, context));
-                });
-            }
-            return fastenUris;
-        }
+            vulnerability.getValidatedFirstPatchedPurls().forEach(purl -> {
+                var firstPatchedVersionId = findIdForPurl(purl, pkgId);
+                if(firstPatchedVersionId != -1L) {
+                    vulnerability.getPatches().forEach(patch -> {
+                        logger.info(vulnerability.getId() + ": Searching for callables in " + patch.getFileName() + " for package-version: " + firstPatchedVersionId);
+                        fastenUris.addAll(metadataUtility.getFastenUrisForPatch(patch.getFileName(),
+                                patch.getNewChangedLineNumbers(),
+                                firstPatchedVersionId, context));
+                    });
+                }
+            });
 
-        private Purl getFirstPatchedPurl() {
-            Purl[] purls = new Purl[vulnerability.getValidatedFirstPatchedPurls().size()];
-            if (purls.length > 0) {
-                purls = vulnerability.getValidatedFirstPatchedPurls().toArray(purls);
-                return purls[0];
-            }
-            return null;
+            return fastenUris;
         }
 
         private Long findIdForPurl(Purl purl, Long pkgId) {
@@ -355,7 +347,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return -1L;
         }
 
-        private HashMap<Long, String> findVulnerableCallables(HashSet<String> vulnerableFastenUris, List<Long> vulnPkgVersionIds) {
+        private HashMap<Long, String> findVulnerableCallableIds(HashSet<String> vulnerableFastenUris, List<Long> vulnPkgVersionIds) {
             var vulnerableCallables = new HashMap<Long, String>();
             vulnerableFastenUris.forEach(uri -> {
                 var callIds = metadataUtility.getCallableIdsForFastenUri(uri, new HashSet<>(vulnPkgVersionIds), context);

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -65,6 +65,9 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         public final static String[] extensions = new String[]{".java", ".py", ".pyw", ".c", ".cpp", ".h"};
         private final static Logger logger = LoggerFactory.getLogger("VulnerabilityStatementsKafkaPlugin");
         private FastenApiClient fastenApiClient = new FastenApiClient();
+        private DSLContext context = null;
+        private Vulnerability vulnerability = null;
+        private Long vulnerabilityId = -1L;
 
         @Override
         public void setDBConnection(Map<String, DSLContext> dslContexts) {
@@ -85,11 +88,12 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         public void consume(String record) {
             this.pluginError = null;
             try {
-                var vulnerability = gson.fromJson(record, Vulnerability.class);
+                vulnerability = gson.fromJson(record, Vulnerability.class);
                 logger.info("Read vulnerability statement " + vulnerability.getId() + " from " + consumeTopics.toString());
+                setDBContext();
                 refreshMetadataUtility();
-                var vulnerabilityId = insertVulnerability(vulnerability);
-                updateCallablesAndPackageVersions(vulnerability, vulnerabilityId);
+                vulnerabilityId = updateVulnerability();
+                updateCallablesAndPackageVersions();
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
                 lastProcessedVulnerability = vulnerability;
             } catch (Exception e) {
@@ -161,51 +165,61 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             this.fastenApiClient = client;
         }
 
-        public Long insertVulnerability(Vulnerability v)  {
-            var context = getDBContext(v);
-
-            v.filterUnsupportedPatches(extensions);
-            try {
-                v.updatePatchDate();
-            } catch (ParseException e) {
-                logger.warn(v.getId() + ": Error updating patch date, continuing: " + e);
-            }
-
-            logger.info(v.getId() + ": Inserting vulnerability into the database for ecosystem " + "\"" + v.getEcosystem() + "\".");
-            return metadataUtility.insertVulnerability(v, context);
+        public Long updateVulnerability(Vulnerability v, DSLContext context) {
+            this.context = context;
+            this.vulnerability = v;
+            return updateVulnerability();
         }
 
-        public void updateCallablesAndPackageVersions(Vulnerability v, Long vulnerabilityId) {
-            var context = getDBContext(v);
-            var allPurls = v.getValidatedPurls();
+        public Long updateVulnerability()  {
+            vulnerability.filterUnsupportedPatches(extensions);
+            try {
+                vulnerability.updatePatchDate();
+            } catch (ParseException e) {
+                logger.warn(vulnerability.getId() + ": Error updating patch date, continuing: " + e);
+            }
+
+            logger.info(vulnerability.getId() + ": Inserting vulnerability into the database for ecosystem " + "\"" + vulnerability.getEcosystem() + "\".");
+            return metadataUtility.insertVulnerability(vulnerability, context);
+        }
+
+        public void updateCallablesAndPackageVersions(Vulnerability v, Long vId, DSLContext context) {
+            this.context = context;
+            this.vulnerability = v;
+            this.vulnerabilityId = vId;
+            updateCallablesAndPackageVersions();
+        }
+
+        public void updateCallablesAndPackageVersions() {
+            var allPurls = vulnerability.getValidatedPurls();
             var pkgIds = metadataUtility.getPackageIds(context, allPurls);
             if (pkgIds.size() > 0) {
                 for(var pkgId : pkgIds.entrySet()) {
-                    updateCallablesAndPackageVersions(v, vulnerabilityId, pkgId.getKey(), pkgId.getValue(), context);
+                    updateCallablesAndPackageVersions(pkgId.getKey(), pkgId.getValue());
                 }
             }
             else {
-                logger.info(v.getId() + ": No matching packages found in database.");
-                updateCallablesAndPackageVersions(v, vulnerabilityId, "", -1L, context);
+                logger.info(vulnerability.getId() + ": No matching packages found in database.");
+                updateCallablesAndPackageVersions("", -1L);
             }
         }
 
-        public void updateCallablesAndPackageVersions(Vulnerability v, Long vulnerabilityId, String packageName, Long pkgId, DSLContext context) {
-            var vulnerablePackageVersionIds = updateVulnerablePackageVersions(v, vulnerabilityId, packageName, pkgId, context);
-            updateVulnerableCallables(v, vulnerabilityId, pkgId, vulnerablePackageVersionIds, context);
+        public void updateCallablesAndPackageVersions(String packageName, Long pkgId) {
+            var vulnerablePackageVersionIds = updateVulnerablePackageVersions(packageName, pkgId);
+            updateVulnerableCallables(pkgId, vulnerablePackageVersionIds);
             if (vulnerablePackageVersionIds.size() == 0) {
-                logger.info(v.getId() + ": No matching package-versions found in database.");
+                logger.info(vulnerability.getId() + ": No matching package-versions found in database.");
             }
         }
 
-        private List<Long> updateVulnerablePackageVersions(Vulnerability v, Long vulnerabilityId, String packageName, Long pkgId, DSLContext context) {
-            var purls = getPurlsForPackage(v.getValidatedPurls(), packageName);
+        private List<Long> updateVulnerablePackageVersions(String packageName, Long pkgId) {
+            var purls = getPurlsForPackage(vulnerability.getValidatedPurls(), packageName);
             var pkgIdMap = new HashMap<String, Long>();
             pkgIdMap.put(packageName, pkgId);
             var vulnerablePackageVersionIds= metadataUtility.getPackageVersionIds(purls, context, pkgIdMap);
 
-            logger.info(v.getId() + ": Inserting data for " + vulnerablePackageVersionIds.size() + " vulnerable package-versions into the database.");
-            vulnerablePackageVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(v, id, context));
+            logger.info(vulnerability.getId() + ": Inserting data for " + vulnerablePackageVersionIds.size() + " vulnerable package-versions into the database.");
+            vulnerablePackageVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(vulnerability, id, context));
             metadataUtility.insertVulnerabilityToPackageVersions(vulnerabilityId, vulnerablePackageVersionIds, context);
             return vulnerablePackageVersionIds;
         }
@@ -216,75 +230,74 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
         }
 
-        private void updateVulnerableCallables(Vulnerability v, Long vulnerabilityId, Long pkgId, List<Long> vulnerablePackageVersionIds, DSLContext context) {
+        private void updateVulnerableCallables(Long pkgId, List<Long> vulnerablePackageVersionIds) {
             var vulnerableFastenUris = new HashSet<String>();
-            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(v, pkgId, context));
-            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(v, pkgId, context));
-            var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds, context);
+            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(pkgId));
+            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(pkgId));
+            var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds);
             var vulnerableCallableIds = vulnerableCallables.keySet();
-            v.setFastenUris(new HashSet<>(vulnerableCallables.values()));
+            vulnerability.setFastenUris(new HashSet<>(vulnerableCallables.values()));
 
-            logger.info(v.getId() + ": Inserting data for " + vulnerableCallableIds.size() + " vulnerable callables into the database.");
-            vulnerableCallableIds.forEach(id -> metadataUtility.injectCallableVulnerability(v, id, context));
+            logger.info(vulnerability.getId() + ": Inserting data for " + vulnerableCallableIds.size() + " vulnerable callables into the database.");
+            vulnerableCallableIds.forEach(id -> metadataUtility.injectCallableVulnerability(vulnerability, id, context));
             metadataUtility.insertVulnerabilityToCallables(vulnerabilityId, vulnerableCallableIds, context);
         }
 
-        public DSLContext getDBContext(Vulnerability v) {
-            var ecosystem = v.getEcosystem();
-            var context = ecosystem.equals("") ? null : contexts.get(ecosystem);
+        public void setDBContext() {
+            var ecosystem = vulnerability.getEcosystem();
+            context = ecosystem.equals("") ? null : contexts.get(ecosystem);
             if (context == null) {
-                throw new UnsupportedOperationException(v.getId() + ": Malformed ecosystem data or unsupported ecosystem \"" + ecosystem + "\"");
+                throw new UnsupportedOperationException(vulnerability.getId() + ": Malformed ecosystem data or unsupported ecosystem \"" + ecosystem + "\"");
             }
-            return context;
         }
 
-        private HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, Long pkgId, DSLContext context) {
-            var lastVulnerablePurl = getLastVulnerablePurl(v);
-            var lastVulnVersionId = findIdForPurl(lastVulnerablePurl, pkgId, context);
+        private HashSet<String> findFastenUrisInLastVulnerableVersion(Long pkgId) {
+            var lastVulnerablePurl = getLastVulnerablePurl();
+            var lastVulnVersionId = findIdForPurl(lastVulnerablePurl, pkgId);
             var fastenUris = new HashSet<String>();
             if(lastVulnVersionId != -1L) {
-                v.getPatches().forEach(p -> {
-                    logger.info(v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + lastVulnVersionId);
+                vulnerability.getPatches().forEach(p -> {
+                    logger.info(vulnerability.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + lastVulnVersionId);
                     fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
                             p.getOriginalChangedLineNumbers(),
                             lastVulnVersionId, context));
                 });
             }
             else {
-                logger.info(v.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl + ", skipping callable search.");
+                logger.info(vulnerability.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl + ", skipping callable search.");
                 if(fastenApiClient.getApiUrl() != null) {
-                    requestPurlIngestion(v, lastVulnerablePurl);
+                    requestPurlIngestion(lastVulnerablePurl);
                 }
             }
             return fastenUris;
         }
 
-        private void requestPurlIngestion(Vulnerability v, Purl p) {
+        private void requestPurlIngestion(Purl p) {
             try {
-                logger.info(v.getId() + ": calling FASTEN API to ingest package-version for purl: " + p);
-                var response = fastenApiClient.requestPackageVersion(v.getEcosystem(), p.getPackageName(), p.getVersion().toString());
+                logger.info(vulnerability.getId() + ": calling FASTEN API to ingest package-version for purl: " + p);
+                var response = fastenApiClient.requestPackageVersion(vulnerability.getEcosystem(), p.getPackageName(), p.getVersion().toString());
                 var code = response.statusCode();
                 if(code != 201) {
-                    logger.warn(v.getId() + ": unexpected response " + code + " to ingest request for purl" + p);
+                    logger.warn(vulnerability.getId() + ": unexpected response " + code + " to ingest request for purl: " + p);
                 }
             } catch (Exception e) {
-                logger.warn(v.getId() + ": there was a problem calling FASTEN API for purl " + p + " : " + e);
+                logger.warn(vulnerability.getId() + ": there was a problem calling FASTEN API for purl " + p + " : " + e);
             }
         }
 
-        private Purl getLastVulnerablePurl(Vulnerability v) {
-            Purl[] purls = new Purl[v.getValidatedPurls().size()];
+        private Purl getLastVulnerablePurl() {
+            Purl[] purls = new Purl[vulnerability.getValidatedPurls().size()];
             assert purls.length > 0;
-            purls = v.getValidatedPurls().toArray(purls);
+            purls = vulnerability.getValidatedPurls().toArray(purls);
             return purls[purls.length - 1];
         }
 
-        private HashSet<String> findFastenUrisInFirstPatchedVersion(Vulnerability v, Long pkgId, DSLContext context) {
-            var firstPatchedVersionId = findIdForPurl(getFirstPatchedPurl(v), pkgId, context);
+        private HashSet<String> findFastenUrisInFirstPatchedVersion(Long pkgId) {
+            var firstPatchedVersionId = findIdForPurl(getFirstPatchedPurl(), pkgId);
             var fastenUris = new HashSet<String>();
             if(firstPatchedVersionId != -1L) {
-                v.getPatches().forEach(p -> {
-                    logger.info(v.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
+                vulnerability.getPatches().forEach(p -> {
+                    logger.info(vulnerability.getId() + ": Searching for callables in " + p.getFileName() + " for package-version: " + firstPatchedVersionId);
                     fastenUris.addAll(metadataUtility.getFastenUrisForPatch(p.getFileName(),
                             p.getNewChangedLineNumbers(),
                             firstPatchedVersionId, context));
@@ -293,23 +306,23 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return fastenUris;
         }
 
-        private Purl getFirstPatchedPurl(Vulnerability v) {
-            Purl[] purls = new Purl[v.getValidatedFirstPatchedPurls().size()];
+        private Purl getFirstPatchedPurl() {
+            Purl[] purls = new Purl[vulnerability.getValidatedFirstPatchedPurls().size()];
             if (purls.length > 0) {
-                purls = v.getValidatedFirstPatchedPurls().toArray(purls);
+                purls = vulnerability.getValidatedFirstPatchedPurls().toArray(purls);
                 return purls[0];
             }
             return null;
         }
 
-        private Long findIdForPurl(Purl purl, Long pkgId, DSLContext context) {
+        private Long findIdForPurl(Purl purl, Long pkgId) {
             if (purl != null && pkgId != -1) {
                 return metadataUtility.getPackageVersionId(purl, context, pkgId);
             }
             return -1L;
         }
 
-        private HashMap<Long, String> findVulnerableCallables(HashSet<String> vulnerableFastenUris, List<Long> vulnPkgVersionIds, DSLContext context) {
+        private HashMap<Long, String> findVulnerableCallables(HashSet<String> vulnerableFastenUris, List<Long> vulnPkgVersionIds) {
             var vulnerableCallables = new HashMap<Long, String>();
             vulnerableFastenUris.forEach(uri -> {
                 var callIds = metadataUtility.getCallableIdsForFastenUri(uri, new HashSet<>(vulnPkgVersionIds), context);

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -25,6 +25,7 @@ import eu.fasten.core.data.vulnerability.Purl;
 import eu.fasten.core.data.vulnerability.Vulnerability;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jooq.DSLContext;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
@@ -93,7 +94,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 setDbContext();
                 setMetadataUtility();
                 vulnerabilityId = updateVulnerability();
-                updateCallablesAndPackageVersions();
+                updatePackageVersionsAndCallables();
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
                 lastProcessedVulnerability = vulnerability;
             } catch (Exception e) {
@@ -184,29 +185,40 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return metadataUtility.insertVulnerability(vulnerability, context);
         }
 
-        public void updateCallablesAndPackageVersions(Vulnerability v, Long vId) {
+        public void updatePackageVersionAndCallables(String ecosystem, String packageName, String version) {
+            if(metadataUtility == null) setMetadataUtility();
+            setDbContext(ecosystem);
+            var vulnerabilities = metadataUtility.getVulnerabilitiesForPurl(ecosystem, packageName, version, context);
+            logger.info("Found the following vulnerabilities for " + packageName + ":" + version + ": " + vulnerabilities.toString());
+            vulnerabilities.forEach(vulnerabilityId -> {
+                var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
+                updatePackageVersionsAndCallables(gson.fromJson(jsonStatement, Vulnerability.class), vulnerabilityId);
+            });
+        }
+
+        public void updatePackageVersionsAndCallables(Vulnerability v, Long vId) {
             if(metadataUtility == null) setMetadataUtility();
             this.vulnerability = v;
             setDbContext();
             this.vulnerabilityId = vId;
-            updateCallablesAndPackageVersions();
+            updatePackageVersionsAndCallables();
         }
 
-        private void updateCallablesAndPackageVersions() {
+        private void updatePackageVersionsAndCallables() {
             var allPurls = vulnerability.getValidatedPurls();
             var pkgIds = metadataUtility.getPackageIds(context, allPurls);
             if (pkgIds.size() > 0) {
                 for(var pkgId : pkgIds.entrySet()) {
-                    updateCallablesAndPackageVersions(pkgId.getKey(), pkgId.getValue());
+                    updatePackageVersionAndCallables(pkgId.getKey(), pkgId.getValue());
                 }
             }
             else {
                 logger.info(vulnerability.getId() + ": No matching packages found in database.");
-                updateCallablesAndPackageVersions("", -1L);
+                updatePackageVersionAndCallables("", -1L);
             }
         }
 
-        private void updateCallablesAndPackageVersions(String packageName, Long pkgId) {
+        private void updatePackageVersionAndCallables(String packageName, Long pkgId) {
             var vulnerablePackageVersionIds = updateVulnerablePackageVersions(packageName, pkgId);
             updateVulnerableCallables(pkgId, vulnerablePackageVersionIds);
             if (vulnerablePackageVersionIds.size() == 0) {
@@ -232,6 +244,12 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
         }
 
+        private LinkedHashSet<Purl> getPurlsForVersion(LinkedHashSet<Purl> purls, ComparableVersion version) {
+            return sortPurls(purls.stream()
+                    .filter(p -> version.equals(p.getVersion()))
+                    .collect(Collectors.toCollection(LinkedHashSet::new)));
+        }
+
         private void updateVulnerableCallables(Long pkgId, List<Long> vulnerablePackageVersionIds) {
             var vulnerableFastenUris = new HashSet<String>();
             vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(pkgId));
@@ -250,6 +268,13 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             context = ecosystem.equals("") ? null : contexts.get(ecosystem);
             if (context == null) {
                 throw new UnsupportedOperationException(vulnerability.getId() + ": Malformed ecosystem data or unsupported ecosystem \"" + ecosystem + "\"");
+            }
+        }
+
+        private void setDbContext(String forge) {
+            context = forge.equals("") ? null : contexts.get(forge);
+            if (context == null) {
+                throw new UnsupportedOperationException(vulnerability.getId() + ": Malformed ecosystem data or unsupported ecosystem \"" + forge + "\"");
             }
         }
 

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -185,8 +185,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 }
             }
             else {
-                updateCallablesAndPackageVersions(v, vulnerabilityId, "", -1L, context);
                 logger.info(v.getId() + ": No matching packages found in database.");
+                updateCallablesAndPackageVersions(v, vulnerabilityId, "", -1L, context);
             }
         }
 
@@ -251,7 +251,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 });
             }
             else {
-                logger.info(v.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl + ", skipping callables.");
+                logger.info(v.getId() + ": could not find package-version in DB for last vulnerable purl: " + lastVulnerablePurl + ", skipping callable search.");
                 if(fastenApiClient.getApiUrl() != null) {
                     requestPurlIngestion(v, lastVulnerablePurl);
                 }

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -37,10 +37,14 @@ import java.text.ParseException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static eu.fasten.core.data.vulnerability.Vulnerability.sortPurls;
 
 public class VulnerabilityStatementsProcessor extends Plugin {
 
@@ -84,7 +88,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 var vulnerability = gson.fromJson(record, Vulnerability.class);
                 logger.info("Read vulnerability statement " + vulnerability.getId() + " from " + consumeTopics.toString());
                 refreshMetadataUtility();
-                insertVulnerability(vulnerability);
+                var vulnerabilityId = insertVulnerability(vulnerability);
+                updateCallablesAndPackageVersions(vulnerability, vulnerabilityId);
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
                 lastProcessedVulnerability = vulnerability;
             } catch (Exception e) {
@@ -156,12 +161,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             this.fastenApiClient = client;
         }
 
-        /**
-         * Method to inject the information contained in a Vulnerability Object.
-         *
-         * @param v               - Vulnerability Object
-         */
-        public void insertVulnerability(Vulnerability v)  {
+        public Long insertVulnerability(Vulnerability v)  {
             var context = getDBContext(v);
 
             v.filterUnsupportedPatches(extensions);
@@ -172,36 +172,57 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
 
             logger.info(v.getId() + ": Inserting vulnerability into the database for ecosystem " + "\"" + v.getEcosystem() + "\".");
-            metadataUtility.insertVulnerability(v, context);
-            updateCallablesAndPackageVersions(v);
+            return metadataUtility.insertVulnerability(v, context);
         }
 
-        public void updateCallablesAndPackageVersions(Vulnerability v) {
+        public void updateCallablesAndPackageVersions(Vulnerability v, Long vulnerabilityId) {
             var context = getDBContext(v);
-            var purls = v.getValidatedPurls();
-            var pkgIds = metadataUtility.getPackageIds(context, purls);
-            if (pkgIds.size() == 0) {
-                logger.info(v.getId() + ": No matching packages found in database.");
-                return;
+            var allPurls = v.getValidatedPurls();
+            var pkgIds = metadataUtility.getPackageIds(context, allPurls);
+            if (pkgIds.size() > 0) {
+                for(var pkgId : pkgIds.entrySet()) {
+                    updateCallablesAndPackageVersions(v, vulnerabilityId, pkgId.getKey(), pkgId.getValue(), context);
+                }
             }
+            else {
+                updateCallablesAndPackageVersions(v, vulnerabilityId, "", -1L, context);
+                logger.info(v.getId() + ": No matching packages found in database.");
+            }
+        }
 
-            var vulnerablePackageVersionIds = metadataUtility.getPackageVersionIds(purls, context, pkgIds);
+        public void updateCallablesAndPackageVersions(Vulnerability v, Long vulnerabilityId, String packageName, Long pkgId, DSLContext context) {
+            var vulnerablePackageVersionIds = updateVulnerablePackageVersions(v, vulnerabilityId, packageName, pkgId, context);
+            updateVulnerableCallables(v, vulnerabilityId, pkgId, vulnerablePackageVersionIds, context);
             if (vulnerablePackageVersionIds.size() == 0) {
                 logger.info(v.getId() + ": No matching package-versions found in database.");
-                return;
             }
+        }
 
-            var vulnerableFastenUris = new HashSet<String>();
-            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(v, pkgIds, context));
-            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(v, pkgIds, context));
-            var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds, context);
-            var vulnerableCallableIds = vulnerableCallables.keySet();
-            v.setFastenUris(new HashSet<>(vulnerableCallables.values()));
+        private List<Long> updateVulnerablePackageVersions(Vulnerability v, Long vulnerabilityId, String packageName, Long pkgId, DSLContext context) {
+            var purls = getPurlsForPackage(v.getValidatedPurls(), packageName);
+            var pkgIdMap = new HashMap<String, Long>();
+            pkgIdMap.put(packageName, pkgId);
+            var vulnerablePackageVersionIds= metadataUtility.getPackageVersionIds(purls, context, pkgIdMap);
 
-            var vulnerabilityId = metadataUtility.getVulnerabilityId(v.getId(), context);
             logger.info(v.getId() + ": Inserting data for " + vulnerablePackageVersionIds.size() + " vulnerable package-versions into the database.");
             vulnerablePackageVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(v, id, context));
             metadataUtility.insertVulnerabilityToPackageVersions(vulnerabilityId, vulnerablePackageVersionIds, context);
+            return vulnerablePackageVersionIds;
+        }
+
+        private LinkedHashSet<Purl> getPurlsForPackage(LinkedHashSet<Purl> purls, String packageName) {
+            return sortPurls(purls.stream()
+                .filter(p -> packageName.equals(p.getPackageName()))
+                .collect(Collectors.toCollection(LinkedHashSet::new)));
+        }
+
+        private void updateVulnerableCallables(Vulnerability v, Long vulnerabilityId, Long pkgId, List<Long> vulnerablePackageVersionIds, DSLContext context) {
+            var vulnerableFastenUris = new HashSet<String>();
+            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(v, pkgId, context));
+            vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(v, pkgId, context));
+            var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds, context);
+            var vulnerableCallableIds = vulnerableCallables.keySet();
+            v.setFastenUris(new HashSet<>(vulnerableCallables.values()));
 
             logger.info(v.getId() + ": Inserting data for " + vulnerableCallableIds.size() + " vulnerable callables into the database.");
             vulnerableCallableIds.forEach(id -> metadataUtility.injectCallableVulnerability(v, id, context));
@@ -217,9 +238,9 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return context;
         }
 
-        private HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {
+        private HashSet<String> findFastenUrisInLastVulnerableVersion(Vulnerability v, Long pkgId, DSLContext context) {
             var lastVulnerablePurl = getLastVulnerablePurl(v);
-            var lastVulnVersionId = findIdForPurl(lastVulnerablePurl, pkgIds, context);
+            var lastVulnVersionId = findIdForPurl(lastVulnerablePurl, pkgId, context);
             var fastenUris = new HashSet<String>();
             if(lastVulnVersionId != -1L) {
                 v.getPatches().forEach(p -> {
@@ -258,8 +279,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return purls[purls.length - 1];
         }
 
-        private HashSet<String> findFastenUrisInFirstPatchedVersion(Vulnerability v, HashMap<String, Long> pkgIds, DSLContext context) {
-            var firstPatchedVersionId = findIdForPurl(getFirstPatchedPurl(v), pkgIds, context);
+        private HashSet<String> findFastenUrisInFirstPatchedVersion(Vulnerability v, Long pkgId, DSLContext context) {
+            var firstPatchedVersionId = findIdForPurl(getFirstPatchedPurl(v), pkgId, context);
             var fastenUris = new HashSet<String>();
             if(firstPatchedVersionId != -1L) {
                 v.getPatches().forEach(p -> {
@@ -281,12 +302,9 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return null;
         }
 
-        private Long findIdForPurl(Purl purl, HashMap<String, Long> pkgIds, DSLContext context) {
-            if (purl != null) {
-                var purlPkdId = pkgIds.get(purl.getPackageName());
-                if(purlPkdId != null) {
-                    return metadataUtility.getPackageVersionId(purl, context, purlPkdId);
-                }
+        private Long findIdForPurl(Purl purl, Long pkgId, DSLContext context) {
+            if (purl != null && pkgId != -1) {
+                return metadataUtility.getPackageVersionId(purl, context, pkgId);
             }
             return -1L;
         }

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -93,8 +94,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 logger.info("Read vulnerability statement " + vulnerability.getId() + " from " + consumeTopics.toString());
                 setDbContext();
                 setMetadataUtility();
-                vulnerabilityId = updateVulnerability();
-                updatePackageVersionsAndCallables();
+                updatePackageVersionsAndCallables(vulnerability, updateVulnerability());
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
                 lastProcessedVulnerability = vulnerability;
             } catch (Exception e) {
@@ -185,6 +185,14 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return metadataUtility.insertVulnerability(vulnerability, context);
         }
 
+        public void updatePackageVersionsAndCallables(Vulnerability v, Long vId) {
+            if(metadataUtility == null) setMetadataUtility();
+            this.vulnerability = v;
+            setDbContext();
+            this.vulnerabilityId = vId;
+            updatePackageVersionsAndCallables(v.getValidatedPurls(), null);
+        }
+
         public void updatePackageVersionAndCallables(String ecosystem, String packageName, String version) {
             if(metadataUtility == null) setMetadataUtility();
             setDbContext(ecosystem);
@@ -192,49 +200,47 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             logger.info("Found the following vulnerabilities for " + packageName + ":" + version + ": " + vulnerabilities.toString());
             vulnerabilities.forEach(vulnerabilityId -> {
                 var jsonStatement = metadataUtility.getVulnerabilityStatement(vulnerabilityId, context);
-                updatePackageVersionsAndCallables(gson.fromJson(jsonStatement, Vulnerability.class), vulnerabilityId);
+                this.vulnerability = gson.fromJson(jsonStatement, Vulnerability.class);
+                this.vulnerabilityId = vulnerabilityId;
+                updatePackageVersionsAndCallables(getPurlsForPackage(vulnerability.getValidatedPurls(), packageName), version);
             });
         }
 
-        public void updatePackageVersionsAndCallables(Vulnerability v, Long vId) {
-            if(metadataUtility == null) setMetadataUtility();
-            this.vulnerability = v;
-            setDbContext();
-            this.vulnerabilityId = vId;
-            updatePackageVersionsAndCallables();
-        }
-
-        private void updatePackageVersionsAndCallables() {
-            var allPurls = vulnerability.getValidatedPurls();
-            var pkgIds = metadataUtility.getPackageIds(context, allPurls);
+        private void updatePackageVersionsAndCallables(LinkedHashSet<Purl> purls, String version) {
+            var pkgIds = metadataUtility.getPackageIds(context, purls);
             if (pkgIds.size() > 0) {
                 for(var pkgId : pkgIds.entrySet()) {
-                    updatePackageVersionAndCallables(pkgId.getKey(), pkgId.getValue());
+                    var purlsForPackage = getPurlsForPackage(purls, pkgId.getKey());
+                    var purlsToUpdate = purlsForPackage;
+                    if(version != null) {
+                        purlsToUpdate = getPurlsForVersion(purlsForPackage, new ComparableVersion(version));
+                    }
+                    var vulnerablePackageVersionIds = updateVulnerablePackageVersions(purlsToUpdate, pkgId.getValue());
+                    updateVulnerableCallables(purlsForPackage, pkgId.getValue(), vulnerablePackageVersionIds);
+
+                    if (vulnerablePackageVersionIds.size() == 0) {
+                        logger.info(vulnerability.getId() + ": No matching package-versions for package + " + pkgId.getKey() + " found in database.");
+                    }
                 }
             }
             else {
                 logger.info(vulnerability.getId() + ": No matching packages found in database.");
-                updatePackageVersionAndCallables("", -1L);
+                updateVulnerableCallables(purls, -1L, updateVulnerablePackageVersions(purls, -1L));
             }
         }
 
-        private void updatePackageVersionAndCallables(String packageName, Long pkgId) {
-            var vulnerablePackageVersionIds = updateVulnerablePackageVersions(packageName, pkgId);
-            updateVulnerableCallables(pkgId, vulnerablePackageVersionIds);
-            if (vulnerablePackageVersionIds.size() == 0) {
-                logger.info(vulnerability.getId() + ": No matching package-versions found in database.");
+        private List<Long> updateVulnerablePackageVersions(LinkedHashSet<Purl> purls, Long pkgId) {
+            var vulnerablePackageVersionIds = new ArrayList<Long>();
+            if(purls.size() > 0) {
+                var packageName = purls.stream().findFirst().orElseThrow().getPackageName();
+                var pkgIdMap = new HashMap<String, Long>();
+                pkgIdMap.put(packageName, pkgId);
+                vulnerablePackageVersionIds.addAll(metadataUtility.getPackageVersionIds(purls, context, pkgIdMap));
             }
-        }
-
-        private List<Long> updateVulnerablePackageVersions(String packageName, Long pkgId) {
-            var purls = getPurlsForPackage(vulnerability.getValidatedPurls(), packageName);
-            var pkgIdMap = new HashMap<String, Long>();
-            pkgIdMap.put(packageName, pkgId);
-            var vulnerablePackageVersionIds= metadataUtility.getPackageVersionIds(purls, context, pkgIdMap);
-
             logger.info(vulnerability.getId() + ": Inserting data for " + vulnerablePackageVersionIds.size() + " vulnerable package-versions into the database.");
             vulnerablePackageVersionIds.forEach(id -> metadataUtility.injectPackageVersionVulnerability(vulnerability, id, context));
             metadataUtility.insertVulnerabilityToPackageVersions(vulnerabilityId, vulnerablePackageVersionIds, context);
+
             return vulnerablePackageVersionIds;
         }
 
@@ -250,9 +256,9 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                     .collect(Collectors.toCollection(LinkedHashSet::new)));
         }
 
-        private void updateVulnerableCallables(Long pkgId, List<Long> vulnerablePackageVersionIds) {
+        private void updateVulnerableCallables(LinkedHashSet<Purl> purls, Long pkgId, List<Long> vulnerablePackageVersionIds) {
             var vulnerableFastenUris = new HashSet<String>();
-            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(pkgId));
+            vulnerableFastenUris.addAll(findFastenUrisInLastVulnerableVersion(purls, pkgId));
             vulnerableFastenUris.addAll(findFastenUrisInFirstPatchedVersion(pkgId));
             var vulnerableCallables = findVulnerableCallables(vulnerableFastenUris, vulnerablePackageVersionIds);
             var vulnerableCallableIds = vulnerableCallables.keySet();
@@ -278,8 +284,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
         }
 
-        private HashSet<String> findFastenUrisInLastVulnerableVersion(Long pkgId) {
-            var lastVulnerablePurl = getLastVulnerablePurl();
+        private HashSet<String> findFastenUrisInLastVulnerableVersion(LinkedHashSet<Purl> purls, Long pkgId) {
+            var lastVulnerablePurl = findLast(purls);
             var lastVulnVersionId = findIdForPurl(lastVulnerablePurl, pkgId);
             var fastenUris = new HashSet<String>();
             if(lastVulnVersionId != -1L) {
@@ -312,11 +318,11 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
         }
 
-        private Purl getLastVulnerablePurl() {
-            Purl[] purls = new Purl[vulnerability.getValidatedPurls().size()];
-            assert purls.length > 0;
-            purls = vulnerability.getValidatedPurls().toArray(purls);
-            return purls[purls.length - 1];
+        private Purl findLast(LinkedHashSet<Purl> purls) {
+            Purl[] purlsArray = new Purl[purls.size()];
+            assert purlsArray.length > 0;
+            purlsArray = purls.toArray(purlsArray);
+            return purlsArray[purlsArray.length - 1];
         }
 
         private HashSet<String> findFastenUrisInFirstPatchedVersion(Long pkgId) {

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -90,8 +90,8 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             try {
                 vulnerability = gson.fromJson(record, Vulnerability.class);
                 logger.info("Read vulnerability statement " + vulnerability.getId() + " from " + consumeTopics.toString());
-                setDBContext();
-                refreshMetadataUtility();
+                setDbContext();
+                setMetadataUtility();
                 vulnerabilityId = updateVulnerability();
                 updateCallablesAndPackageVersions();
                 outputPath = baseOutputPath + File.separator + vulnerability.getId() + ".json";
@@ -153,7 +153,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         public void freeResource() {
         }
 
-        public void refreshMetadataUtility() {
+        public void setMetadataUtility() {
             metadataUtility = new MetadataUtility();
         }
 
@@ -165,13 +165,14 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             this.fastenApiClient = client;
         }
 
-        public Long updateVulnerability(Vulnerability v, DSLContext context) {
-            this.context = context;
+        public Long updateVulnerability(Vulnerability v) {
+            if(metadataUtility == null) setMetadataUtility();
             this.vulnerability = v;
+            setDbContext();
             return updateVulnerability();
         }
 
-        public Long updateVulnerability()  {
+        private Long updateVulnerability()  {
             vulnerability.filterUnsupportedPatches(extensions);
             try {
                 vulnerability.updatePatchDate();
@@ -183,14 +184,15 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             return metadataUtility.insertVulnerability(vulnerability, context);
         }
 
-        public void updateCallablesAndPackageVersions(Vulnerability v, Long vId, DSLContext context) {
-            this.context = context;
+        public void updateCallablesAndPackageVersions(Vulnerability v, Long vId) {
+            if(metadataUtility == null) setMetadataUtility();
             this.vulnerability = v;
+            setDbContext();
             this.vulnerabilityId = vId;
             updateCallablesAndPackageVersions();
         }
 
-        public void updateCallablesAndPackageVersions() {
+        private void updateCallablesAndPackageVersions() {
             var allPurls = vulnerability.getValidatedPurls();
             var pkgIds = metadataUtility.getPackageIds(context, allPurls);
             if (pkgIds.size() > 0) {
@@ -204,7 +206,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             }
         }
 
-        public void updateCallablesAndPackageVersions(String packageName, Long pkgId) {
+        private void updateCallablesAndPackageVersions(String packageName, Long pkgId) {
             var vulnerablePackageVersionIds = updateVulnerablePackageVersions(packageName, pkgId);
             updateVulnerableCallables(pkgId, vulnerablePackageVersionIds);
             if (vulnerablePackageVersionIds.size() == 0) {
@@ -243,7 +245,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             metadataUtility.insertVulnerabilityToCallables(vulnerabilityId, vulnerableCallableIds, context);
         }
 
-        public void setDBContext() {
+        private void setDbContext() {
             var ecosystem = vulnerability.getEcosystem();
             context = ecosystem.equals("") ? null : contexts.get(ecosystem);
             if (context == null) {

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -93,8 +93,8 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        var vId = kafkaPlugin.insertVulnerability(v);
-        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
+        var vId = kafkaPlugin.updateVulnerability(v, context);
+        kafkaPlugin.updateCallablesAndPackageVersions(v, vId, context);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
@@ -197,8 +197,8 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        var vId = kafkaPlugin.insertVulnerability(v);
-        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
+        var vId = kafkaPlugin.updateVulnerability(v, context);
+        kafkaPlugin.updateCallablesAndPackageVersions(v, vId, context);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -31,7 +31,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.text.ParseException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doNothing;
@@ -88,7 +93,8 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        kafkaPlugin.insertVulnerability(v);
+        var vId = kafkaPlugin.insertVulnerability(v);
+        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
@@ -191,7 +197,8 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        kafkaPlugin.insertVulnerability(v);
+        var vId = kafkaPlugin.insertVulnerability(v);
+        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -93,8 +93,8 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        var vId = kafkaPlugin.updateVulnerability(v, context);
-        kafkaPlugin.updateCallablesAndPackageVersions(v, vId, context);
+        var vId = kafkaPlugin.updateVulnerability(v);
+        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
@@ -197,8 +197,8 @@ public class VulnerabilityStatementsProcessorTest {
         when(metadataUtility.getFullFastenUri(fasten_uri, 42L)).thenReturn("full_fasten_uri");
 
         // CALL
-        var vId = kafkaPlugin.updateVulnerability(v, context);
-        kafkaPlugin.updateCallablesAndPackageVersions(v, vId, context);
+        var vId = kafkaPlugin.updateVulnerability(v);
+        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());

--- a/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
+++ b/analyzer/vulnerability-statements-processor/src/test/java/eu/fasten/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessorTest.java
@@ -94,7 +94,7 @@ public class VulnerabilityStatementsProcessorTest {
 
         // CALL
         var vId = kafkaPlugin.updateVulnerability(v);
-        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
+        kafkaPlugin.updatePackageVersionsAndCallables(v, vId);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());
@@ -198,7 +198,7 @@ public class VulnerabilityStatementsProcessorTest {
 
         // CALL
         var vId = kafkaPlugin.updateVulnerability(v);
-        kafkaPlugin.updateCallablesAndPackageVersions(v, vId);
+        kafkaPlugin.updatePackageVersionsAndCallables(v, vId);
 
         // MOCKITO VERIFY
         Mockito.verify(metadataUtility).getPackageIds(context, v.getValidatedPurls());

--- a/core/src/main/java/eu/fasten/core/data/vulnerability/Vulnerability.java
+++ b/core/src/main/java/eu/fasten/core/data/vulnerability/Vulnerability.java
@@ -285,7 +285,7 @@ public class Vulnerability implements Serializable {
         return validatedFirstPatchedPurls;
     }
 
-    public LinkedHashSet<Purl> validateAndSortPurls(LinkedHashSet<String> purls) {
+    public static LinkedHashSet<Purl> validateAndSortPurls(LinkedHashSet<String> purls) {
         var validatedPurls = new LinkedHashSet<Purl>();
         purls.forEach(p -> {
             var parsedPurl = Purl.of(p);
@@ -293,7 +293,11 @@ public class Vulnerability implements Serializable {
                 validatedPurls.add(parsedPurl);
             }
         });
-        return validatedPurls.stream().sorted(Comparator.comparing(Purl::getVersion)).
+        return sortPurls(validatedPurls);
+    }
+
+    public static LinkedHashSet<Purl> sortPurls(LinkedHashSet<Purl> purls) {
+        return purls.stream().sorted(Comparator.comparing(Purl::getVersion)).
             collect(Collectors.toCollection(LinkedHashSet::new));
     }
 


### PR DESCRIPTION
## Description
Lists of purls in the vulnerability statements sometimes contain purls for different packages; this was not handled correctly while searching for the last vulnerable purl. This case has been fixed. Also, not all first patched purls were searched for vulnerable callables; this has also been fixed.

A refactoring was done on the vulnerability-packages-listener to defer most work to the vulnerability-statements-processor. It now simply notifies on package-version updates. On such updates, only the specific package-version is processed, not all possible package-versions for each matching vulnerability.

## Motivation and context
Bug fixes and efficiency.

## Testing
Unit tests, local runs.
