### PR TITLE
Adjust API response to prettify rendering of callables in web

### DIFF
--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -21,8 +21,12 @@ package eu.fasten.core.data.metadatadb;
 import com.github.t9t.jooq.json.JsonbDSL;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.FastenJavaURI;
+import eu.fasten.core.data.FastenURI;
 import eu.fasten.core.data.metadatadb.codegen.Keys;
 import eu.fasten.core.data.metadatadb.codegen.enums.Access;
 import eu.fasten.core.data.metadatadb.codegen.enums.CallableType;
@@ -39,6 +43,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.*;
 import static org.jooq.impl.DSL.*;
@@ -1058,7 +1064,7 @@ public class MetadataDao {
 
         var res = queryResult.formatJSON(new JSONFormat().format(true).header(false).recordFormat(JSONFormat.RecordFormat.OBJECT).quoteNested(false));
 
-        // Parse result json string back into object
+        // Temporary variable to contain pre-processed json from the query.
         JSONArray json;
         try {
             json = new JSONArray(res);
@@ -1067,10 +1073,14 @@ public class MetadataDao {
             return null;
         }
 
+        // The gson that will convert raw fasten uri into parsed object.
         GsonBuilder builder = new GsonBuilder();
         Gson gson = builder.create();
 
-        // Go through each callable, parse fasten uri, insert signature.
+        // The result array that will be returned.
+        JSONArray result = new JSONArray();
+
+        // Go through each callable, convert raw fasten uri into parsed object, write down to result array.
         for (Object j : json) {
             try {
                 JSONObject jObj = (JSONObject) j;
@@ -1079,11 +1089,13 @@ public class MetadataDao {
                 var uriObj = new FastenJavaURI(fullUri);
                 var js =  gson.toJson(uriObj);
                 jObj.put("fasten_uri", new JSONObject(js));
+                result.put(jObj);
             } catch (IllegalArgumentException err) {
                 logger.warn("Error FASTEN URI Parser: " + err.toString());
             }
         }
-        return json.toString();
+
+        return result.toString();
     }
 
     public String getPackageBinaryModules(String packageName, String packageVersion, int offset, int limit) throws PackageVersionNotFoundException {


### PR DESCRIPTION
## Description
In the API response of list of callables for the module, instead of raw Fasten URI, include the parsed object of it.

## Motivation and context
In order for the web app to be more dynamic and clear in how it renders callables for the users, it needs Fasten URI to be parsed into pieces (method name, arguments and return types, etc), so the web can display them accordingly and functionally rich.

## Additional context
Related: [fasten-project/fasten-web!66](https://github.com/fasten-project/fasten-web/pull/66)
