### PR TITLE
Avoid unnecessary Maven progress reports in builds

### DIFF
--- a/.github/workflows/maven_develop.yml
+++ b/.github/workflows/maven_develop.yml
@@ -24,4 +24,4 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Build with Maven
-        run: mvn clean install
+        run: mvn -B -ntp clean install

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
             <version>1.7.32</version>
         </dependency>
         <dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-nop</artifactId>
+		    <version>1.7.30</version>
+		    <scope>test</scope>
+		</dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.7</version>


### PR DESCRIPTION
Maven's default progress indicators make the build output hard to read. This minimal change should avoid this.