### PR TITLE
Avoid swallowing exceptions in RepoClonerPlugin

### DIFF
--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -130,26 +130,29 @@ public class RepoClonerPlugin extends Plugin {
                     + File.separator + product.replace(Constants.mvnCoordinateSeparator, "_")
                     + ".json";
             repoUrl = json.optString("repoUrl").replaceAll("[\\n\\t ]", "");
-            if (!repoUrl.isEmpty()) {
-                var gitCloner = new GitCloner(baseDir);
-                var hgCloner = new HgCloner(baseDir);
-                var svnCloner = new SvnCloner(baseDir);
-                var result = cloneRepo(repoUrl, artifact, group, gitCloner, hgCloner, svnCloner);
-                if (result.getFirst() != null) {
-                    repoPath = result.getFirst();
-                    logger.info("Successfully cloned the repository for " + group + ":" + artifact + ":" + version + " from " + repoUrl);
-                } else if (result.getSecond() != null) {
-                    var errorTriple = result.getSecond();
-                    var errMsg = "Could not clone the repository for " + group + ":" + artifact + ":" + version + " from " + repoUrl
-                            + "; GitCloner: " + (errorTriple.getLeft() != null ? errorTriple.getLeft().getMessage() : "null")
-                            + "; SvnCloner: " + (errorTriple.getMiddle() != null ? errorTriple.getMiddle().getMessage() : "null")
-                            + "; HgCloner: " + (errorTriple.getRight() != null ? errorTriple.getRight().getMessage() : "null");
-                    logger.error(errMsg);
-                    this.pluginError = new CloneFailedException(errMsg);
-                }
-            } else {
-                logger.info("Repository URL not found");
-                this.pluginError = new RepoUrlNotFoundException("Repository URL not found");
+
+            if (repoUrl.isEmpty()) {
+                var m = "No Repository URL provided in the input record";
+                logger.info(m);
+                this.pluginError = new RepoUrlNotFoundException(m);
+                return;
+            }
+
+            var gitCloner = new GitCloner(baseDir);
+            var hgCloner = new HgCloner(baseDir);
+            var svnCloner = new SvnCloner(baseDir);
+            var result = cloneRepo(repoUrl, artifact, group, gitCloner, hgCloner, svnCloner);
+            if (result.getFirst() != null) {
+                repoPath = result.getFirst();
+                logger.info("Successfully cloned the repository for " + group + ":" + artifact + ":" + version + " from " + repoUrl);
+            } else if (result.getSecond() != null) {
+                var errorTriple = result.getSecond();
+                var errMsg = "Could not clone the repository for " + group + ":" + artifact + ":" + version + " from " + repoUrl
+                        + "; GitCloner: " + (errorTriple.getLeft() != null ? errorTriple.getLeft().getMessage() : "null")
+                        + "; SvnCloner: " + (errorTriple.getMiddle() != null ? errorTriple.getMiddle().getMessage() : "null")
+                        + "; HgCloner: " + (errorTriple.getRight() != null ? errorTriple.getRight().getMessage() : "null");
+                logger.error(errMsg);
+                this.pluginError = new CloneFailedException(errMsg);
             }
         }
 

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -24,8 +24,8 @@ import eu.fasten.analyzer.repoclonerplugin.utils.GitCloner;
 import eu.fasten.analyzer.repoclonerplugin.utils.HgCloner;
 import eu.fasten.analyzer.repoclonerplugin.utils.SvnCloner;
 import eu.fasten.core.data.Constants;
+import eu.fasten.core.plugins.AbstractKafkaPlugin;
 import eu.fasten.core.plugins.DataWriter;
-import eu.fasten.core.plugins.KafkaPlugin;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.commons.math3.util.Pair;
@@ -37,9 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Optional;
 
 public class RepoClonerPlugin extends Plugin {
@@ -49,10 +46,8 @@ public class RepoClonerPlugin extends Plugin {
     }
 
     @Extension
-    public static class RepoCloner implements KafkaPlugin, DataWriter {
+    public static class RepoCloner extends AbstractKafkaPlugin implements DataWriter {
 
-        private List<String> consumeTopics = new LinkedList<>(Collections.singletonList("fasten.POMAnalyzer.out"));
-        private Exception pluginError = null;
         private final Logger logger = LoggerFactory.getLogger(RepoCloner.class.getName());
         private String repoPath = null;
         private String artifact = null;
@@ -73,38 +68,7 @@ public class RepoClonerPlugin extends Plugin {
         }
 
         @Override
-        public Optional<List<String>> consumeTopic() {
-            return Optional.of(consumeTopics);
-        }
-
-        @Override
-        public void setTopics(List<String> consumeTopics) {
-            this.consumeTopics = consumeTopics;
-        }
-
-        @Override
-        public Optional<String> produce() {
-            var json = new JSONObject();
-            json.put("artifactId", artifact);
-            json.put("groupId", group);
-            json.put("version", version);
-            json.put("repoPath", (repoPath != null) ? repoPath : "");
-            json.put("commitTag", (commitTag != null) ? commitTag : "");
-            json.put("sourcesUrl", (sourcesUrl != null) ? sourcesUrl : "");
-            json.put("repoUrl", (repoUrl != null) ? repoUrl : "");
-            json.put("date", date);
-            json.put("forge", (forge != null) ? forge : "");
-            json.put("repoType", (repoType != null) ? repoType : "");
-            return Optional.of(json.toString());
-        }
-
-        @Override
-        public String getOutputPath() {
-            return this.outputPath;
-        }
-
-        @Override
-        public void consume(String record) {
+        public void consume(String record, ProcessingLane l) {
             this.pluginError = null;
             this.artifact = null;
             this.group = null;
@@ -223,38 +187,24 @@ public class RepoClonerPlugin extends Plugin {
         }
 
         @Override
-        public String name() {
-            return "Repo Cloner Plugin";
+        public Optional<String> produce() {
+            var json = new JSONObject();
+            json.put("artifactId", artifact);
+            json.put("groupId", group);
+            json.put("version", version);
+            json.put("repoPath", (repoPath != null) ? repoPath : "");
+            json.put("commitTag", (commitTag != null) ? commitTag : "");
+            json.put("sourcesUrl", (sourcesUrl != null) ? sourcesUrl : "");
+            json.put("repoUrl", (repoUrl != null) ? repoUrl : "");
+            json.put("date", date);
+            json.put("forge", (forge != null) ? forge : "");
+            json.put("repoType", (repoType != null) ? repoType : "");
+            return Optional.of(json.toString());
         }
 
         @Override
-        public String description() {
-            return "Repo Cloner Plugin. "
-                    + "Consumes a repository URL, "
-                    + "clones the repo to the provided directory building directory hierarchy"
-                    + "and produces the path to directory with repository.";
-        }
-
-        @Override
-        public String version() {
-            return "0.1.2";
-        }
-
-        @Override
-        public void start() {
-        }
-
-        @Override
-        public void stop() {
-        }
-
-        @Override
-        public Exception getPluginError() {
-            return this.pluginError;
-        }
-
-        @Override
-        public void freeResource() {
+        public String getOutputPath() {
+            return this.outputPath;
         }
 
         @Override

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/CloneFailedException.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/CloneFailedException.java
@@ -1,0 +1,7 @@
+package eu.fasten.analyzer.repoclonerplugin.exceptions;
+
+public class CloneFailedException extends Exception {
+    public CloneFailedException(String errorMsg) {
+        super(errorMsg);
+    }
+}

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/CloneFailedException.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/CloneFailedException.java
@@ -1,6 +1,25 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package eu.fasten.analyzer.repoclonerplugin.exceptions;
 
 public class CloneFailedException extends Exception {
+
+    private static final long serialVersionUID = 4083117503167220389L;
+
     public CloneFailedException(String errorMsg) {
         super(errorMsg);
     }

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/RepoUrlNotFoundException.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/RepoUrlNotFoundException.java
@@ -1,0 +1,7 @@
+package eu.fasten.analyzer.repoclonerplugin.exceptions;
+
+public class RepoUrlNotFoundException extends Exception {
+    public RepoUrlNotFoundException(String errMsg) {
+        super(errMsg);
+    }
+}

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/RepoUrlNotFoundException.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/exceptions/RepoUrlNotFoundException.java
@@ -1,6 +1,25 @@
+/*
+ * Copyright 2021 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package eu.fasten.analyzer.repoclonerplugin.exceptions;
 
 public class RepoUrlNotFoundException extends Exception {
+
+    private static final long serialVersionUID = 4983197508167230342L;
+
     public RepoUrlNotFoundException(String errMsg) {
         super(errMsg);
     }


### PR DESCRIPTION
## Description
This PR addresses #431 by setting `pluginError` in the plug-in. 

## Motivation and context
Before this fix, `RepoCloner` swallows exceptions, and hence records with empty Paths ended up in the `.out` topic.

## Testing
Tested with the DC.

