### PR TITLE
Fix ExtendendGID Graphs produced by C & Python Metadata Plugin

### DIFF
--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -275,9 +275,10 @@ public abstract class MetadataDBExtension implements KafkaPlugin, DBConnector {
         var gid2uriMap = new HashMap<Long, String>(callablesIds.size());
         callables.forEach(c -> gid2uriMap.put(lidToGidMap.get(c.getId().longValue()), c.getFastenUri()));
 
-        // Create a GID Graph for production
         var typesMap = new HashMap<Long, String>(namespaceMap.size());
         namespaceMap.forEach((k, v) -> typesMap.put(v, k));
+        
+        // Create a GID Graph for production
         this.gidGraph = new ExtendedGidGraph(packageVersionId, callGraph.product, callGraph.version,
                 callablesIds, numInternal, edges, gid2uriMap, typesMap);
         return packageVersionId;

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabaseCPlugin.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabaseCPlugin.java
@@ -24,7 +24,7 @@ import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.ExtendedRevisionCCallGraph;
 import eu.fasten.core.data.ExtendedRevisionCallGraph;
 import eu.fasten.core.data.Graph;
-import eu.fasten.core.data.callableindex.GidGraph;
+import eu.fasten.core.data.callableindex.ExtendedGidGraph;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.data.metadatadb.codegen.enums.Access;
 import eu.fasten.core.data.metadatadb.codegen.tables.records.CallSitesRecord;
@@ -136,9 +136,15 @@ public class MetadataDatabaseCPlugin extends Plugin {
             callablesIds.addAll(internalNodesSet);
             callablesIds.addAll(externalNodesSet);
 
+            var gid2uriMap = new HashMap<Long, String>(callablesIds.size());
+            callables.forEach(c -> gid2uriMap.put(lidToGidMap.get(c.getId().longValue()), c.getFastenUri()));
+
+            var typesMap = new HashMap<Long, String>(namespaceMap.size());
+            namespaceMap.forEach((k, v) -> typesMap.put(v, k));
+            
             // Create a GID Graph for production
-            this.gidGraph = new GidGraph(packageVersionId, callGraph.product, callGraph.version,
-                    callablesIds, numInternal, edges);
+            this.gidGraph = new ExtendedGidGraph(packageVersionId, callGraph.product, callGraph.version,
+                    callablesIds, numInternal, edges, gid2uriMap, typesMap);
             return packageVersionId;
         }
 

--- a/core/src/main/java/eu/fasten/core/data/callableindex/ExtendedGidGraph.java
+++ b/core/src/main/java/eu/fasten/core/data/callableindex/ExtendedGidGraph.java
@@ -75,14 +75,25 @@ public class ExtendedGidGraph extends GidGraph {
     public JSONObject toJSON() {
         var json = super.toJSON();
         var callSitesInfo = new JSONObject();
-        getCallsInfo().forEach((edge, info) -> {
-            var edgeStr = String.format("[%d, %d]", edge.getFirst(), edge.getSecond());
-            var infoJson = new JSONObject();
-            infoJson.put("line", info.getLine());
-            infoJson.put("receiver_type_ids", new JSONArray(Arrays.asList(info.getReceiverTypeIds())));
-            infoJson.put("call_type", info.getCallType().getLiteral());
-            callSitesInfo.put(edgeStr, infoJson);
-        });
+        try {
+            getCallsInfo().forEach((edge, info) -> {
+                var edgeStr = String.format("[%d, %d]", edge.getFirst(), edge.getSecond());
+                var infoJson = new JSONObject();
+                infoJson.put("line", info.getLine());
+                infoJson.put("receiver_type_ids", new JSONArray(Arrays.asList(info.getReceiverTypeIds())));
+                infoJson.put("call_type", info.getCallType().getLiteral());
+                callSitesInfo.put(edgeStr, infoJson);
+            });
+        } catch(NullPointerException e) {
+            getCallsInfo().forEach((edge, info) -> {
+                var edgeStr = String.format("[%d, %d]", edge.getFirst(), edge.getSecond());
+                var infoJson = new JSONObject();
+                infoJson.put("line", JSONObject.NULL);
+                infoJson.put("receiver_type_ids", JSONObject.NULL);
+                infoJson.put("call_type", JSONObject.NULL);
+                callSitesInfo.put(edgeStr, infoJson);
+            });
+        }
         json.put("callsites_info", callSitesInfo);
         var gidToUriJson = new JSONObject();
         this.gidToUriMap.forEach((k, v) -> gidToUriJson.put(String.valueOf(k), v));

--- a/core/src/main/java/eu/fasten/core/data/callableindex/ExtendedGidGraph.java
+++ b/core/src/main/java/eu/fasten/core/data/callableindex/ExtendedGidGraph.java
@@ -71,29 +71,39 @@ public class ExtendedGidGraph extends GidGraph {
         return typeMap;
     }
 
+    public JSONObject toCPythonJSON() {
+        var json = super.toJSON();
+        var callSitesInfo = new JSONObject();
+        getCallsInfo().forEach((edge, info) -> {
+            var edgeStr = String.format("[%d, %d]", edge.getFirst(), edge.getSecond());
+            var infoJson = new JSONObject();
+            infoJson.put("line", JSONObject.NULL);
+            infoJson.put("receiver_type_ids", JSONObject.NULL);
+            infoJson.put("call_type", JSONObject.NULL);
+            callSitesInfo.put(edgeStr, infoJson);
+        });
+        json.put("callsites_info", callSitesInfo);
+        var gidToUriJson = new JSONObject();
+        this.gidToUriMap.forEach((k, v) -> gidToUriJson.put(String.valueOf(k), v));
+        json.put("gid_to_uri", gidToUriJson);
+        var typesJson = new JSONObject();
+        this.typeMap.forEach((k, v) -> typesJson.put(String.valueOf(k), v));
+        json.put("types_map", typesJson);
+        return json;
+    }
+
     @Override
     public JSONObject toJSON() {
         var json = super.toJSON();
         var callSitesInfo = new JSONObject();
-        try {
-            getCallsInfo().forEach((edge, info) -> {
-                var edgeStr = String.format("[%d, %d]", edge.getFirst(), edge.getSecond());
-                var infoJson = new JSONObject();
-                infoJson.put("line", info.getLine());
-                infoJson.put("receiver_type_ids", new JSONArray(Arrays.asList(info.getReceiverTypeIds())));
-                infoJson.put("call_type", info.getCallType().getLiteral());
-                callSitesInfo.put(edgeStr, infoJson);
-            });
-        } catch(NullPointerException e) {
-            getCallsInfo().forEach((edge, info) -> {
-                var edgeStr = String.format("[%d, %d]", edge.getFirst(), edge.getSecond());
-                var infoJson = new JSONObject();
-                infoJson.put("line", JSONObject.NULL);
-                infoJson.put("receiver_type_ids", JSONObject.NULL);
-                infoJson.put("call_type", JSONObject.NULL);
-                callSitesInfo.put(edgeStr, infoJson);
-            });
-        }
+        getCallsInfo().forEach((edge, info) -> {
+            var edgeStr = String.format("[%d, %d]", edge.getFirst(), edge.getSecond());
+            var infoJson = new JSONObject();
+            infoJson.put("line", info.getLine());
+            infoJson.put("receiver_type_ids", new JSONArray(Arrays.asList(info.getReceiverTypeIds())));
+            infoJson.put("call_type", info.getCallType().getLiteral());
+            callSitesInfo.put(edgeStr, infoJson);
+        });
         json.put("callsites_info", callSitesInfo);
         var gidToUriJson = new JSONObject();
         this.gidToUriMap.forEach((k, v) -> gidToUriJson.put(String.valueOf(k), v));


### PR DESCRIPTION
## Description
This Pull Request aims to fix the ExtendendGID Graphs produced by C & Python Metadata Plugin on two ways:

### Feed the C output topic with ExtendedGID graphs instead of GID
Firstly, regarding the C Metadata Plugin, it produced graphs following the GID format  for the output kafka topic . 
In order to be properly employed by the Callable Indexer and thus stored in the RocksDao db,
 the produced C Graphs were modified to follow the ExtendedGIDFormat, just like Python and Java.

### Avoid NullPointerException when producing ExtendedGID Graphs.
Secondly, as pointed out by @MagielBruntink, despite the fact that the Python Metadata Plugin succesfully stored metadata in the db, it failed to produce the ExtendedGID Graphs to the output topic. This happened because as can be seen bellow:

https://github.com/fasten-project/fasten/blob/600985190e07aa479a6f25bd2e13155dc084c941/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPlugin.java#L167

https://github.com/fasten-project/fasten/blob/600985190e07aa479a6f25bd2e13155dc084c941/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDatabaseCPlugin.java#L247

for both C & Python only the Graph edges were stored in the CallSites table. This resulted on an NullPointerException later, as in order to get a json representation of the ExtendedGID Graph, the attributes of the Call Sites table where retrieved from the db on the following way:

https://github.com/fasten-project/fasten/blob/600985190e07aa479a6f25bd2e13155dc084c941/core/src/main/java/eu/fasten/core/data/callableindex/ExtendedGidGraph.java#L80-L86

This resulted on an NullPointerException, preventing the production to the output topic. 
This exception was not triggered for java revisions, meaning that in the java db, all the call sites table attributes  were always popullated, avoiding every time the exception.

Thus, in order to tackle this issue, since Java always has populated attributes whereas C & Python never, we created a new toJson() method which is the exact same with the initial one, with the main difference that  we populate all the "callsites_information" attributes of the ExtendedGID Graph with null values, in order to follow the exact same format with Java. This method is employed when processing C & Python Revisions on the Metadata Plugin.

## Motivation and context

With this fix, the Metadata C & Python Plugin will have the excepcted behaviour. instead of triggering an NullPointerException.

## Testing

I tested both C & Python Metadata Plugins by feeding on them Dummy Kafka Topics, and observing the results on the produced topics( fasten.MetadaDBC/PythonExtension.err & fasten.MetadaDBC/PythonExtension.out). The Graphs had the expected format without  producing any record in the Error Kafka topics.

