### PR TITLE
Fix broken equals method in MavenProduct

### DIFF
--- a/core/src/main/java/eu/fasten/core/maven/data/MavenProduct.java
+++ b/core/src/main/java/eu/fasten/core/maven/data/MavenProduct.java
@@ -28,37 +28,37 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  */
 public class MavenProduct {
 
-	public long id;
-	public String groupId;
-	public String artifactId;
+    public transient long id;
 
-	public MavenProduct() {
-	}
+    public String groupId;
+    public String artifactId;
 
-	public MavenProduct(final String groupId, final String artifactId) {
-		this.id = 0;
-		this.groupId = groupId;
-		this.artifactId = artifactId;
-	}
+    public MavenProduct() {}
 
-	public MavenProduct(long id, String groupId, String artifactId) {
-		this.id = id;
-		this.groupId = groupId;
-		this.artifactId = artifactId;
-	}
+    public MavenProduct(final String groupId, final String artifactId) {
+        this.id = 0;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		return EqualsBuilder.reflectionEquals(this, obj);
-	}
+    public MavenProduct(long id, String groupId, String artifactId) {
+        this.id = id;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
 
-	@Override
-	public int hashCode() {
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
 
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
-	}
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
+    }
 }

--- a/core/src/test/java/eu/fasten/core/maven/data/MavenProductTest.java
+++ b/core/src/test/java/eu/fasten/core/maven/data/MavenProductTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.fasten.core.maven.data;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class MavenProductTest {
+
+    @Test
+    public void defaultsInitNoArgs() {
+        var sut = new MavenProduct();
+        assertEquals(0, sut.id);
+        assertNull(sut.groupId);
+        assertNull(sut.artifactId);
+    }
+
+    @Test
+    public void defaultsInit1() {
+        var sut = new MavenProduct("g", "a");
+        assertEquals(0, sut.id);
+        assertEquals("g", sut.groupId);
+        assertEquals("a", sut.artifactId);
+    }
+
+    @Test
+    public void defaultsInit2() {
+        var sut = new MavenProduct(1, "g", "a");
+        assertEquals(1, sut.id);
+        assertEquals("g", sut.groupId);
+        assertEquals("a", sut.artifactId);
+    }
+
+    @Test
+    public void equalityDefault() {
+        var a = new MavenProduct();
+        var b = new MavenProduct();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void equalityActualValues() {
+        var a = new MavenProduct(1, "g", "a");
+        var b = new MavenProduct(1, "g", "a");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void equalityDespiteDifferentId() {
+        var a = new MavenProduct(1, "g", "a");
+        var b = new MavenProduct(2, "g", "a");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void equalityDifferentGroup() {
+        var a = new MavenProduct(1, "g", "a");
+        var b = new MavenProduct(1, "g2", "a");
+        assertNotEquals(a, b);
+        assertNotEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void equalityDifferentArtifact() {
+        var a = new MavenProduct(1, "g", "a");
+        var b = new MavenProduct(1, "g", "a2");
+        assertNotEquals(a, b);
+        assertNotEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void hasToString() {
+        var actual = new MavenProduct(1, "g", "a").toString();
+        assertTrue(actual.contains(MavenProduct.class.getSimpleName()));
+        assertTrue(actual.contains("\n"));
+        assertTrue(actual.contains("@"));
+        assertTrue(actual.contains("artifactId"));
+    }
+}


### PR DESCRIPTION
One of the recent refactorings broke the behavior of `MavenProduct`. I have fixed the issue and provided a test suite for that class to prevent a regression in the future. This should address the first part of Issue #413. Please find the regression test in [MavenProductTest:L68](https://github.com/fasten-project/fasten/blob/0c192fd0b2635b3cbe3ecf04b8a77c1bc0be54a3/core/src/test/java/eu/fasten/core/maven/data/MavenProductTest.java#L68)