### PR TITLE
[FASTEN server] Fix paths in input records on-the-fly

### DIFF
--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -65,25 +65,30 @@ public class FastenServer implements Runnable {
     boolean shouldExitAfterPluginInit;
 
     @Option(names = {"-pl", "--plugin_list"},
-        paramLabel = "plugins",
-        description = "List of plugins to FastenServerStartup. Can be used multiple times.",
-        split = ",")
+            paramLabel = "plugins",
+            description = "List of plugins to FastenServerStartup. Can be used multiple times.",
+            split = ",")
     List<String> plugins;
 
     @Option(names = {"-po", "--plugin_output"},
-        paramLabel = "dir",
-        description = "Path to directory where plugin output messages will be stored")
+            paramLabel = "dir",
+            description = "Path to directory where plugin output messages will be stored")
     Map<String, String> outputDirs;
 
+    @Option(names = {"-pi", "--plugin_input"},
+            paramLabel = "dir",
+            description = "Path to directory where plugin input messages are stored")
+    Map<String, String> inputDirs;
+
     @Option(names = {"-pol", "--plugin_output_link"},
-        paramLabel = "dir",
-        description = "HTTP link to the root directory where output messages will be stored")
+            paramLabel = "dir",
+            description = "HTTP link to the root directory where output messages will be stored")
     Map<String, String> outputLinks;
 
     // TODO rename parameter to better transport meaning, e.g., either use param (and enum in code)
     // like --mode DEV or rename it to --deploymentMode or --devMode
     @Option(names = {"-m", "--mode"},
-        description = "Deployment or Development mode")
+            description = "Deployment or Development mode")
     boolean isDeployed;
 
     @Option(names = {"-k", "--kafka_server"},
@@ -276,6 +281,7 @@ public class FastenServer implements Runnable {
 
                 return new FastenKafkaPlugin(consumerNormProperties, consumerPrioProperties, producerProperties, k, skipOffsets,
                         (outputDirs != null) ? outputDirs.get(k.getClass().getSimpleName()) : null,
+                        (inputDirs != null) ? inputDirs.get(k.getClass().getSimpleName()) : null,
                         (outputLinks != null) ? outputLinks.get(k.getClass().getSimpleName()) : null,
                         (outputTopic != null) ? outputTopic : k.getClass().getSimpleName(),
                         (consumeTimeout != -1) ? true : false,

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaConsumeTimeoutTest.java
@@ -1,18 +1,17 @@
 package eu.fasten.server.plugins.kafka;
 
-import static eu.fasten.core.plugins.KafkaPlugin.ProcessingLane.NORMAL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import eu.fasten.core.plugins.KafkaPlugin;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.jupiter.api.Test;
-
-import eu.fasten.core.plugins.KafkaPlugin;
+import static eu.fasten.core.plugins.KafkaPlugin.ProcessingLane.NORMAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaConsumeTimeoutTest {
 
@@ -20,7 +19,7 @@ public class KafkaConsumeTimeoutTest {
     public void testDisableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, -1, false, false, "");
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", false, -1, false, false, "");
 
         assertFalse(plugin.isConsumeTimeoutEnabled());
         assertEquals(-1, plugin.getConsumeTimeout());
@@ -30,7 +29,7 @@ public class KafkaConsumeTimeoutTest {
     public void testEnableTimeout() {
         DummyPlugin dummyPlugin = new DummyPlugin(false, 0);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 10, false, false, "");
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", true, 10, false, false, "");
 
         assertTrue(plugin.isConsumeTimeoutEnabled());
         assertEquals(10, plugin.getConsumeTimeout());
@@ -42,7 +41,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 3;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false, "");
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", true, timeOut, false, false, "");
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false, NORMAL);
@@ -58,7 +57,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false, "");
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", true, timeOut, false, false, "");
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false, NORMAL);
@@ -76,7 +75,7 @@ public class KafkaConsumeTimeoutTest {
         long timeOut = 2;
         DummyPlugin dummyPlugin = new DummyPlugin(true, blockTime);
 
-        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, timeOut, false, false, "");
+        FastenKafkaPlugin plugin = new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", true, timeOut, false, false, "");
 
         long startTime  = System.currentTimeMillis();
         plugin.consumeWithTimeout("dummy", timeOut, false, NORMAL);

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaPluginConsumeBehaviourTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaPluginConsumeBehaviourTest.java
@@ -1,25 +1,9 @@
 package eu.fasten.server.plugins.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import eu.fasten.core.plugins.KafkaPlugin;
+import eu.fasten.core.plugins.KafkaPlugin.ProcessingLane;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -34,11 +18,25 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
-import eu.fasten.core.plugins.KafkaPlugin;
-import eu.fasten.core.plugins.KafkaPlugin.ProcessingLane;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class KafkaPluginConsumeBehaviourTest {
 
@@ -83,7 +81,7 @@ public class KafkaPluginConsumeBehaviourTest {
 
     @Test
     public void testNoLocalStorageNoTimeout() throws IllegalAccessException {
-        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, 0, false, false, ""));
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", false, 0, false, false, ""));
         setupMocks(kafkaPlugin);
 
         kafkaPlugin.handleConsuming();
@@ -93,7 +91,7 @@ public class KafkaPluginConsumeBehaviourTest {
 
     @Test
     public void testNoLocalStorageTimeout() throws IllegalAccessException {
-        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, 0, false, false, ""));
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", false, 0, false, false, ""));
         setupMocks(kafkaPlugin);
 
         kafkaPlugin.handleConsuming();
@@ -109,7 +107,7 @@ public class KafkaPluginConsumeBehaviourTest {
         localStorage.clear(List.of(1));
         localStorage.store("{key: 'Im a record!'}", 0);
 
-        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 5, false, true, tempDir.getAbsolutePath()));
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", true, 5, false, true, tempDir.getAbsolutePath()));
         setupMocks(kafkaPlugin);
 
         kafkaPlugin.handleConsuming();
@@ -126,7 +124,7 @@ public class KafkaPluginConsumeBehaviourTest {
         LocalStorage localStorage = new LocalStorage(tempDir.getAbsolutePath());
         localStorage.clear(List.of(0));
 
-        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, 5, false, true, tempDir.getAbsolutePath()));
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", false, 5, false, true, tempDir.getAbsolutePath()));
         setupMocks(kafkaPlugin);
 
         kafkaPlugin.handleConsuming();
