### PR TITLE
Fix MavenRepoAnalyzer related build issue in GitHub runners

### DIFF
--- a/analyzer/repo-analyzer/src/main/java/eu/fasten/analyzer/repoanalyzer/repo/MavenRepoAnalyzer.java
+++ b/analyzer/repo-analyzer/src/main/java/eu/fasten/analyzer/repoanalyzer/repo/MavenRepoAnalyzer.java
@@ -139,7 +139,7 @@ public class MavenRepoAnalyzer extends RepoAnalyzer {
         var artifact = plugin.addElement("artifactId");
         artifact.setText("jacoco-maven-plugin");
         var version = plugin.addElement("version");
-        version.setText("0.8.2");
+        version.setText("0.8.7");
         var executions = plugin.addElement("executions");
         var execution1 = executions.addElement("execution");
         var goals1 = execution1.addElement("goals");

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
             </plugin>
 
             <plugin>
+                <!-- On updates, also update `analyzer/repo-analyzer/.../MavenRepoAnalyzer.java` -->
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>


### PR DESCRIPTION
The recent version bump of the `maven-jacoco-plugin` lead to a build failure that could only be observed on the Ubuntu build in GitHub runners (it would build fine with the Windows runner or in local builds). I have investigated the issue and found a nested Maven project that is used in one of the tests that also uses Jacoco in the old version. Apparently this conflicts, which lead to the failure. I was able to fix the test by bumping the Jacoco version in the nested test project as well.