### PR TITLE
Fix vulnerability statements processor db cleanup

### DIFF
--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -167,7 +167,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
             logger.info("Read vulnerability statement " + v.getId() + " from " + consumeTopics.toString());
             contexts.keySet().forEach(ecosystem -> getDbContext(ecosystem).
                     transaction(configuration -> {
-                        logger.info(v.getId() + ": Inserting vulnerability into the database for ecosystem: " + "\"" + ecosystem + "\".");
+                        logger.info(v.getId() + ": Updating vulnerability in the database for ecosystem: " + "\"" + ecosystem + "\".");
                         var vulnerabilityForEcosystem = gson.fromJson(record, Vulnerability.class);
                         restrictByEcosystem(vulnerabilityForEcosystem, ecosystem);
                         updateVulnerability(vulnerabilityForEcosystem, DSL.using(configuration));
@@ -189,9 +189,13 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 metadataUtility.deleteVulnerabilityData(vulnerability.getId(), vulnerabilityId, dbContext);
             }
             if(!vulnerability.getValidatedPurls().isEmpty()) {
+                logger.info(vulnerability.getId() + ": Inserting vulnerability and purls.");
                 vulnerabilityId = metadataUtility.insertVulnerability(vulnerability, dbContext);
                 metadataUtility.insertPurls(vulnerabilityId, vulnerability.getValidatedPurls(), dbContext);
                 updatePackageVersions(null, dbContext);
+            }
+            else {
+                logger.info(vulnerability.getId() + ": No relevant purls for ecosystem, skipping insertion.");
             }
         }
 

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -165,7 +165,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         public Vulnerability updateVulnerability(String record) {
             var v = gson.fromJson(record, Vulnerability.class);
             logger.info("Read vulnerability statement " + v.getId() + " from " + consumeTopics.toString());
-            v.getEcosystems().forEach(ecosystem -> getDbContext(ecosystem).
+            contexts.keySet().forEach(ecosystem -> getDbContext(ecosystem).
                     transaction(configuration -> {
                         logger.info(v.getId() + ": Inserting vulnerability into the database for ecosystem: " + "\"" + ecosystem + "\".");
                         var vulnerabilityForEcosystem = gson.fromJson(record, Vulnerability.class);
@@ -184,10 +184,15 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         private void updateVulnerability(DSLContext dbContext)  {
             updateVulnerabilityPatchData();
 
-            this.vulnerabilityId = metadataUtility.insertVulnerability(vulnerability, dbContext);
-            metadataUtility.deleteVulnerabilityData(vulnerability.getId(), vulnerabilityId, dbContext);
-            metadataUtility.insertPurls(vulnerabilityId, vulnerability.getValidatedPurls(), dbContext);
-            updatePackageVersions(null, dbContext);
+            this.vulnerabilityId = metadataUtility.getVulnerabilityId(vulnerability.getId(), dbContext);
+            if(vulnerabilityId != -1) {
+                metadataUtility.deleteVulnerabilityData(vulnerability.getId(), vulnerabilityId, dbContext);
+            }
+            if(!vulnerability.getValidatedPurls().isEmpty()) {
+                metadataUtility.insertVulnerability(vulnerability, dbContext);
+                metadataUtility.insertPurls(vulnerabilityId, vulnerability.getValidatedPurls(), dbContext);
+                updatePackageVersions(null, dbContext);
+            }
         }
 
         private void updateVulnerabilityPatchData() {

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -189,7 +189,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 metadataUtility.deleteVulnerabilityData(vulnerability.getId(), vulnerabilityId, dbContext);
             }
             if(!vulnerability.getValidatedPurls().isEmpty()) {
-                metadataUtility.insertVulnerability(vulnerability, dbContext);
+                vulnerabilityId = metadataUtility.insertVulnerability(vulnerability, dbContext);
                 metadataUtility.insertPurls(vulnerabilityId, vulnerability.getValidatedPurls(), dbContext);
                 updatePackageVersions(null, dbContext);
             }

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
@@ -446,7 +446,7 @@ public class MetadataUtility {
             return pkgRecord.component1();
         }
         else {
-            return null;
+            return -1L;
         }
     }
 

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/db/MetadataUtility.java
@@ -457,6 +457,11 @@ public class MetadataUtility {
 
         deletePackageVersionVulnerabilityData(externalVulnerabilityId, vulnerabilityId, context);
         deleteCallableVulnerabilityData(externalVulnerabilityId, vulnerabilityId, context);
+
+        context.deleteFrom(Vulnerabilities.VULNERABILITIES)
+                .where(Vulnerabilities.VULNERABILITIES.ID.equal(vulnerabilityId))
+                .and(Vulnerabilities.VULNERABILITIES.EXTERNAL_ID.equal(externalVulnerabilityId))
+                .execute();
     }
 
     private void deletePackageVersionVulnerabilityData(String externalVulnerabilityId, Long vulnerabilityId, DSLContext context) {


### PR DESCRIPTION
## Description
Improved the vulnerability-statements-processor by cleaning up DBs of all ecosystems. This is useful in case old data is remaining after bugs or data issues.

