### PR TITLE
Fix minor bug in getERCGLinkTest()

### DIFF
--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
@@ -162,7 +162,7 @@ public class PackageApiServiceImplTest {
         packageName = "junit:junit";
         version = "4.12";
         Mockito.when(kbDao.assertPackageExistence(packageName, version)).thenReturn(false);
-        result = service.getPackageVersion(packageName, version, null, null);
+        result = service.getERCGLink(packageName, version, null, null);
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
     }
 }


### PR DESCRIPTION
## Description
 Fixed a minor bug in getERCGLinkTest(). More specifically, in the assertion test, I replaced getPackageVersion()  with the correct getERCGLink() method call. It is a very tiny change, but i preferred to submit a PR rather than changing it directly on develop branch, for documentation purposes.