### PR TITLE
Refactor REST-API Plugin Tests

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImpl.java
@@ -117,6 +117,7 @@ public class StitchingApiServiceImpl implements StitchingApiService {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
+    @Override
     public ResponseEntity<String> batchIngestArtifacts(JSONArray jsonArtifacts) {
         var artifacts = new ArrayList<LazyIngestionProvider.IngestedArtifact>();
         for (int i = 0; i < jsonArtifacts.length(); i++) {

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/ModuleApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/ModuleApiTest.java
@@ -47,7 +47,7 @@ public class ModuleApiTest {
         Mockito.when(service.getPackageModules(packageName, version, offset, limit, null, null)).thenReturn(response);
         var result = api.getPackageModules(packageName, version, offset, limit, null, null);
         assertEquals(response, result);
-        Mockito.verify(service, Mockito.times(1)).getPackageModules(packageName, version, offset, limit, null, null);
+        Mockito.verify(service).getPackageModules(packageName, version, offset, limit, null, null);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class ModuleApiTest {
         Mockito.when(service.getModuleMetadata(packageName, version, module, null, null)).thenReturn(response);
         var result = api.getModuleMetadata(packageName, version, module, null, null);
         assertEquals(response, result);
-        Mockito.verify(service, Mockito.times(1)).getModuleMetadata(packageName, version, module, null, null);
+        Mockito.verify(service).getModuleMetadata(packageName, version, module, null, null);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ModuleApiTest {
         Mockito.when(service.getModuleFiles(packageName, version, module, offset, limit, null, null)).thenReturn(response);
         var result = api.getModuleFiles(packageName, version, module, offset, limit, null, null);
         assertEquals(response, result);
-        Mockito.verify(service, Mockito.times(1)).getModuleFiles(packageName, version, module, offset, limit, null, null);
+        Mockito.verify(service).getModuleFiles(packageName, version, module, offset, limit, null, null);
     }
 
     @Test
@@ -83,6 +83,6 @@ public class ModuleApiTest {
         Mockito.when(service.getModuleCallables(packageName, version, module, offset, limit, null, null)).thenReturn(response);
         var result = api.getModuleCallables(packageName, version, module, offset, limit, null, null);
         assertEquals(response, result);
-        Mockito.verify(service, Mockito.times(1)).getModuleCallables(packageName, version, module, offset, limit, null, null);
+        Mockito.verify(service).getModuleCallables(packageName, version, module, offset, limit, null, null);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/ModuleApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/ModuleApiTest.java
@@ -47,7 +47,7 @@ public class ModuleApiTest {
         Mockito.when(service.getPackageModules(packageName, version, offset, limit, null, null)).thenReturn(response);
         var result = api.getPackageModules(packageName, version, offset, limit, null, null);
         assertEquals(response, result);
-        Mockito.verify(service).getPackageModules(packageName, version, offset, limit, null, null);
+        Mockito.verify(service, Mockito.times(1)).getPackageModules(packageName, version, offset, limit, null, null);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class ModuleApiTest {
         Mockito.when(service.getModuleMetadata(packageName, version, module, null, null)).thenReturn(response);
         var result = api.getModuleMetadata(packageName, version, module, null, null);
         assertEquals(response, result);
-        Mockito.verify(service).getModuleMetadata(packageName, version, module, null, null);
+        Mockito.verify(service, Mockito.times(1)).getModuleMetadata(packageName, version, module, null, null);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ModuleApiTest {
         Mockito.when(service.getModuleFiles(packageName, version, module, offset, limit, null, null)).thenReturn(response);
         var result = api.getModuleFiles(packageName, version, module, offset, limit, null, null);
         assertEquals(response, result);
-        Mockito.verify(service).getModuleFiles(packageName, version, module, offset, limit, null, null);
+        Mockito.verify(service, Mockito.times(1)).getModuleFiles(packageName, version, module, offset, limit, null, null);
     }
 
     @Test
@@ -83,6 +83,6 @@ public class ModuleApiTest {
         Mockito.when(service.getModuleCallables(packageName, version, module, offset, limit, null, null)).thenReturn(response);
         var result = api.getModuleCallables(packageName, version, module, offset, limit, null, null);
         assertEquals(response, result);
-        Mockito.verify(service).getModuleCallables(packageName, version, module, offset, limit, null, null);
+        Mockito.verify(service, Mockito.times(1)).getModuleCallables(packageName, version, module, offset, limit, null, null);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/BinaryModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/BinaryModuleApiServiceImplTest.java
@@ -51,11 +51,12 @@ public class BinaryModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getPackageBinaryModules(packageName, version, offset, limit, null, null);
         assertEquals(expected, result);
-        Mockito.verify(kbDao).getPackageBinaryModules(packageName, version, offset, limit);
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageBinaryModules(packageName, version, offset, limit);
     }
 
+
     @Test
-    void getBinaryModuleMetadataTest() {
+    void getBinaryModuleMetadataPositiveTest() {
         var packageName = "pkg";
         var version = "pkg ver";
         var module = "bin module";
@@ -65,11 +66,20 @@ public class BinaryModuleApiServiceImplTest {
         var result = service.getBinaryModuleMetadata(packageName, version, module, null, null);
         assertEquals(expected, result);
 
+        Mockito.verify(kbDao, Mockito.times(1)).getBinaryModuleMetadata(packageName, version, module);
+    }
+
+    @Test
+    void getBinaryModuleMetadataNegativeTest() {
+        var packageName = "pkg";
+        var version = "pkg ver";
+        var module = "bin module";
+
         Mockito.when(kbDao.getBinaryModuleMetadata(packageName, version, module)).thenReturn(null);
-        result = service.getBinaryModuleMetadata(packageName, version, module, null, null);
+        var result = service.getBinaryModuleMetadata(packageName, version, module, null, null);
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
 
-        Mockito.verify(kbDao, Mockito.times(2)).getBinaryModuleMetadata(packageName, version, module);
+        Mockito.verify(kbDao, Mockito.times(1)).getBinaryModuleMetadata(packageName, version, module);
     }
 
     @Test
@@ -82,6 +92,6 @@ public class BinaryModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getBinaryModuleFiles(packageName, version, module, offset, limit, null, null);
         assertEquals(expected, result);
-        Mockito.verify(kbDao).getBinaryModuleFiles(packageName, version, module, offset, limit);
+        Mockito.verify(kbDao, Mockito.times(1)).getBinaryModuleFiles(packageName, version, module, offset, limit);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/BinaryModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/BinaryModuleApiServiceImplTest.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.restapiplugin.mvn.api.impl;
 import eu.fasten.analyzer.restapiplugin.mvn.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.mvn.RestApplication;
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,7 +44,7 @@ public class BinaryModuleApiServiceImplTest {
     }
 
     @Test
-    void getPackageBinaryModulesTest() {
+    void getPackageBinaryModulesPositiveTest() {
         var packageName = "pkg";
         var version = "pkg ver";
         var response = "modules";
@@ -54,6 +55,15 @@ public class BinaryModuleApiServiceImplTest {
         Mockito.verify(kbDao, Mockito.times(1)).getPackageBinaryModules(packageName, version, offset, limit);
     }
 
+    @Test
+    void getPackageBinaryModulesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        Mockito.when(kbDao.getPackageBinaryModules(packageName, version, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getPackageBinaryModules(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageBinaryModules(packageName, version, offset, limit);
+    }
 
     @Test
     void getBinaryModuleMetadataPositiveTest() {
@@ -83,7 +93,19 @@ public class BinaryModuleApiServiceImplTest {
     }
 
     @Test
-    void getBinaryModuleFilesTest() {
+    void getBinaryModuleMetadataIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        var module = "bin module";
+        Mockito.when(kbDao.getBinaryModuleMetadata(packageName, version, module)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getBinaryModuleMetadata(packageName, version, module, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
+        Mockito.verify(kbDao, Mockito.times(1)).getBinaryModuleMetadata(packageName, version, module);
+    }
+
+    @Test
+    void getBinaryModuleFilesPositiveTest() {
         var packageName = "pkg";
         var version = "pkg ver";
         var module = "bin module";
@@ -92,6 +114,18 @@ public class BinaryModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getBinaryModuleFiles(packageName, version, module, offset, limit, null, null);
         assertEquals(expected, result);
+        Mockito.verify(kbDao, Mockito.times(1)).getBinaryModuleFiles(packageName, version, module, offset, limit);
+    }
+
+    @Test
+    void getBinaryModuleFilesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        var module = "bin module";
+        Mockito.when(kbDao.getBinaryModuleFiles(packageName, version, module, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getBinaryModuleFiles(packageName, version, module, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
         Mockito.verify(kbDao, Mockito.times(1)).getBinaryModuleFiles(packageName, version, module, offset, limit);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImplTest.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.restapiplugin.mvn.api.impl;
 import eu.fasten.analyzer.restapiplugin.mvn.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.mvn.RestApplication;
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class CallableApiServiceImplTest {
     }
 
     @Test
-    void getPackageCallablesTest() {
+    void getPackageCallablesPositiveTest() {
         var packageName = "pkg";
         var version = "pkg ver";
         var response = "callables";
@@ -54,6 +55,17 @@ public class CallableApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getPackageCallables(packageName, version, offset, limit, null, null);
         assertEquals(expected, result);
+        Mockito.verify(kbDao).getPackageCallables(packageName, version, offset, limit);
+    }
+
+    @Test
+    void getPackageCallablesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        Mockito.when(kbDao.getPackageCallables(packageName, version, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getPackageCallables(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
         Mockito.verify(kbDao).getPackageCallables(packageName, version, offset, limit);
     }
 

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImplTest.java
@@ -58,7 +58,7 @@ public class CallableApiServiceImplTest {
     }
 
     @Test
-    void getCallableMetadataTest() {
+    void getCallableMetadataPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var callable = "callable uri";
@@ -68,21 +68,32 @@ public class CallableApiServiceImplTest {
         var result = service.getCallableMetadata(packageName, version, callable, null, null);
         assertEquals(expected, result);
 
+        Mockito.verify(kbDao, Mockito.times(1)).getCallableMetadata(packageName, version, callable);
+    }
+
+    @Test
+    void getCallableMetadataNegativeTest() {
+        var packageName = "group:artifact";
+        var version = "version";
+        var callable = "callable uri";
         Mockito.when(kbDao.getCallableMetadata(packageName, version, callable)).thenReturn(null);
-        result = service.getCallableMetadata(packageName, version, callable, null, null);
+        var result = service.getCallableMetadata(packageName, version, callable, null, null);
         assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
-
-        Mockito.verify(kbDao, Mockito.times(2)).getCallableMetadata(packageName, version, callable);
-
-        packageName = "junit:junit";
-        version = "4.12";
-        Mockito.when(kbDao.getCallableMetadata(packageName, version, callable)).thenReturn(null);
-        result = service.getCallableMetadata(packageName, version, callable, null, null);
-        assertEquals(HttpStatus.CREATED, result.getStatusCode());
 
         Mockito.verify(kbDao, Mockito.times(1)).getCallableMetadata(packageName, version, callable);
     }
 
+    @Test
+    void getCallableMetadataIngestTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        var callable = "callable uri";
+        Mockito.when(kbDao.getCallableMetadata(packageName, version, callable)).thenReturn(null);
+        var result = service.getCallableMetadata(packageName, version, callable, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
+        Mockito.verify(kbDao, Mockito.times(1)).getCallableMetadata(packageName, version, callable);
+    }
     @Test
     void getCallablesTest() {
         var ids = List.of(1L, 2L, 3L);

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/CallableApiServiceImplTest.java
@@ -94,6 +94,7 @@ public class CallableApiServiceImplTest {
 
         Mockito.verify(kbDao, Mockito.times(1)).getCallableMetadata(packageName, version, callable);
     }
+
     @Test
     void getCallablesTest() {
         var ids = List.of(1L, 2L, 3L);

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/DependencyApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/DependencyApiServiceImplTest.java
@@ -22,14 +22,14 @@ import eu.fasten.analyzer.restapiplugin.mvn.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.mvn.RestApplication;
 import eu.fasten.analyzer.restapiplugin.mvn.api.DependencyApi;
 import eu.fasten.core.data.metadatadb.MetadataDao;
-import org.json.JSONObject;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import java.util.HashMap;
-import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DependencyApiServiceImplTest {
@@ -47,7 +47,7 @@ public class DependencyApiServiceImplTest {
     }
 
     @Test
-    void getPackageDependenciesTest() {
+    void getPackageDependenciesPositiveTest() {
         var packageName = "pkg";
         var version = "pkg ver";
         var response = "dependencies";
@@ -58,4 +58,13 @@ public class DependencyApiServiceImplTest {
         Mockito.verify(kbDao).getPackageDependencies(packageName, version, offset, limit);
     }
 
+    @Test
+    void getPackageDependenciesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        Mockito.when(kbDao.getPackageDependencies(packageName, version, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getPackageDependencies(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+        Mockito.verify(kbDao).getPackageDependencies(packageName, version, offset, limit);
+    }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/EdgeApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/EdgeApiServiceImplTest.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.restapiplugin.mvn.api.impl;
 import eu.fasten.analyzer.restapiplugin.mvn.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.mvn.RestApplication;
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,7 +44,7 @@ public class EdgeApiServiceImplTest {
     }
 
     @Test
-    void getPackageEdgesTest() {
+    void getPackageEdgesPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var response = "edges";
@@ -54,4 +55,13 @@ public class EdgeApiServiceImplTest {
         Mockito.verify(kbDao).getPackageEdges(packageName, version, offset, limit);
     }
 
+    @Test
+    void getPackageEdgesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        Mockito.when(kbDao.getPackageEdges(packageName, version, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getPackageEdges(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+        Mockito.verify(kbDao).getPackageEdges(packageName, version, offset, limit);
+    }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/FileApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/FileApiServiceImplTest.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.restapiplugin.mvn.api.impl;
 import eu.fasten.analyzer.restapiplugin.mvn.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.mvn.RestApplication;
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,7 +44,7 @@ public class FileApiServiceImplTest {
     }
 
     @Test
-    void getPackageFilesTest() {
+    void getPackageFilesPositiveTest() {
         var packageName = "pkg";
         var version = "pkg ver";
         var response = "files";
@@ -54,4 +55,13 @@ public class FileApiServiceImplTest {
         Mockito.verify(kbDao).getPackageFiles(packageName, version, offset, limit);
     }
 
+    @Test
+    void getPackageFilesIngestionTest(){
+        var packageName = "junit:junit";
+        var version = "4.12";
+        Mockito.when(kbDao.getPackageFiles(packageName, version, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getPackageFiles(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+        Mockito.verify(kbDao).getPackageFiles(packageName, version, offset, limit);
+    }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
@@ -55,7 +55,7 @@ public class ModuleApiServiceImplTest {
     }
 
     @Test
-    void getModuleMetadataTest() {
+    void getModuleMetadataPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var module = "module";
@@ -65,13 +65,20 @@ public class ModuleApiServiceImplTest {
         var result = service.getModuleMetadata(packageName, version, module, null, null);
         assertEquals(expected, result);
 
-        Mockito.when(kbDao.getModuleMetadata(packageName, version, module)).thenReturn(null);
-        result = service.getModuleMetadata(packageName, version, module, null, null);
-        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
-
-        Mockito.verify(kbDao, Mockito.times(2)).getModuleMetadata(packageName, version, module);
+        Mockito.verify(kbDao, Mockito.times(1)).getModuleMetadata(packageName, version, module);
     }
 
+    @Test
+    void getModuleMetadataNegativeTest() {
+        var packageName = "group:artifact";
+        var version = "version";
+        var module = "module";
+        Mockito.when(kbDao.getModuleMetadata(packageName, version, module)).thenReturn(null);
+        var result = service.getModuleMetadata(packageName, version, module, null, null);
+        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+
+        Mockito.verify(kbDao, Mockito.times(1)).getModuleMetadata(packageName, version, module);
+    }
     @Test
     void getModuleFilesTest() {
         var packageName = "group:artifact";

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
@@ -43,7 +43,7 @@ public class ModuleApiServiceImplTest {
     }
 
     @Test
-    void getPackageModulesTest() {
+    void getPackageModulesPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var response = "modules";
@@ -51,6 +51,17 @@ public class ModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getPackageModules(packageName, version, offset, limit, null, null);
         assertEquals(expected, result);
+        Mockito.verify(kbDao).getPackageModules(packageName, version, offset, limit);
+    }
+
+    @Test
+    void getPackageModulesNegativeTest() {
+        var packageName = "group:artifact";
+        var version = "version";
+        Mockito.when(kbDao.getPackageModules(packageName, version, offset, limit)).thenReturn(null);
+        var result = service.getPackageModules(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+
         Mockito.verify(kbDao).getPackageModules(packageName, version, offset, limit);
     }
 
@@ -81,7 +92,7 @@ public class ModuleApiServiceImplTest {
     }
 
     @Test
-    void getModuleFilesTest() {
+    void getModuleFilesPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var module = "module";
@@ -90,6 +101,17 @@ public class ModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getModuleFiles(packageName, version, module, offset, limit, null, null);
         assertEquals(expected, result);
+        Mockito.verify(kbDao).getModuleFiles(packageName, version, module, offset, limit);
+    }
+
+    @Test
+    void getModuleFilesNegativeTest() {
+        var packageName = "group:artifact";
+        var version = "version";
+        var module = "module";
+        Mockito.when(kbDao.getModuleFiles(packageName, version, module, offset, limit)).thenReturn(null);
+        var result = service.getModuleFiles(packageName, version, module, offset, limit, null, null);
+        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
         Mockito.verify(kbDao).getModuleFiles(packageName, version, module, offset, limit);
     }
 
@@ -103,6 +125,17 @@ public class ModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getModuleCallables(packageName, version, module, offset, limit, null, null);
         assertEquals(expected, result);
+        Mockito.verify(kbDao).getModuleCallables(packageName, version, module, offset, limit);
+    }
+
+    @Test
+    void getModuleCallablesNegativeTest() {
+        var packageName = "group:artifact";
+        var version = "version";
+        var module = "module";
+        Mockito.when(kbDao.getModuleCallables(packageName, version, module, offset, limit)).thenReturn(null);
+        var result = service.getModuleCallables(packageName, version, module, offset, limit, null, null);
+        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
         Mockito.verify(kbDao).getModuleCallables(packageName, version, module, offset, limit);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
@@ -105,7 +105,7 @@ public class ModuleApiServiceImplTest {
     }
 
     @Test
-    void getModuleCallablesTest() {
+    void getModuleCallablesPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var module = "module";

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
@@ -79,6 +79,7 @@ public class ModuleApiServiceImplTest {
 
         Mockito.verify(kbDao, Mockito.times(1)).getModuleMetadata(packageName, version, module);
     }
+
     @Test
     void getModuleFilesTest() {
         var packageName = "group:artifact";

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.restapiplugin.mvn.api.impl;
 import eu.fasten.analyzer.restapiplugin.mvn.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.mvn.RestApplication;
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,7 +44,7 @@ public class ModuleApiServiceImplTest {
     }
 
     @Test
-    void getPackageModulesTest() {
+    void getPackageModulesPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var response = "modules";
@@ -51,6 +52,17 @@ public class ModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getPackageModules(packageName, version, offset, limit, null, null);
         assertEquals(expected, result);
+        Mockito.verify(kbDao).getPackageModules(packageName, version, offset, limit);
+    }
+
+    @Test
+    void getPackageModulesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        Mockito.when(kbDao.getPackageModules(packageName, version, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getPackageModules(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
         Mockito.verify(kbDao).getPackageModules(packageName, version, offset, limit);
     }
 
@@ -81,6 +93,17 @@ public class ModuleApiServiceImplTest {
     }
 
     @Test
+    void getModuleMetadataIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        var module = "module";
+        Mockito.when(kbDao.getModuleMetadata(packageName, version, module)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getModuleMetadata(packageName, version, module, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
+        Mockito.verify(kbDao, Mockito.times(1)).getModuleMetadata(packageName, version, module);
+    }
+    @Test
     void getModuleFilesPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
@@ -101,6 +124,18 @@ public class ModuleApiServiceImplTest {
         Mockito.when(kbDao.getModuleFiles(packageName, version, module, offset, limit)).thenReturn(null);
         var result = service.getModuleFiles(packageName, version, module, offset, limit, null, null);
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+        Mockito.verify(kbDao).getModuleFiles(packageName, version, module, offset, limit);
+    }
+
+    @Test
+    void getModuleFilesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        var module = "module";
+        Mockito.when(kbDao.getModuleFiles(packageName, version, module, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getModuleFiles(packageName, version, module, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
         Mockito.verify(kbDao).getModuleFiles(packageName, version, module, offset, limit);
     }
 
@@ -127,4 +162,17 @@ public class ModuleApiServiceImplTest {
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
         Mockito.verify(kbDao).getModuleCallables(packageName, version, module, offset, limit);
     }
+
+    @Test
+    void getModuleCallablesIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        var module = "module";
+        Mockito.when(kbDao.getModuleCallables(packageName, version, module, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getModuleCallables(packageName, version, module, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
+        Mockito.verify(kbDao).getModuleCallables(packageName, version, module, offset, limit);
+    }
+
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/ModuleApiServiceImplTest.java
@@ -43,7 +43,7 @@ public class ModuleApiServiceImplTest {
     }
 
     @Test
-    void getPackageModulesPositiveTest() {
+    void getPackageModulesTest() {
         var packageName = "group:artifact";
         var version = "version";
         var response = "modules";
@@ -51,17 +51,6 @@ public class ModuleApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getPackageModules(packageName, version, offset, limit, null, null);
         assertEquals(expected, result);
-        Mockito.verify(kbDao).getPackageModules(packageName, version, offset, limit);
-    }
-
-    @Test
-    void getPackageModulesNegativeTest() {
-        var packageName = "group:artifact";
-        var version = "version";
-        Mockito.when(kbDao.getPackageModules(packageName, version, offset, limit)).thenReturn(null);
-        var result = service.getPackageModules(packageName, version, offset, limit, null, null);
-        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
-
         Mockito.verify(kbDao).getPackageModules(packageName, version, offset, limit);
     }
 

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
@@ -115,7 +115,7 @@ public class PackageApiServiceImplTest {
     }
 
     @Test
-    void getPackageVersionLazyIngestionTest() {
+    void getPackageVersionIngestionTest() {
         var packageName = "junit:junit";
         var version = "4.12";
         Mockito.when(kbDao.getPackageVersion(packageName, version)).thenReturn(null);

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
@@ -58,7 +58,7 @@ public class PackageApiServiceImplTest {
     }
 
     @Test
-    void getPackageLastVersionTest() {
+    void getPackageLastVersionPositiveTest() {
         var packageName = "group:artifact";
         var response = "a package";
         Mockito.when(kbDao.getPackageLastVersion(packageName)).thenReturn(response);
@@ -66,11 +66,17 @@ public class PackageApiServiceImplTest {
         var result = service.getPackageLastVersion(packageName);
         assertEquals(expected, result);
 
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageLastVersion(packageName);
+    }
+
+    @Test
+    void getPackageLastVersionNegativeTest() {
+        var packageName = "group:artifact";
         Mockito.when(kbDao.getPackageLastVersion(packageName)).thenReturn(null);
-        result = service.getPackageLastVersion(packageName);
+        var result = service.getPackageLastVersion(packageName);
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
 
-        Mockito.verify(kbDao, Mockito.times(2)).getPackageLastVersion(packageName);
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageLastVersion(packageName);
     }
 
     @Test
@@ -81,11 +87,11 @@ public class PackageApiServiceImplTest {
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.getPackageVersions(packageName, offset, limit);
         assertEquals(expected, result);
-        Mockito.verify(kbDao).getPackageVersions(packageName, offset, limit);
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageVersions(packageName, offset, limit);
     }
 
     @Test
-    void getPackageVersionTest() {
+    void getPackageVersionPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var response = "package version";
@@ -94,23 +100,33 @@ public class PackageApiServiceImplTest {
         var result = service.getPackageVersion(packageName, version, null, null);
         assertEquals(expected, result);
 
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageVersion(packageName, version);
+    }
+
+    @Test
+    void getPackageVersionNegativeTest() {
+        var packageName = "group:artifact";
+        var version = "version";
         Mockito.when(kbDao.getPackageVersion(packageName, version)).thenReturn(null);
-        result = service.getPackageVersion(packageName, version, null, null);
+        var result = service.getPackageVersion(packageName, version, null, null);
         assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
 
-        Mockito.verify(kbDao, Mockito.times(2)).getPackageVersion(packageName, version);
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageVersion(packageName, version);
+    }
 
-        packageName = "junit:junit";
-        version = "4.12";
+    @Test
+    void getPackageVersionLazyIngestionTest() {
+        var packageName = "junit:junit";
+        var version = "4.12";
         Mockito.when(kbDao.getPackageVersion(packageName, version)).thenReturn(null);
-        result = service.getPackageVersion(packageName, version, null, null);
+        var result = service.getPackageVersion(packageName, version, null, null);
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
 
         Mockito.verify(kbDao, Mockito.times(1)).getPackageVersion(packageName, version);
     }
 
     @Test
-    void getPackageMetadataTest() {
+    void getPackageMetadataPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var response = "package metadata";
@@ -119,11 +135,18 @@ public class PackageApiServiceImplTest {
         var result = service.getPackageMetadata(packageName, version);
         assertEquals(expected, result);
 
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageMetadata(packageName, version);
+    }
+
+    @Test
+    void getPackageNegativeMetadataTest() {
+        var packageName = "group:artifact";
+        var version = "version";
         Mockito.when(kbDao.getPackageMetadata(packageName, version)).thenReturn(null);
-        result = service.getPackageMetadata(packageName, version);
+        var result = service.getPackageMetadata(packageName, version);
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
 
-        Mockito.verify(kbDao, Mockito.times(2)).getPackageMetadata(packageName, version);
+        Mockito.verify(kbDao, Mockito.times(1)).getPackageMetadata(packageName, version);
     }
 
     @Test
@@ -151,7 +174,7 @@ public class PackageApiServiceImplTest {
 
     @Test
     @Disabled("Causes internet traffic")
-    void getERCGLinkTest() throws IOException {
+    void getERCGLinkPositiveTest() throws IOException {
         var packageName = "junit:junit";
         var version = "4.12";
         Mockito.when(kbDao.assertPackageExistence(packageName, version)).thenReturn(true);
@@ -159,10 +182,19 @@ public class PackageApiServiceImplTest {
         var result = service.getERCGLink(packageName, version, null, null);
         assertNotNull(result);
 
-        packageName = "junit:junit";
-        version = "4.12";
+        Mockito.verify(kbDao, Mockito.times(1)).assertPackageExistence(packageName, version);
+
+    }
+
+    @Test
+    void getERCGLinkNegativeTest() throws IOException {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        KnowledgeBaseConnector.rcgBaseUrl = "http://lima.ewi.tudelft.nl/";
         Mockito.when(kbDao.assertPackageExistence(packageName, version)).thenReturn(false);
-        result = service.getPackageVersion(packageName, version, null, null);
+        var result = service.getERCGLink(packageName, version, null, null);
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
+        Mockito.verify(kbDao, Mockito.times(1)).assertPackageExistence(packageName, version);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
@@ -162,13 +162,23 @@ public class PackageApiServiceImplTest {
     }
 
     @Test
-    void searchPackageNamesTest() {
+    void searchPackageNamesPositiveTest() {
         var packageName = "group:artifact";
         var response = "matching package versions";
         Mockito.when(kbDao.searchPackageNames(packageName, offset, limit)).thenReturn(response);
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
         var result = service.searchPackageNames(packageName, offset, limit);
         assertEquals(expected, result);
+        Mockito.verify(kbDao).searchPackageNames(packageName, offset, limit);
+    }
+
+    @Test
+    void searchPackageNamesNegativeTest() {
+        var packageName = "group:artifact";
+        Mockito.when(kbDao.searchPackageNames(packageName, offset, limit)).thenReturn(null);
+        var result = service.searchPackageNames(packageName, offset, limit);
+        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+
         Mockito.verify(kbDao).searchPackageNames(packageName, offset, limit);
     }
 
@@ -190,7 +200,6 @@ public class PackageApiServiceImplTest {
     void getERCGLinkNegativeTest() throws IOException {
         var packageName = "junit:junit";
         var version = "4.12";
-        KnowledgeBaseConnector.rcgBaseUrl = "http://lima.ewi.tudelft.nl/";
         Mockito.when(kbDao.assertPackageExistence(packageName, version)).thenReturn(false);
         var result = service.getERCGLink(packageName, version, null, null);
         assertEquals(HttpStatus.CREATED, result.getStatusCode());

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageApiServiceImplTest.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.restapiplugin.mvn.api.impl;
 import eu.fasten.analyzer.restapiplugin.mvn.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.mvn.RestApplication;
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -150,7 +151,7 @@ public class PackageApiServiceImplTest {
     }
 
     @Test
-    void getPackageCallgraphTest() throws IOException {
+    void getPackageCallgraphPositiveTest() throws IOException {
         var packageName = "group:artifact";
         var version = "version";
         var response = "package callgraph";
@@ -159,6 +160,17 @@ public class PackageApiServiceImplTest {
         var result = service.getPackageCallgraph(packageName, version, offset, limit, null, null);
         Mockito.verify(kbDao).getPackageCallgraph(packageName, version, offset, limit);
         assertEquals(expected, result);
+    }
+
+    @Test
+    void getPackageCallgraphIngestionTest() throws IOException {
+        var packageName = "junit:junit";
+        var version = "4.12";
+        Mockito.when(kbDao.getPackageCallgraph(packageName, version, offset, limit)).thenThrow(new PackageVersionNotFoundException("Error"));
+        var result = service.getPackageCallgraph(packageName, version, offset, limit, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+
+        Mockito.verify(kbDao).getPackageCallgraph(packageName, version, offset, limit);
     }
 
     @Test
@@ -197,7 +209,7 @@ public class PackageApiServiceImplTest {
     }
 
     @Test
-    void getERCGLinkNegativeTest() throws IOException {
+    void getERCGLinkIngestionTest() throws IOException {
         var packageName = "junit:junit";
         var version = "4.12";
         Mockito.when(kbDao.assertPackageExistence(packageName, version)).thenReturn(false);

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageVersionApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/PackageVersionApiServiceImplTest.java
@@ -41,7 +41,7 @@ public class PackageVersionApiServiceImplTest {
     }
 
     @Test
-    void getERCGLinkTest() {
+    void getERCGLinkPositiveTest() {
         var coordinate = "group:artifact:version";
         var id = 42L;
         Mockito.when(kbDao.getArtifactName(id)).thenReturn(coordinate);
@@ -50,10 +50,16 @@ public class PackageVersionApiServiceImplTest {
         var result = service.getERCGLink(id);
         assertEquals(expected, result);
 
+        Mockito.verify(kbDao, Mockito.times(1)).getArtifactName(id);
+    }
+    @Test
+    void getERCGLinkNegativeTest() {
+        var id = 42L;
+        KnowledgeBaseConnector.rcgBaseUrl = "http://lima.ewi.tudelft.nl/";
         Mockito.when(kbDao.getArtifactName(id)).thenReturn(null);
-        result = service.getERCGLink(id);
+        var result = service.getERCGLink(id);
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
 
-        Mockito.verify(kbDao, Mockito.times(2)).getArtifactName(id);
+        Mockito.verify(kbDao, Mockito.times(1)).getArtifactName(id);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImplTest.java
@@ -86,10 +86,17 @@ public class StitchingApiServiceImplTest {
     }
 
     @Test
-    void getCallablesMetadataNegativeTest() {
+    void getCallablesMetadataInvalidURITest() {
         var allAttributes = false;
         var attributes = List.of("foo");
         var result = service.getCallablesMetadata(List.of("invalid_uri"), allAttributes, attributes);
+        assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+    }
+
+    @Test
+    void getCallablesMetadataNegativeTest() {
+        var uris = List.of("fasten://mvn!group:artifact$version/namespace/callable_uri");
+        var result = service.getCallablesMetadata(uris, false, null);
         assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImplTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/mvn/api/impl/StitchingApiServiceImplTest.java
@@ -52,11 +52,11 @@ public class StitchingApiServiceImplTest {
         var expected = new ResponseEntity<>(new JSONObject(map).toString(), HttpStatus.OK);
         var result = service.resolveCallablesToUris(gids);
         assertEquals(expected, result);
-        Mockito.verify(kbDao).getFullFastenUris(gids);
+        Mockito.verify(kbDao, Mockito.times(1)).getFullFastenUris(gids);
     }
 
     @Test
-    void getCallablesMetadataTest() {
+    void getCallablesMetadataPositiveAllAttributesTest() {
         var uris = List.of("fasten://mvn!group:artifact$version/namespace/callable_uri");
         var map = new HashMap<String, JSONObject>(1);
         map.put(uris.get(0), new JSONObject("{\"hello\":\"world\", \"foo\":8}"));
@@ -67,16 +67,29 @@ public class StitchingApiServiceImplTest {
         var result = service.getCallablesMetadata(uris, allAttributes, attributes);
         assertEquals(expected, result);
 
-        allAttributes = false;
-        attributes = List.of("foo");
-        result = service.getCallablesMetadata(uris, allAttributes, attributes);
-        expected = new ResponseEntity<>(new JSONObject("{\"fasten://mvn!group:artifact$version/namespace/callable_uri\":{\"foo\":8}}").toString(), HttpStatus.OK);
-        assertEquals(expected, result);
-
-        result = service.getCallablesMetadata(List.of("invalid_uri"), allAttributes, attributes);
-        assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
-
-        Mockito.verify(kbDao, Mockito.times(2)).getCallablesMetadataByUri("mvn", "group:artifact", "version", List.of("/namespace/callable_uri"));
+        Mockito.verify(kbDao, Mockito.times(1)).getCallablesMetadataByUri("mvn", "group:artifact", "version", List.of("/namespace/callable_uri"));
     }
 
+    @Test
+    void getCallablesMetadataPositiveNotAllAttributesTest() {
+        var uris = List.of("fasten://mvn!group:artifact$version/namespace/callable_uri");
+        var map = new HashMap<String, JSONObject>(1);
+        map.put(uris.get(0), new JSONObject("{\"hello\":\"world\", \"foo\":8}"));
+        Mockito.when(kbDao.getCallablesMetadataByUri("mvn", "group:artifact", "version", List.of("/namespace/callable_uri"))).thenReturn(map);
+        var allAttributes = false;
+        List<String> attributes = List.of("foo");
+        var result = service.getCallablesMetadata(uris, allAttributes, attributes);
+        var expected = new ResponseEntity<>(new JSONObject("{\"fasten://mvn!group:artifact$version/namespace/callable_uri\":{\"foo\":8}}").toString(), HttpStatus.OK);
+        assertEquals(expected, result);
+
+        Mockito.verify(kbDao, Mockito.times(1)).getCallablesMetadataByUri("mvn", "group:artifact", "version", List.of("/namespace/callable_uri"));
+    }
+
+    @Test
+    void getCallablesMetadataNegativeTest() {
+        var allAttributes = false;
+        var attributes = List.of("foo");
+        var result = service.getCallablesMetadata(List.of("invalid_uri"), allAttributes, attributes);
+        assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+    }
 }


### PR DESCRIPTION
## Description
This PR aims to improve the Rest-API Plugin Tests on the following ways:
 - [x] Applied the Separation of Concerns design pattern in REST-API Plugin tests by creating separate test cases for each test case
 - [x] Added some extra test cases testing succesfull Lazy Ingestions.
- [x] Included the minor bug fix on getERCGLinkTest as  described on: https://github.com/fasten-project/fasten/pull/389
## Motivation and context
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

I noticed that the REST-API Plugin included some test cases that tested more than one cases of a method's behaviour. This made each testing method more complex than it should be and it also makes it harder to see the reason a test failed when debugging or refactoring.  In addition, I noticed that most cases regarding a succesfull lazy ingestion where untested.

## Testing
Please describe in detail how you tested your changes.

All tests are performed sucessfully.
