### PR TITLE
Reduce plugin description to one line to fix manifest error

### DIFF
--- a/analyzer/javacg-opal/pom.xml
+++ b/analyzer/javacg-opal/pom.xml
@@ -151,10 +151,7 @@
 										<Plugin-Class>eu.fasten.analyzer.javacgopal.OPALPlugin</Plugin-Class>
 										<Plugin-Id>opal-plugin</Plugin-Id>
 										<Plugin-Version>0.0.1</Plugin-Version>
-										<Plugin-Description>
-											Given a Maven coordinate or a file,
-											generates call graphs and puts them into a Kafka topic
-										</Plugin-Description>
+										<Plugin-Description>Generates CGs for Maven packages/files</Plugin-Description>
 										<Plugin-License>Apache License 2.0</Plugin-License>
 									</manifestEntries>
 								</transformer>


### PR DESCRIPTION
Fixes the issue reported in #349.

The problem is hilarious: when the plugin description is broken down to multiple lines (which is perfectly fine in the declaring XML), the resulting `MANIFEST.MF` contains new lines that the parser does not like. In the particular case, the line was too long, so the auto-formatter added a new line.

The simple solution was to shorten the description to make sure that we do not see this issue happening again (accidentally). Maybe we should think about removing the description altogether from all plugins, what do they add?