### PR TITLE
Quickfix: Connect to RocksDB & enable Lazy Ingestion only when initializing the Java REST-API

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
@@ -206,7 +206,6 @@ public class KnowledgeBaseConnector {
                     System.exit(1);
                 }
                 logger.info("...Graph database connection established successfully.");
-              
             }
         }
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
@@ -196,33 +196,29 @@ public class KnowledgeBaseConnector {
      */
     @PostConstruct
     public void connectToGraphDB() {
-        switch (KnowledgeBaseConnector.forge) {
-            case Constants.mvnForge: {
-                logger.info("Establishing connection to the Graph Database at " + graphdbPath + "...");
-                try {
-                    graphDao = RocksDBConnector.createReadOnlyRocksDBAccessObject(graphdbPath);
-                } catch (RuntimeException e) {
-                    logger.error("Couldn't connect to the Graph Database", e);
-                    System.exit(1);
-                }
-                logger.info("...Graph database connection established successfully.");
+        if (this.forge.equals(Constants.mvnForge)) {
+            logger.info("Establishing connection to the Graph Database at " + graphdbPath + "...");
+            try {
+                graphDao = RocksDBConnector.createReadOnlyRocksDBAccessObject(graphdbPath);
+            } catch (RuntimeException e) {
+                logger.error("Couldn't connect to the Graph Database", e);
+                System.exit(1);
             }
+            logger.info("...Graph database connection established successfully.");
         }
     }
 
     @PostConstruct
     public void initKafkaProducer() {
-        switch (this.forge) {
-            case Constants.mvnForge: {
-                ingestTopic = this.kafkaOutputTopic;
-                var producerProperties = new Properties();
-                producerProperties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);
-                producerProperties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "fasten_restapi_producer");
-                producerProperties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-                producerProperties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-                producerProperties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "1000000");
-                kafkaProducer = new KafkaProducer<>(producerProperties);
-            }
+        if (this.forge.equals(Constants.mvnForge)) {
+            ingestTopic = this.kafkaOutputTopic;
+            var producerProperties = new Properties();
+            producerProperties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);
+            producerProperties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "fasten_restapi_producer");
+            producerProperties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+            producerProperties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+            producerProperties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "1000000");
+            kafkaProducer = new KafkaProducer<>(producerProperties);
         }
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
@@ -18,6 +18,7 @@
 
 package eu.fasten.analyzer.restapiplugin;
 
+import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.callableindex.RocksDao;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.dbconnectors.PostgresConnector;
@@ -195,25 +196,34 @@ public class KnowledgeBaseConnector {
      */
     @PostConstruct
     public void connectToGraphDB() {
-        logger.info("Establishing connection to the Graph Database at " + graphdbPath + "...");
-        try {
-            graphDao = RocksDBConnector.createReadOnlyRocksDBAccessObject(graphdbPath);
-        } catch (RuntimeException e) {
-            logger.error("Couldn't connect to the Graph Database", e);
-            System.exit(1);
+        switch (KnowledgeBaseConnector.forge) {
+            case Constants.mvnForge: {
+                logger.info("Establishing connection to the Graph Database at " + graphdbPath + "...");
+                try {
+                    graphDao = RocksDBConnector.createReadOnlyRocksDBAccessObject(graphdbPath);
+                } catch (RuntimeException e) {
+                    logger.error("Couldn't connect to the Graph Database", e);
+                    System.exit(1);
+                }
+                logger.info("...Graph database connection established successfully.");
+              
+            }
         }
-        logger.info("...Graph database connection established successfully.");
     }
 
     @PostConstruct
     public void initKafkaProducer() {
-        ingestTopic = this.kafkaOutputTopic;
-        var producerProperties = new Properties();
-        producerProperties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);
-        producerProperties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "fasten_restapi_producer");
-        producerProperties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        producerProperties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        producerProperties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "1000000");
-        kafkaProducer = new KafkaProducer<>(producerProperties);
+        switch (this.forge) {
+            case Constants.mvnForge: {
+                ingestTopic = this.kafkaOutputTopic;
+                var producerProperties = new Properties();
+                producerProperties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);
+                producerProperties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "fasten_restapi_producer");
+                producerProperties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+                producerProperties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+                producerProperties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "1000000");
+                kafkaProducer = new KafkaProducer<>(producerProperties);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
On this PR, we modify the REST-API by performing the GraphDB connection only on the Java REST-API Deployment. 
Also, since C & Python deployments do not include Lazy Ingestion, we avoid creating a corresponding Kafka Producer .

## Motivation and context
After trying to deploy C & Python REST-API on monster, I came up with a bug, as the REST-API failed to initilialize due to not being able to connect to the Graph Database. This PR fixes this issue.