### PR TITLE
Quckfix: make VulnCallChainsAPI lazy so init after KnowledgeBaseConne…

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/VulnerableCallChainsApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/VulnerableCallChainsApi.java
@@ -18,6 +18,7 @@
 
 package eu.fasten.analyzer.restapiplugin.mvn.api;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Lazy
 @RestController
 @RequestMapping("/{forge}/packages/{pkg}/{pkg_ver}/vulnerable-call-chains")
 public class VulnerableCallChainsApi {

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/VulnerableCallChainsApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/VulnerableCallChainsApiServiceImpl.java
@@ -32,7 +32,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 


### PR DESCRIPTION
## Description
The PR makes `Vulnerable Call Chains API` controller lazy, so it would be initialized later.

## Motivation
The Rest API deployment currently fails, because new controller of `Vulnerable Call Chains API` is being initialized, while `KnowledgeBaseConnector` has not yet fetched plugin's arguments.