### PR TITLE
Added build on windows-2019

### DIFF
--- a/.github/workflows/dockerpublish_develop_slim.yaml
+++ b/.github/workflows/dockerpublish_develop_slim.yaml
@@ -1,36 +1,43 @@
-name: Publish Docker image
+name: Build, test, and publish slim FASTEN server image
 
 on:
   push:
-    # Publish `develop` as Docker `latest` image.
     branches:
       - develop
 
-  # Run tests for any PRs.
   pull_request:
     branches:
       - develop
 
 env:
-  # TODO: Change variable to your image's name.
   IMAGE_NAME: fasten.server.develop.slim
 
 jobs:
-
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
-  push:
-
-    runs-on: ubuntu-18.04
+  windows-build:
+    runs-on: windows-2019
     if: github.event_name == 'push'
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.11
+          java-version: '11'
+      - name: Build jar
+        run: mvn clean install
+
+  linux-build-and-push:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
       - name: Build jar
         run: mvn clean install
       - name: Build image


### PR DESCRIPTION
## Description
Adds a Github action job to build on Windows.

## Motivation and context
FASTEN development promises a portable development environment, including Windows. However, we had no CI for Windows, leading to non-portable code from getting committed.

