### PR TITLE
Extended stored error information in FastenKafkaPlugin

### DIFF
--- a/server/src/main/java/eu/fasten/server/plugins/kafka/ExistsInLocalStorageException.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/ExistsInLocalStorageException.java
@@ -1,9 +1,37 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.fasten.server.plugins.kafka;
 
-public class ExistsInLocalStorageException extends Exception {
+public class ExistsInLocalStorageException extends RuntimeException {
 
-    public ExistsInLocalStorageException(String errorMessage) {
-        super(errorMessage);
+    private static final long serialVersionUID = -6286814935442948792L;
+
+    public ExistsInLocalStorageException() {
+        super();
     }
 
+    public ExistsInLocalStorageException(String msg) {
+        super(msg);
+    }
+
+    public ExistsInLocalStorageException(Throwable t) {
+        super(t);
+    }
+
+    public ExistsInLocalStorageException(String msg, Throwable t) {
+        super(msg, t);
+    }
 }


### PR DESCRIPTION
I changed the way error information is stored by the `FastenKafkaPlugin`. Instead of using our own custom `JsonObject`, I now simply use the `ExceptionUtils` from Apache commons to store exactly the string that would normally be printed on the terminal. This includes everything we have stored so far, plus additional information like nested exceptions.

To make things easier to edit, I used an auto-formatter in the first commit, but did not introduce any other changes... the programmatic changes happen in the other commits. As a reviewer, you should look at the commits separately to make it easier for you to understand what has changed.

In the course of this extension, I also did several minor improvements to readability/maintainability and I also added a proper teardown method to the `KafkaPluginConsumeBehaviorTest`.