@@ -140,7 +138,7 @@ public class KafkaPluginConsumeBehaviourTest {
         LocalStorage localStorage = new LocalStorage(tempDir.getAbsolutePath());
         localStorage.clear(List.of(1));
 
-        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 5, false, true, tempDir.getAbsolutePath()));
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, null, "", true, 5, false, true, tempDir.getAbsolutePath()));
         setupMocks(kafkaPlugin);
 
         kafkaPlugin.handleConsuming();
@@ -149,8 +147,8 @@ public class KafkaPluginConsumeBehaviourTest {
     
     @Test
 	public void exceptionsAreStoredInPlugin() throws Exception {
-		FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(),
-				new Properties(), dummyPlugin, 0, null, null, "", false, 0, false, false, ""));
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(),
+                new Properties(), dummyPlugin, 0, null, null, null, "", false, 0, false, false, ""));
 		setupMocks(kafkaPlugin);
 
 
@@ -169,8 +167,8 @@ public class KafkaPluginConsumeBehaviourTest {
     
     @Test
 	public void outputContainsRichError() throws Exception {
-		FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(),
-				new Properties(), dummyPlugin, 0, null, null, "", false, 0, false, false, ""));
+        FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(),
+                new Properties(), dummyPlugin, 0, null, null, null, "", false, 0, false, false, ""));
 		setupMocks(kafkaPlugin);
 
 		var e = createNestedException();


### PR DESCRIPTION
## Description
This PR makes the following changes to the FASTEN server:
- Adds an optional argument `--po`, which is a base directory for reading input records. E.g., the MetadataDBExtension requires this argument as it reads CG files from the disk.
- Adds the method `fixPathInRecord`, which adds the base directory to the relative paths so that the plug-ins can read input records.
- Stores relative path in the `dir` field of `payload` in the output records.

This is a backward-compatible change. Therefore, output records with absolute paths can still be processed.

## Motivation and context
As discussed in the previous dev. call, in output records, we would like to store relative paths to the FASTEN data on the disk such as CGs and GID graphs.

## Testing
Tested with the DC locally.

## Task list  
- [x] Fix paths in input records on-the-fly
- [ ] Add the `--pi` argument to the Docker compose setup.
- [ ] Add the `--pi` argument to the production deployments

