### PR TITLE
Fix the methods for finding vulnerable pacakge versions/callables in MetadataDao

### DIFF
--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -74,6 +74,7 @@ import javax.annotation.Nullable;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1587,6 +1588,10 @@ public class MetadataDao {
         return result.value1() + Constants.mvnCoordinateSeparator + result.value2();
     }
 
+    /**
+     * Finds a set of vulnerable package version ID given a set of package version IDs.
+     * If none of given package version IDs are vulnerable, it returns an empty set.
+     */
     public Set<Long> findVulnerablePackageVersions(Set<Long> packageVersionIDs) {
         var result = context
                 .select(PackageVersions.PACKAGE_VERSIONS.ID)
@@ -1597,31 +1602,31 @@ public class MetadataDao {
         return new HashSet<>(result.map(Record1::value1));
     }
 
-    public Map<Long, JSONObject> findVulnerableCallables(Set<Long> vulnerablePackageVersions, Set<Long> callableIDs) {
+    /**
+     * Given a set of vulnerable package version IDs and a set of callable IDs, it returns a map of vulnerable callable IDs
+     * and their corresponding vulnerability JSON statement (if any).
+     */
+    public Map<Long, List<JSONObject>> findVulnerableCallables(Set<Long> vulnerablePackageVersions, Set<Long> callableIDs) {
 
-        PackageVersions pv = PackageVersions.PACKAGE_VERSIONS;
-        Modules m = Modules.MODULES;
-        Callables c = Callables.CALLABLES;
         Vulnerabilities v = Vulnerabilities.VULNERABILITIES;
         VulnerabilitiesXPackageVersions vxp = VulnerabilitiesXPackageVersions.VULNERABILITIES_X_PACKAGE_VERSIONS;
         VulnerabilitiesXCallables vxc = VulnerabilitiesXCallables.VULNERABILITIES_X_CALLABLES;
 
-        var result = context
-                .select(vxc.CALLABLE_ID, v.STATEMENT)
-                .from(c, v, vxp, vxc)
-                .join(m)
-                .on(c.MODULE_ID.eq(m.ID))
-                .join(pv)
-                .on(m.PACKAGE_VERSION_ID.eq(pv.ID))
-                .where(pv.ID.in(vulnerablePackageVersions))
-                .and(pv.ID.eq(vxp.PACKAGE_VERSION_ID))
-                .and(vxc.VULNERABILITY_ID.eq(vxp.VULNERABILITY_ID))
-                .and(v.ID.eq(vxc.VULNERABILITY_ID))
+        var result = context.
+                select(vxc.CALLABLE_ID, v.STATEMENT)
+                .from(v, vxp, vxc)
+                .where(vxp.PACKAGE_VERSION_ID.in(vulnerablePackageVersions))
+                .and(v.ID.eq(vxp.VULNERABILITY_ID))
                 .and(vxc.CALLABLE_ID.in(callableIDs))
                 .fetch();
-        var map = new HashMap<Long, JSONObject>(result.size());
+
+        var map = new HashMap<Long, List<JSONObject>>(result.size());
         for (var record : result) {
-            map.put(record.value1(), new JSONObject(record.value2().data()));
+            if (!map.containsKey(record.value1())) {
+                map.put(record.value1(), new ArrayList<>(Collections.singletonList(new JSONObject(record.value2().data()))));
+            } else {
+                map.get(record.value1()).add(new JSONObject(record.value2().data()));
+            }
         }
         return map;
     }

--- a/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
+++ b/core/src/main/java/eu/fasten/core/data/metadatadb/MetadataDao.java
@@ -22,9 +22,9 @@ import com.github.t9t.jooq.json.JsonbDSL;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import eu.fasten.core.data.Constants;
-import eu.fasten.core.data.FastenPythonURI;
-import eu.fasten.core.data.FastenJavaURI;
 import eu.fasten.core.data.FastenCURI;
+import eu.fasten.core.data.FastenJavaURI;
+import eu.fasten.core.data.FastenPythonURI;
 import eu.fasten.core.data.FastenURI;
 import eu.fasten.core.data.metadatadb.codegen.Keys;
 import eu.fasten.core.data.metadatadb.codegen.enums.Access;
@@ -1590,9 +1590,9 @@ public class MetadataDao {
     public Set<Long> findVulnerablePackageVersions(Set<Long> packageVersionIDs) {
         var result = context
                 .select(PackageVersions.PACKAGE_VERSIONS.ID)
-                .from(PackageVersions.PACKAGE_VERSIONS)
+                .from(PackageVersions.PACKAGE_VERSIONS, VulnerabilitiesXPackageVersions.VULNERABILITIES_X_PACKAGE_VERSIONS)
                 .where(PackageVersions.PACKAGE_VERSIONS.ID.in(packageVersionIDs))
-                .and("package_versions.metadata::jsonb->'vulnerabilities' is not null")
+                .and(PackageVersions.PACKAGE_VERSIONS.ID.eq(VulnerabilitiesXPackageVersions.VULNERABILITIES_X_PACKAGE_VERSIONS.PACKAGE_VERSION_ID))
                 .fetch();
         return new HashSet<>(result.map(Record1::value1));
     }


### PR DESCRIPTION
## Description
Specifically, this PR makes changes to the `findVulnerablePackageVersions` and `findVulnerableCallables` methods by using the introduced vulnerability tables in #316.

## Motivation and context
After the merge of #316, the `vulnerabilities` field is no longer stored in the metadata field of the `package_versins` and `callables`. Therefore, it is necessary to adapt the mentioned methods for finding vulnerable package versions/callables.

## Testing
Tested with several vulnerable package versions and callables using the production metadata DB.

## Additional context
The method  `findVulnerablePackageVersions` needs this fix for the vulnerability chain finder [here](https://github.com/fasten-project/data-processing/pull/11).