### PR TITLE
Fixing an issue where ingested Maven artefacts by the REST API won't be processed in the pipeline

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
@@ -18,20 +18,18 @@
 
 package eu.fasten.analyzer.restapiplugin;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
+import eu.fasten.core.data.Constants;
+import eu.fasten.core.maven.MavenResolver;
+import eu.fasten.core.maven.utils.MavenUtilities;
+import org.json.JSONObject;
 
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.json.JSONObject;
-
-import eu.fasten.core.data.Constants;
-import eu.fasten.core.maven.MavenResolver;
-import eu.fasten.core.maven.utils.MavenUtilities;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public class LazyIngestionProvider {
 
@@ -66,8 +64,6 @@ public class LazyIngestionProvider {
             	// TODO why is the date necessary?
                 jsonRecord.put("date", date);
             }
-            Timestamp curTime = new Timestamp(System.currentTimeMillis());
-            KnowledgeBaseConnector.kbDao.insertIngestedArtifact(toKey(packageName, version), "0.0.1-SNAPSHOT");
             if (KnowledgeBaseConnector.kafkaProducer != null && KnowledgeBaseConnector.ingestTopic != null) {
                 KafkaWriter.sendToKafka(KnowledgeBaseConnector.kafkaProducer, KnowledgeBaseConnector.ingestTopic, jsonRecord.toString());
             }


### PR DESCRIPTION
## Description
Fixes the issue https://github.com/fasten-project/data-processing/issues/16. 
Specifically, it removes the `insertIngestedArtifact` call from `LazyIngenstionProvider` in the REST API. Therefore, the ingested artifacts won't be inserted into the `ingested_artifacts` table and they will only be produced into the `fasten.mvn.releases.priority.out` topic.

## Motivation and context
As mentioned in https://github.com/fasten-project/data-processing/issues/16, the POMAnalyzer should only insert into the `ingested_artifacts` table, not the REST API. Otherwise, the ingested artifacts will be skipped by the POMAnalyzer and hence the ingested artifacts won't be processed in the pipeline.

## Testing
Tested with the DC.