### PR TITLE
Fix target signatures callable index

### DIFF
--- a/analyzer/callable-index/src/test/java/eu/fasten/analyzer/callableindex/CallableIndexServerPluginTest.java
+++ b/analyzer/callable-index/src/test/java/eu/fasten/analyzer/callableindex/CallableIndexServerPluginTest.java
@@ -19,14 +19,12 @@
 package eu.fasten.analyzer.callableindex;
 
 import eu.fasten.analyzer.callableindex.CallableIndexServerPlugin.CallableIndexFastenPlugin;
-import eu.fasten.core.data.DirectedGraph;
-import eu.fasten.core.data.FastenJavaURI;
 import eu.fasten.core.data.callableindex.ExtendedGidGraph;
-import eu.fasten.core.data.callableindex.GraphMetadata;
+import eu.fasten.core.data.callableindex.GraphMetadata.NodeMetadata;
+import eu.fasten.core.data.callableindex.GraphMetadata.ReceiverRecord;
 import eu.fasten.core.data.callableindex.GraphMetadata.ReceiverRecord.CallType;
 import eu.fasten.core.data.callableindex.RocksDao;
-import eu.fasten.core.merge.CallGraphUtils;
-import org.apache.commons.lang.StringUtils;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -42,7 +40,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static eu.fasten.core.data.callableindex.GraphMetadata.*;
 import static eu.fasten.core.utils.TestUtils.getTestResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -83,14 +80,15 @@ public class CallableIndexServerPluginTest {
 
     @Test
     public void consumerTopicsTest() {
-        var topics = Optional.of(List.of("fasten.MetadataDBJavaExtension.priority.out","fasten" +
+        var topics = Optional.of(List.of("fasten.MetadataDBJavaExtension.priority.out", "fasten" +
             ".MetadataDBExtension.out"));
         assertEquals(topics, callableIndexFastenPlugin.consumeTopic());
     }
 
     @Test
     public void consumerTopicChangeTest() {
-        var topics1 = Optional.of(List.of("fasten.MetadataDBJavaExtension.priority.out","fasten.MetadataDBExtension.out"));
+        var topics1 = Optional.of(List.of("fasten.MetadataDBJavaExtension.priority.out",
+            "fasten.MetadataDBExtension.out"));
         assertEquals(topics1, callableIndexFastenPlugin.consumeTopic());
         var differentTopic = Collections.singletonList("DifferentKafkaTopic");
         callableIndexFastenPlugin.setTopics(differentTopic);
@@ -126,9 +124,10 @@ public class CallableIndexServerPluginTest {
         NodeMetadata doRoadTripCallSites = getNodeMetadata(rocksDao, 1, 2);
         assertLine(doRoadTripCallSites, 15, "/lib/MotorVehicle.on()%2Fjava.lang%2FBooleanType",
             CallType.INTERFACE, List.of("/lib/MotorVehicle"));
-        assertLine(doRoadTripCallSites, 16, "/lib/VehicleWash.wash(MotorVehicle)%2Fjava.lang%2FVoidType",
-            CallType.VIRTUAL,  List.of("/lib/VehicleWash"));
-        assertLine(doRoadTripCallSites, 17,  "/lib/MotorVehicle.off()%2Fjava.lang%2FBooleanType",
+        assertLine(doRoadTripCallSites, 16,
+            "/lib/VehicleWash.wash(MotorVehicle)%2Fjava.lang%2FVoidType",
+            CallType.VIRTUAL, List.of("/lib/VehicleWash"));
+        assertLine(doRoadTripCallSites, 17, "/lib/MotorVehicle.off()%2Fjava.lang%2FBooleanType",
             CallType.INTERFACE, List.of("/lib/MotorVehicle"));
     }
 
@@ -149,7 +148,7 @@ public class CallableIndexServerPluginTest {
 
     private void assertLine(final NodeMetadata doRoadTripCallSite, final int line,
                             final String signature, final CallType callType,
-                              final List<String> receiverTypes) {
+                            final List<String> receiverTypes) {
         final var line15 = getReceiverRecordForLine(doRoadTripCallSite, line);
         assert line15 != null;
         assertEquals(signature, line15.receiverSignature);
@@ -158,7 +157,7 @@ public class CallableIndexServerPluginTest {
     }
 
     private ReceiverRecord getReceiverRecordForLine(final NodeMetadata nodeMetadata,
-                                                    final int line){
+                                                    final int line) {
         for (final var rec : nodeMetadata.receiverRecords) {
             if (rec.line == line) {
                 return rec;

--- a/analyzer/callable-index/src/test/java/eu/fasten/analyzer/callableindex/CallableIndexServerPluginTest.java
+++ b/analyzer/callable-index/src/test/java/eu/fasten/analyzer/callableindex/CallableIndexServerPluginTest.java
@@ -18,12 +18,20 @@
 
 package eu.fasten.analyzer.callableindex;
 
+import eu.fasten.analyzer.callableindex.CallableIndexServerPlugin.CallableIndexFastenPlugin;
+import eu.fasten.core.data.DirectedGraph;
+import eu.fasten.core.data.FastenJavaURI;
 import eu.fasten.core.data.callableindex.ExtendedGidGraph;
+import eu.fasten.core.data.callableindex.GraphMetadata;
+import eu.fasten.core.data.callableindex.GraphMetadata.ReceiverRecord.CallType;
 import eu.fasten.core.data.callableindex.RocksDao;
+import eu.fasten.core.merge.CallGraphUtils;
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.rocksdb.RocksDBException;
@@ -34,18 +42,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static eu.fasten.core.data.callableindex.GraphMetadata.*;
 import static eu.fasten.core.utils.TestUtils.getTestResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CallableIndexServerPluginTest {
 
-    private CallableIndexServerPlugin.CallableIndexFastenPlugin callableIndexFastenPlugin;
+    private CallableIndexFastenPlugin callableIndexFastenPlugin;
     private final RocksDao rocksDao = Mockito.mock(RocksDao.class);
 
     @BeforeEach
     public void setUp() {
-        callableIndexFastenPlugin = new CallableIndexServerPlugin.CallableIndexFastenPlugin();
+        callableIndexFastenPlugin = new CallableIndexFastenPlugin();
         //callableIndexFastenPlugin.addTopic("fasten.MetadataDBExtension.out");
         callableIndexFastenPlugin.setRocksDao(rocksDao);
     }
@@ -60,14 +69,6 @@ public class CallableIndexServerPluginTest {
         callableIndexFastenPlugin.setRocksDao(rocksDao);
         callableIndexFastenPlugin.consume(json.toString());
         Mockito.verify(rocksDao).saveToRocksDb(graph);
-    }
-
-    @Test
-    public void consumeTest() {
-        var json = new JSONObject("{\"payload\": {}}");
-        var jsonFile = getTestResource("gid_graph_test.json");
-        json.getJSONObject("payload").put("dir", jsonFile.getPath());
-        callableIndexFastenPlugin.consume(json.toString());
     }
 
     @Test
@@ -108,5 +109,61 @@ public class CallableIndexServerPluginTest {
             + "Consumes list of edges (pair of global IDs produced by PostgreSQL from Kafka"
             + " topic and populates graph database (RocksDB) with consumed data";
         assertEquals(description, callableIndexFastenPlugin.description());
+    }
+
+    @Disabled("This test is only for local development and debugging purposes! " +
+        "It needs docker compose up and running with app:0.0.1" +
+        "synthetic jar ingested. Local variable callableIndexPath should also be provided. ")
+    @Test
+    void integrationTestForSavingAGIDJsonToCallableIndex() throws RocksDBException {
+        final var callableIndexPath = "";
+        final var rocksDao = new RocksDao(callableIndexPath, false);
+        final var ci = new CallableIndexFastenPlugin();
+        ci.setRocksDao(rocksDao);
+
+        consumeResource(ci, "app_0.0.1.json");
+
+        NodeMetadata doRoadTripCallSites = getNodeMetadata(rocksDao, 1, 2);
+        assertLine(doRoadTripCallSites, 15, "/lib/MotorVehicle.on()%2Fjava.lang%2FBooleanType",
+            CallType.INTERFACE, List.of("/lib/MotorVehicle"));
+        assertLine(doRoadTripCallSites, 16, "/lib/VehicleWash.wash(MotorVehicle)%2Fjava.lang%2FVoidType",
+            CallType.VIRTUAL,  List.of("/lib/VehicleWash"));
+        assertLine(doRoadTripCallSites, 17,  "/lib/MotorVehicle.off()%2Fjava.lang%2FBooleanType",
+            CallType.INTERFACE, List.of("/lib/MotorVehicle"));
+    }
+
+    private NodeMetadata getNodeMetadata(final RocksDao rocksDao, final int graphId,
+                                         final int nodeId) throws RocksDBException {
+        final var dg = rocksDao.getGraphData(graphId);
+        final var metadata = rocksDao.getGraphMetadata(graphId, dg);
+        return metadata.gid2NodeMetadata.get(nodeId);
+    }
+
+    public void consumeResource(final CallableIndexFastenPlugin ci,
+                                final String resourceName) {
+        var json = new JSONObject("{\"payload\": {}}");
+        var jsonFile = getTestResource(resourceName);
+        json.getJSONObject("payload").put("dir", jsonFile.getPath());
+        ci.consume(json.toString());
+    }
+
+    private void assertLine(final NodeMetadata doRoadTripCallSite, final int line,
+                            final String signature, final CallType callType,
+                              final List<String> receiverTypes) {
+        final var line15 = getReceiverRecordForLine(doRoadTripCallSite, line);
+        assert line15 != null;
+        assertEquals(signature, line15.receiverSignature);
+        assertEquals(callType, line15.callType);
+        assertEquals(receiverTypes, line15.receiverTypes);
+    }
+
+    private ReceiverRecord getReceiverRecordForLine(final NodeMetadata nodeMetadata,
+                                                    final int line){
+        for (final var rec : nodeMetadata.receiverRecords) {
+            if (rec.line == line) {
+                return rec;
+            }
+        }
+        return null;
     }
 }

--- a/analyzer/callable-index/src/test/resources/app_0.0.1.json
+++ b/analyzer/callable-index/src/test/resources/app_0.0.1.json
@@ -1,0 +1,363 @@
+{
+  "callsites_info": {
+    "[11, 1]": {
+      "line": 9,
+      "receiver_type_ids": [
+        2
+      ],
+      "call_type": "special"
+    },
+    "[13, 8]": {
+      "line": 18,
+      "receiver_type_ids": [
+        4
+      ],
+      "call_type": "special"
+    },
+    "[8, 17]": {
+      "line": 8,
+      "receiver_type_ids": [
+        5
+      ],
+      "call_type": "special"
+    },
+    "[8, 15]": {
+      "line": 10,
+      "receiver_type_ids": [
+        1
+      ],
+      "call_type": "special"
+    },
+    "[13, 2]": {
+      "line": 20,
+      "receiver_type_ids": [
+        2
+      ],
+      "call_type": "virtual"
+    },
+    "[10, 25]": {
+      "line": 18,
+      "receiver_type_ids": [
+        11
+      ],
+      "call_type": "interface"
+    },
+    "[3, 17]": {
+      "line": 5,
+      "receiver_type_ids": [
+        5
+      ],
+      "call_type": "special"
+    },
+    "[12, 2]": {
+      "line": 27,
+      "receiver_type_ids": [
+        2
+      ],
+      "call_type": "virtual"
+    },
+    "[11, 19]": {
+      "line": 8,
+      "receiver_type_ids": [
+        8
+      ],
+      "call_type": "special"
+    },
+    "[13, 10]": {
+      "line": 19,
+      "receiver_type_ids": [
+        4
+      ],
+      "call_type": "virtual"
+    },
+    "[2, 21]": {
+      "line": 15,
+      "receiver_type_ids": [
+        9
+      ],
+      "call_type": "interface"
+    },
+    "[14, 11]": {
+      "line": 12,
+      "receiver_type_ids": [
+        6
+      ],
+      "call_type": "special"
+    },
+    "[11, 23]": {
+      "line": 6,
+      "receiver_type_ids": [
+        10
+      ],
+      "call_type": "special"
+    },
+    "[14, 13]": {
+      "line": 13,
+      "receiver_type_ids": [
+        6
+      ],
+      "call_type": "virtual"
+    },
+    "[12, 6]": {
+      "line": 28,
+      "receiver_type_ids": [
+        3
+      ],
+      "call_type": "virtual"
+    },
+    "[13, 9]": {
+      "line": 21,
+      "receiver_type_ids": [
+        4
+      ],
+      "call_type": "virtual"
+    },
+    "[5, 18]": {
+      "line": 8,
+      "receiver_type_ids": [
+        7
+      ],
+      "call_type": "virtual"
+    },
+    "[9, 16]": {
+      "line": 22,
+      "receiver_type_ids": [
+        1
+      ],
+      "call_type": "special"
+    },
+    "[2, 20]": {
+      "line": 16,
+      "receiver_type_ids": [
+        8
+      ],
+      "call_type": "virtual"
+    },
+    "[12, 5]": {
+      "line": 26,
+      "receiver_type_ids": [
+        3
+      ],
+      "call_type": "virtual"
+    },
+    "[12, 3]": {
+      "line": 25,
+      "receiver_type_ids": [
+        3
+      ],
+      "call_type": "special"
+    },
+    "[2, 22]": {
+      "line": 17,
+      "receiver_type_ids": [
+        9
+      ],
+      "call_type": "interface"
+    },
+    "[14, 12]": {
+      "line": 14,
+      "receiver_type_ids": [
+        6
+      ],
+      "call_type": "virtual"
+    },
+    "[1, 23]": {
+      "line": 10,
+      "receiver_type_ids": [
+        10
+      ],
+      "call_type": "special"
+    },
+    "[9, 24]": {
+      "line": 23,
+      "receiver_type_ids": [
+        11
+      ],
+      "call_type": "interface"
+    },
+    "[6, 18]": {
+      "line": 12,
+      "receiver_type_ids": [
+        7
+      ],
+      "call_type": "virtual"
+    }
+  },
+  "product": "eu.fasten-project.tests.syntheticjars:app",
+  "nodes": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25
+  ],
+  "types_map": {
+    "11": "/java.util/List",
+    "1": "/java.util/LinkedList",
+    "2": "/app/RoadTrip",
+    "3": "/app/MotorCycle",
+    "4": "/app/Car",
+    "5": "/lib/BasicMotorVehicle",
+    "6": "/null/Main",
+    "7": "/java.io/PrintStream",
+    "8": "/lib/VehicleWash",
+    "9": "/lib/MotorVehicle",
+    "10": "/java.lang/Object"
+  },
+  "edges": [
+    [
+      3,
+      17
+    ],
+    [
+      12,
+      5
+    ],
+    [
+      12,
+      6
+    ],
+    [
+      5,
+      18
+    ],
+    [
+      10,
+      25
+    ],
+    [
+      14,
+      11
+    ],
+    [
+      14,
+      12
+    ],
+    [
+      14,
+      13
+    ],
+    [
+      11,
+      1
+    ],
+    [
+      9,
+      16
+    ],
+    [
+      2,
+      20
+    ],
+    [
+      2,
+      21
+    ],
+    [
+      2,
+      22
+    ],
+    [
+      13,
+      2
+    ],
+    [
+      9,
+      24
+    ],
+    [
+      13,
+      8
+    ],
+    [
+      11,
+      19
+    ],
+    [
+      13,
+      9
+    ],
+    [
+      13,
+      10
+    ],
+    [
+      11,
+      23
+    ],
+    [
+      6,
+      18
+    ],
+    [
+      8,
+      15
+    ],
+    [
+      8,
+      17
+    ],
+    [
+      1,
+      23
+    ],
+    [
+      12,
+      2
+    ],
+    [
+      12,
+      3
+    ]
+  ],
+  "index": 1,
+  "gid_to_uri": {
+    "22": "/lib/MotorVehicle.off()%2Fjava.lang%2FBooleanType",
+    "23": "/java.lang/Object.%3Cinit%3E()VoidType",
+    "24": "/java.util/List.clear()%2Fjava.lang%2FVoidType",
+    "25": "/java.util/List.add(%2Fjava.lang%2FObject)%2Fjava.lang%2FBooleanType",
+    "10": "/app/Car.addtoTrunk(%2Fjava.lang%2FString)%2Fjava.lang%2FVoidType",
+    "11": "/null/Main.%3Cinit%3E()%2Fjava.lang%2FVoidType",
+    "12": "/null/Main.doMotorCycleStuff()%2Fjava.lang%2FVoidType",
+    "13": "/null/Main.doCarStuff()%2Fjava.lang%2FVoidType",
+    "14": "/null/Main.main(%2Fjava.lang%2FString%5B%5D)%2Fjava.lang%2FVoidType",
+    "15": "/java.util/LinkedList.%3Cinit%3E()%2Fjava.lang%2FVoidType",
+    "16": "/java.util/LinkedList.%3Cinit%3E(Collection)%2Fjava.lang%2FVoidType",
+    "17": "/lib/BasicMotorVehicle.%3Cinit%3E()%2Fjava.lang%2FVoidType",
+    "18": "/java.io/PrintStream.println(%2Fjava.lang%2FString)%2Fjava.lang%2FVoidType",
+    "19": "/lib/VehicleWash.%3Cinit%3E()%2Fjava.lang%2FVoidType",
+    "1": "/app/RoadTrip.%3Cinit%3E(%2Flib%2FVehicleWash)%2Fjava.lang%2FVoidType",
+    "2": "/app/RoadTrip.doRoadTrip(%2Flib%2FMotorVehicle)%2Fjava.lang%2FVoidType",
+    "3": "/app/MotorCycle.%3Cinit%3E()%2Fjava.lang%2FVoidType",
+    "4": "/app/MotorCycle.getName()%2Fjava.lang%2FString",
+    "5": "/app/MotorCycle.kickStandUp()%2Fjava.lang%2FVoidType",
+    "6": "/app/MotorCycle.kickStandDown()%2Fjava.lang%2FVoidType",
+    "7": "/app/Car.getName()%2Fjava.lang%2FString",
+    "8": "/app/Car.%3Cinit%3E()%2Fjava.lang%2FVoidType",
+    "9": "/app/Car.getTrunk()%2Fjava.util%2FList",
+    "20": "/lib/VehicleWash.wash(MotorVehicle)%2Fjava.lang%2FVoidType",
+    "21": "/lib/MotorVehicle.on()%2Fjava.lang%2FBooleanType"
+  },
+  "version": "0.0.1",
+  "numInternalNodes": 14
+}

--- a/core/src/main/java/eu/fasten/core/data/callableindex/RocksDao.java
+++ b/core/src/main/java/eu/fasten/core/data/callableindex/RocksDao.java
@@ -174,7 +174,9 @@ public class RocksDao implements Closeable {
         // Gather data by source and store it in lists of GraphMetadata.ReceiverRecord.
         edgesInfo.forEach((pair, record) -> map.compute(pair.getFirst().longValue(), (k, list) -> {
             if (list == null) list = new ArrayList<>();
-            list.add(new ReceiverRecord(record.getLine(), transformCallType(record.getCallType()), gidToUriMap.get(pair.getFirst()), Arrays.stream(record.getReceiverTypeIds()).map(typeMap::get).collect(Collectors.toList())));
+            list.add(new ReceiverRecord(record.getLine(), transformCallType(record.getCallType())
+                , gidToUriMap.get(pair.getSecond()),
+                Arrays.stream(record.getReceiverTypeIds()).map(typeMap::get).collect(Collectors.toList())));
             return list;
         }));
 


### PR DESCRIPTION
## Description
CallableIndexPlugin had an issue storing GID graphs to RocksDB. I.e. the signatures of the target methods were wrong which was due to a bug in the RocksDao class. 

I fixed this and implemented an integration test using DC that checks whether the data that we read from the file and store in CallableIndexPlugin is stored correctly. Also, I ran the VulPathFinder plugin and observed that Merging and downstream tasks that depend on the callable-index work now.