### PR TITLE
Reduce the logs generated by merger and cg generator

### DIFF
--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/OPALPartialCallGraphConstructor.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/OPALPartialCallGraphConstructor.java
@@ -260,20 +260,19 @@ public class OPALPartialCallGraphConstructor {
 
     private Stmt<DUVar<ValueInformation>>[] getStmts(Function1<Method, AITACode<TACMethodParameter, ValueInformation>> tac,
                                                      Method definedSource) {
-        Stmt<DUVar<ValueInformation>>[] stmts = null;
-        if (definedSource != null) {
-            AITACode<TACMethodParameter, ValueInformation> sourceTac = null;
-            try {
-                sourceTac = tac.apply(definedSource);
-
-            }catch (NoSuchElementException e){
-            	// TODO investigate this warning, as it happens frequently in practice!
-                logger.warn("couldn't find the stmt");
-            }
-            if (sourceTac != null) {
-                stmts = sourceTac.stmts();
-            }
+        if (definedSource == null) {
+            return null;
         }
-        return stmts;
+        AITACode<TACMethodParameter, ValueInformation> sourceTac;
+        try {
+            sourceTac = tac.apply(definedSource);
+        } catch (NoSuchElementException e){
+            // TODO this happens frequently in practice, investigate why!
+            return null;
+        }
+        if (sourceTac == null) {
+            return null;
+        }
+        return sourceTac.stmts();
     }
 }

--- a/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/OPALPartialCallGraphConstructor.java
+++ b/analyzer/javacg-opal/src/main/java/eu/fasten/analyzer/javacgopal/data/OPALPartialCallGraphConstructor.java
@@ -254,11 +254,7 @@ public class OPALPartialCallGraphConstructor {
                 cha.appendGraph(sourceDeclaration, cg.calleesOf(sourceDeclaration), getStmts(tac,
                     null), pcg.graph, incompeletes, visitedPCs, callSiteOnly);
             }
-            if (!incompeletes.isEmpty()) {
-                logger.warn("There is an incomplete call site " +
-                    "that OPAL did not take care of. source: " + sourceDeclaration + "PCs: "+ incompeletes);
 
-            }
         }
     }
 

--- a/core/src/main/java/eu/fasten/core/merge/CGMerger.java
+++ b/core/src/main/java/eu/fasten/core/merge/CGMerger.java
@@ -423,8 +423,7 @@ public class CGMerger {
         if (metadata == null) {
             return null;
         }
-        logger.info("Merging graph with {} nodes and {} edges",
-            callGraph.numNodes(), callGraph.numArcs());
+
         final Set<LongLongPair> edges = ConcurrentHashMap.newKeySet();
 
         metadata.gid2NodeMetadata.long2ObjectEntrySet().parallelStream().forEach(entry -> {
@@ -450,10 +449,6 @@ public class CGMerger {
             addEdge(result, edge.firstLong(), edge.secondLong());
         }
 
-        logger.info("Merged call graphs in {} seconds, num node: {}, num edges: {}",
-            new DecimalFormat("#0.000").format(
-                (System.currentTimeMillis() - totalTime) / 1000d), result.numNodes(),
-            result.numArcs());
         return result;
     }
 
@@ -870,7 +865,7 @@ public class CGMerger {
                 result.addEdge(longLongPair.firstLong(), longLongPair.secondLong());
             }
         }
-        logger.info("Number of Augmented nodes: {}", numNode);
+        logger.info("Number of Augmented nodes: {} edges: {}", numNode, result.numArcs());
 
         return result;
     }


### PR DESCRIPTION
## Description
Remove some of the less necessary yet frequent log statements from the merger and CG generator not to pollute our builds.
