### PR TITLE
Debian license detector feeder debugging

### DIFF
--- a/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
+++ b/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
@@ -39,8 +39,8 @@ public class DebianLicenseDetectorPlugin extends Plugin {
 
     @Extension
     public static class DebianLicenseDetectorExtension implements KafkaPlugin {
-        private static String packageVersion = "latest";
-        private static String packageName ;
+        private static String packageVersion = null;
+        private static String packageName = null;
         private static int HttpGetCount = 0;
         private static int FilesCount=0;
         private static int FilesWithLicensesCount=0;
@@ -89,6 +89,7 @@ public class DebianLicenseDetectorPlugin extends Plugin {
             try { // Fasten error-handling guidelines
                 reset();
                 JSONObject json = new JSONObject(record);
+                object = new JSONObject();
                 logger.info("Debian license detector started.");
 
                 // Retrieving the package name

--- a/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
+++ b/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
@@ -277,10 +277,10 @@ public class DebianLicenseDetectorPlugin extends Plugin {
             if (json.has("input")) {
                 JSONObject json2 = json.getJSONObject("input");
                 //if (json2.has("input")) {
-                if (json2.has("payload")) {
-                    JSONObject json3 = json2.getJSONObject("payload");
-                    if (json3.has("product")) {
-                        return json3.getString("product");
+                if (json2.has("input")) {
+                    JSONObject json3 = json2.getJSONObject("input");
+                    if (json3.has("source")) {
+                        return json3.getString("source");
                     } else {
                         String packageNameNotFound = "Package name not found";
                         return packageNameNotFound;

--- a/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
+++ b/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
@@ -41,6 +41,9 @@ public class DebianLicenseDetectorPlugin extends Plugin {
     public static class DebianLicenseDetectorExtension implements KafkaPlugin {
         private static String packageVersion = null;
         private static String packageName = null;
+
+        private static String productName = null;
+
         private static int HttpGetCount = 0;
         private static int FilesCount=0;
         private static int FilesWithLicensesCount=0;
@@ -98,11 +101,17 @@ public class DebianLicenseDetectorPlugin extends Plugin {
                 // Retrieving the package version
                 packageVersion = extractPackageVersion(json);
                 logger.info("The package version is:"+packageVersion+".");
+                // Retrieving the product name
+                productName = extractProductName(json);
+                logger.info("The product name is:"+productName+".");
+
+
 
                 //Adding packageName and packageVersion to the out message (object).
                 JSONObject packageInfo = new JSONObject();
                 packageInfo.put("packageName", packageName);
                 packageInfo.put("packageVersion", packageVersion);
+                packageInfo.put("productName", packageVersion);
                 // forcing the packageName and packageVersion information into the files JSONArray
                 object.accumulate("files", packageInfo);
 
@@ -289,6 +298,30 @@ public class DebianLicenseDetectorPlugin extends Plugin {
             }
             return null;
         }
+
+        /**
+         * Retrieves the product name of the input record.
+         *
+         * @param json the input record containing package information.
+         * @return the package name.
+         */
+        protected static String extractProductName(JSONObject json) {
+            if (json.has("input")) {
+                JSONObject json2 = json.getJSONObject("input");
+                //if (json2.has("input")) {
+                if (json2.has("payload")) {
+                    JSONObject json3 = json2.getJSONObject("payload");
+                    if (json3.has("product")) {
+                        return json3.getString("product");
+                    } else {
+                        String packageNameNotFound = "Package name not found";
+                        return packageNameNotFound;
+                    }
+                }
+            }
+            return null;
+        }
+
 
         /**
          * Retrieves the copyright file given a package name and the package version path.

--- a/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
+++ b/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
@@ -275,10 +275,11 @@ public class DebianLicenseDetectorPlugin extends Plugin {
         protected static String extractPackageName(JSONObject json) {
             if (json.has("input")) {
                 JSONObject json2 = json.getJSONObject("input");
-                if (json2.has("input")) {
-                    JSONObject json3 = json2.getJSONObject("input");
-                    if (json3.has("source")) {
-                        return json3.getString("source");
+                //if (json2.has("input")) {
+                if (json2.has("payload")) {
+                    JSONObject json3 = json2.getJSONObject("payload");
+                    if (json3.has("product")) {
+                        return json3.getString("product");
                     } else {
                         String packageNameNotFound = "Package name not found";
                         return packageNameNotFound;

--- a/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
+++ b/analyzer/debian-license-detector/src/main/java/eu/fasten/analyzer/debianlicensedetector/DebianLicenseDetectorPlugin.java
@@ -111,7 +111,7 @@ public class DebianLicenseDetectorPlugin extends Plugin {
                 JSONObject packageInfo = new JSONObject();
                 packageInfo.put("packageName", packageName);
                 packageInfo.put("packageVersion", packageVersion);
-                packageInfo.put("productName", packageVersion);
+                packageInfo.put("productName", productName);
                 // forcing the packageName and packageVersion information into the files JSONArray
                 object.accumulate("files", packageInfo);
 

--- a/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
+++ b/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
@@ -211,15 +211,25 @@ public class DebianLicenseFeederPlugin extends Plugin {
             fileLicenses.forEach(f -> {
                 logger.debug("(cycling files) Object f: " + f);
                 JSONObject file = (JSONObject) f;
+                //this debug message is not correct for the Debian use case TODO modify it accordingly
                 logger.debug("(cycling files) JSONObject f: " + file + " has " +
                         (file.has("path") ? "" : "no ") + "path and " +
                         (file.has("licenses") ? file.getJSONArray("licenses").length() : "no") + " licenses.");
                 if (file.has("path") && file.has("license")) {
+                    JSONObject licenseObject = new JSONObject();
+                    System.out.println("After licenseObject-Created");
+                    licenseObject.put("name", file.getString("license"));
+                    System.out.println("After licenseObject-put file.getString(license)");
+                    JSONArray ja = new JSONArray();
+                    System.out.println("After ja creating");
+                    ja.put(licenseObject);
+                    System.out.println("After ja.put(licenseObject)");
                     metadataDao.insertFileLicenses(
                             packageName,
                             packageVersion,
                             file.getString("path"),
-                            new JSONObject().put("license", file.getString("license")).toString()
+                            new JSONObject().put("licenses", ja).toString()
+                            //new JSONObject().put("license", file.getString("license")).toString()
                     );
                 }
             });

--- a/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
+++ b/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
@@ -219,7 +219,7 @@ public class DebianLicenseFeederPlugin extends Plugin {
                     JSONObject licenseObject = new JSONObject();
                     System.out.println("After licenseObject-Created");
                     licenseObject.put("name", file.getString("license"));
-                    licenseObject.put("source", "DEBIAN_API");
+                    licenseObject.put("source", "DEBIAN_PACKAGES");
                     System.out.println("After licenseObject-put file.getString(license)");
                     JSONArray ja = new JSONArray();
                     System.out.println("After ja creating");

--- a/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
+++ b/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
@@ -63,18 +63,19 @@ public class DebianLicenseFeederPlugin extends Plugin {
 
                 String packageName = extractPackageName(record);
                 String packageVersion = extractPackageVersion(record);
+                String productName = extractProductName(record);
 
                 //Revision coordinates = extractDebianCoordinates(record);
                 logger.info("Package name: " + packageName + ".");
                 logger.info("Package version: " + packageVersion + ".");
-
+                logger.info("Product name: " + productName + ".");
                 // Inserting detected outbound into the database
                 var metadataDao = new MetadataDao(dslContext);
                 System.out.println("After new MetadataDao(dslContext) ");
                 dslContext.transaction(transaction -> {
                     metadataDao.setContext(DSL.using(transaction));
-                    insertOutboundLicenses(packageName, packageVersion, record, metadataDao);
-                    insertFileLicenses(packageName, packageVersion, record, metadataDao);
+                    insertOutboundLicenses(productName, packageVersion, record, metadataDao);
+                    insertFileLicenses(productName, packageVersion, record, metadataDao);
                 });
 
                 // TODO Inserting licenses in files
@@ -114,9 +115,43 @@ public class DebianLicenseFeederPlugin extends Plugin {
                     return packageName;
                 }
             }
-            System.out.println("Package version not retrieved.");
+            System.out.println("Package name not retrieved.");
             return null;
         }
+
+        /**
+         * Retrieves the C/Debian coordinate of the input record (product and version).
+         * TODO Unit tests.
+         *
+         * @param record the input record containing repository information (`fasten.MetadataDBCExtension.out`).
+         * @return the product and version of the input record.
+         * @throws IllegalArgumentException in case the function couldn't find coordinate information
+         *                                  in the input record.
+         */
+        // To check if Revision is still an acceptable type of data
+
+
+
+        protected String extractProductName(String record) {
+            var payload = new JSONObject(record);
+            if (payload.has("payload")) {
+                payload = payload.getJSONObject("payload");
+            }
+            JSONArray array1 = payload.getJSONArray("files");
+            logger.info("Product name:");
+            for (int j = 0; j < array1.length(); j++) {
+                JSONObject obj2 = array1.getJSONObject(j);
+                //System.out.println(obj2);
+                if (obj2.has("productName")){
+                    String productName = obj2.getString("productName");
+                    System.out.println(productName);
+                    return productName;
+                }
+            }
+            System.out.println("Product name not retrieved.");
+            return null;
+        }
+
 
         protected String extractPackageVersion(String record) {
             var payload = new JSONObject(record);

--- a/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
+++ b/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
@@ -70,6 +70,7 @@ public class DebianLicenseFeederPlugin extends Plugin {
 
                 // Inserting detected outbound into the database
                 var metadataDao = new MetadataDao(dslContext);
+                System.out.println("After new MetadataDao(dslContext) ");
                 dslContext.transaction(transaction -> {
                     metadataDao.setContext(DSL.using(transaction));
                     insertOutboundLicenses(packageName, packageVersion, record, metadataDao);
@@ -146,12 +147,15 @@ public class DebianLicenseFeederPlugin extends Plugin {
          * @param metadataDao Data Access Object to insert records in the database.
          */
         protected void insertOutboundLicenses(String packageName, String packageVersion, String record, MetadataDao metadataDao) {
+            System.out.println("[BEGINNING] inside of insertOutboundLicenses");
             var payload = new JSONObject(record);
             if (payload.has("payload")) {
                 payload = payload.getJSONObject("payload");
             }
 
             JSONArray outboundLicenses = payload.getJSONArray("outbound");
+            System.out.println("After payload.getJSONArray outbound");
+            System.out.println(outboundLicenses);
             logger.info("About to insert outbound licenses...");
             metadataDao.insertPackageOutboundLicenses(
                     packageName,

--- a/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
+++ b/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
@@ -217,14 +217,10 @@ public class DebianLicenseFeederPlugin extends Plugin {
                         (file.has("licenses") ? file.getJSONArray("licenses").length() : "no") + " licenses.");
                 if (file.has("path") && file.has("license")) {
                     JSONObject licenseObject = new JSONObject();
-                    System.out.println("After licenseObject-Created");
                     licenseObject.put("name", file.getString("license"));
                     licenseObject.put("source", "DEBIAN_PACKAGES");
-                    System.out.println("After licenseObject-put file.getString(license)");
                     JSONArray ja = new JSONArray();
-                    System.out.println("After ja creating");
                     ja.put(licenseObject);
-                    System.out.println("After ja.put(licenseObject)");
                     metadataDao.insertFileLicenses(
                             packageName,
                             packageVersion,

--- a/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
+++ b/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
@@ -219,6 +219,7 @@ public class DebianLicenseFeederPlugin extends Plugin {
                     JSONObject licenseObject = new JSONObject();
                     System.out.println("After licenseObject-Created");
                     licenseObject.put("name", file.getString("license"));
+                    licenseObject.put("source", "DEBIAN_API");
                     System.out.println("After licenseObject-put file.getString(license)");
                     JSONArray ja = new JSONArray();
                     System.out.println("After ja creating");


### PR DESCRIPTION
## Description
It fixes a bug on the detector which was affecting the feeder.

## Motivation and context
The JSON object created in the detector to store files licenses was not emptying after an execution ( keeping the previous results, and including them in each new Kafka message).

## Testing
Tested in DC.


## Additional context
In this PR the Detector is getting the package name from the `Product` json value instead of the `Source` one. 
It should also address better the imminent fix required in the Debian builder ([#6](https://github.com/fasten-project/debian-builder/issues/6) ).

A minor change related to the feeder output has also been introduced.
The `metadata` field of the `files` table is now having this kind of format :

`{"licenses": [{"name": "BSD-2", "source": "DEBIAN_API"}]}`

