### PR TITLE
Fix processing slowdown when messages only arrive in normal lane

### DIFF
--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -240,6 +240,9 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
                 // TODO: Keep a list of processed priority messages like normal ones
             }
             doCommitSync(ProcessingLane.PRIORITY);
+        }
+
+        if(hadMessagesOnLastPollCycle) {
             return; // skip normal
         }
 


### PR DESCRIPTION
Right now, the server will slow down for messages on normal, as it will always wait on the PRIO lane. This PR changes this: we ONLY wait on PRIO and ONLY when there have been no messages in any lane on the previous poll cycle. The only corner case is when are no subscription for PRIO, then we wait in NORMAL instead.

Waiting is necessary as Duration.ZERO does not seem to trigger any re-assign/rebalancing of the topics in case consumers change and also to avoid contant polling in times when no new messages arrive.

(see https://github.com/fasten-project/fasten-docker-deployment/pull/22 for context)