### PR TITLE
Minor optimization to the FASTEN server's consuming handler

### DIFF
--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -245,6 +245,7 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
         }
 
         if (!normTopics.isEmpty()) {
+            sendHeartBeat(connPrio);
             var records = connNorm.poll(normTimeout);
 
             // Keep a list of all records and offsets we processed (by default this is only

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -216,11 +216,6 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
      * Consumes a message from a Kafka topics and passes it to a plugin.
      */
     public void handleConsuming() {
-
-        // Refresh connection timeout of normal consumer when priority records are
-        // processed
-        sendHeartBeat(connNorm);
-
         // normally, we ONLY wait on PRIO and ONLY when there have been no messages in any lane...
         var prioTimeout = hadMessagesOnLastPollCycle ? Duration.ZERO : POLL_TIMEOUT;
         // ... unless there is no subscription for PRIO, then we wait in NORMAL instead
@@ -229,6 +224,10 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
         hadMessagesOnLastPollCycle = false;
         
         if (!prioTopics.isEmpty()) {
+            // Refresh connection timeout of normal consumer when priority records are
+            // processed
+            sendHeartBeat(connNorm);
+
             var prioRecords = connPrio.poll(prioTimeout);
             for (var r : prioRecords) {
                 hadMessagesOnLastPollCycle = true;

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/LocalStorage.java
@@ -39,13 +39,13 @@ public class LocalStorage {
     /**
      * Verify if a message is already in the local storage.
      *
-     * @param message the message to verify.
+     * @param message   the message to verify.
      * @param partition the partition this message belongs to.
      * @return true if local storage, otherwise false.
      */
-    public boolean exists(String message, int partition) {
+    public boolean exists(String message, int partition, String topicName) {
         String hashedMessage = getSHA1(message);
-        String[] filesInFolder = getPartitionFolder(partition).list();
+        String[] filesInFolder = getPartitionFolder(partition, topicName).list();
 
         for (String hash : filesInFolder) {
             if (hash.equals(hashedMessage)) {
@@ -58,17 +58,17 @@ public class LocalStorage {
     /**
      * Remove a message from local storage.
      *
-     * @param message the message to remove.
+     * @param message   the message to remove.
      * @param partition the partition this message belongs to.
      * @return true if sucessfully deleted, otherwise false (for instance, when it doesn't exist).
      */
-    public boolean delete(String message, int partition) {
-        if (!exists(message, partition)) {
+    public boolean delete(String message, int partition, String topicName) {
+        if (!exists(message, partition, topicName)) {
             return false;
         }
 
         String hashedMessage = getSHA1(message);
-        File fileToRemove = new File(getPartitionFolder(partition).getPath() + File.separator + hashedMessage);
+        File fileToRemove = new File(getPartitionFolder(partition, topicName).getPath() + File.separator + hashedMessage);
 
         return fileToRemove.delete();
     }
@@ -76,53 +76,55 @@ public class LocalStorage {
     /**
      * Deletes a file by hash.
      *
-     * @param hash the hash to remove from local storage.
+     * @param hash      the hash to remove from local storage.
      * @param partition the partition this message belongs to.
      * @return if successfully deleted.
      */
-    private boolean deleteByHash(String hash, int partition) {
-        File fileToRemove = new File(getPartitionFolder(partition).getPath() + File.separator + hash);
+    private boolean deleteByHash(String hash, int partition, String topicName) {
+        File fileToRemove = new File(getPartitionFolder(partition, topicName).getPath() + File.separator + hash);
         return fileToRemove.delete();
     }
 
     /**
      * Stores a message in local storage.
      *
-     * @param message the raw message to store. Will be hashed into SHA-1 format.
+     * @param message   the raw message to store. Will be hashed into SHA-1 format.
      * @param partition the partition this message belongs to.
      * @return if successfully stored.
      * @throws IOException when file can't be created.
      */
-    public boolean store(String message, int partition) throws IOException {
-        if (exists(message, partition)) {
+    public boolean store(String message, int partition, String topicName) throws IOException {
+        if (exists(message, partition, topicName)) {
             return false;
         }
 
         String hashedMessage = getSHA1(message);
-        File fileToCreate = new File(getPartitionFolder(partition).getPath() + File.separator + hashedMessage);
+        File fileToCreate = new File(getPartitionFolder(partition, topicName).getPath() + File.separator + hashedMessage);
 
         return fileToCreate.createNewFile();
     }
 
     /**
      * Remove all hashes/files from local storage.
+     *
      * @param partitions the partitions folders to remove from.
      */
-    public void clear(List<Integer> partitions) {
+    public void clear(List<Integer> partitions, String topicName) {
         for (int partition : partitions) {
-            for (String hash : getPartitionFolder(partition).list()) {
-                deleteByHash(hash, partition);
+            for (String hash : getPartitionFolder(partition, topicName).list()) {
+                deleteByHash(hash, partition, topicName);
             }
         }
     }
 
     /**
      * Get the folder of a certain partition based on the parent (storage) folder.
+     *
      * @param partition the partition number.
      * @return the partition folder (in a File instance).
      */
-    public File getPartitionFolder(int partition) {
-        File partitionFolder = new File(storageFolder.getPath() + File.separator + "partition-" + partition  + File.separator);
+    public File getPartitionFolder(int partition, String topicName) {
+        File partitionFolder = new File(storageFolder.getPath() + File.separator + topicName + File.separator + "partition-" + partition + File.separator);
 
         if (!partitionFolder.exists()) {
             partitionFolder.mkdirs();

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaPluginConsumeBehaviourTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/KafkaPluginConsumeBehaviourTest.java
@@ -1,25 +1,9 @@
 package eu.fasten.server.plugins.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import eu.fasten.core.plugins.KafkaPlugin;
+import eu.fasten.core.plugins.KafkaPlugin.ProcessingLane;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -34,11 +18,25 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
-import eu.fasten.core.plugins.KafkaPlugin;
-import eu.fasten.core.plugins.KafkaPlugin.ProcessingLane;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class KafkaPluginConsumeBehaviourTest {
 
@@ -79,6 +77,7 @@ public class KafkaPluginConsumeBehaviourTest {
         when(mockConsumer.poll(any())).thenReturn(records);
         when(records.iterator()).thenReturn(listOfRecords.iterator());
         when(record.value()).thenReturn("{key: 'Im a record!'}");
+        when(record.topic()).thenReturn("dummy_topic");
     }
 
     @Test
@@ -106,8 +105,8 @@ public class KafkaPluginConsumeBehaviourTest {
         setEnv("POD_INSTANCE_ID", "test_pod");
 
         LocalStorage localStorage = new LocalStorage(tempDir.getAbsolutePath());
-        localStorage.clear(List.of(1));
-        localStorage.store("{key: 'Im a record!'}", 0);
+        localStorage.clear(List.of(1), "dummy_topic");
+        localStorage.store("{key: 'Im a record!'}", 0, "dummy_topic");
 
         FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 5, false, true, tempDir.getAbsolutePath()));
         setupMocks(kafkaPlugin);
@@ -124,7 +123,7 @@ public class KafkaPluginConsumeBehaviourTest {
         setEnv("POD_INSTANCE_ID", "test_pod");
 
         LocalStorage localStorage = new LocalStorage(tempDir.getAbsolutePath());
-        localStorage.clear(List.of(0));
+        localStorage.clear(List.of(0), "dummy_topic");
 
         FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", false, 5, false, true, tempDir.getAbsolutePath()));
         setupMocks(kafkaPlugin);
@@ -138,7 +137,7 @@ public class KafkaPluginConsumeBehaviourTest {
         setEnv("POD_INSTANCE_ID", "test_pod");
 
         LocalStorage localStorage = new LocalStorage(tempDir.getAbsolutePath());
-        localStorage.clear(List.of(1));
+        localStorage.clear(List.of(1), "dummy_topic");
 
         FastenKafkaPlugin kafkaPlugin = spy(new FastenKafkaPlugin(false, new Properties(), new Properties(), new Properties(), dummyPlugin, 0, null, null, "", true, 5, false, true, tempDir.getAbsolutePath()));
         setupMocks(kafkaPlugin);

--- a/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
+++ b/server/src/test/java/eu/fasten/server/plugins/kafka/LocalStorageTest.java
@@ -25,19 +25,21 @@ public class LocalStorageTest {
     @AfterEach
     public void clearStorage() {
         localStorage = null;
-        File toRemove = new File("src/test/resources/test_pod/");
+        File toRemove = new File("src/test/resources/test_pod/dummy_topic");
 
         String[] entries = toRemove.list();
 
-        for(String s: entries){
-            File currentFile = new File(toRemove.getPath(), s);
-            if (currentFile.isDirectory()) {
-                for (String child : currentFile.list()) {
-                    new File(currentFile.getPath(), child).delete();
+        if (entries != null) {
+            for (String s : entries) {
+                File currentFile = new File(toRemove.getPath(), s);
+                if (currentFile.isDirectory()) {
+                    for (String child : currentFile.list()) {
+                        new File(currentFile.getPath(), child).delete();
+                    }
                 }
-            }
 
-            currentFile.delete();
+                currentFile.delete();
+            }
         }
 
         toRemove.delete();
@@ -45,63 +47,63 @@ public class LocalStorageTest {
 
     @Test
     public void testCreatePositive() throws IOException {
-        Assertions.assertTrue(localStorage.store("A very nice message!", 1));
-        Assertions.assertTrue(localStorage.store("Second message!", 1));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("Second message!", 1, "dummy_topic"));
     }
 
     @Test
     public void testExists() throws IOException {
-        Assertions.assertTrue(localStorage.store("A very nice message!", 1));
-        Assertions.assertTrue(localStorage.store("Extra message", 1));
-        Assertions.assertTrue(localStorage.exists("A very nice message!", 1));
-        Assertions.assertFalse(localStorage.exists("Doesn't exist", 1));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("Extra message", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.exists("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertFalse(localStorage.exists("Doesn't exist", 1, "dummy_topic"));
     }
 
     @Test
     public void testCreateNegative() throws IOException {
-        Assertions.assertTrue(localStorage.store("A very nice message!", 1));
-        Assertions.assertFalse(localStorage.store("A very nice message!", 1));
-        Assertions.assertTrue(localStorage.store("Second message!", 1));
-        Assertions.assertFalse(localStorage.store("Second message!", 1));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertFalse(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("Second message!", 1, "dummy_topic"));
+        Assertions.assertFalse(localStorage.store("Second message!", 1, "dummy_topic"));
     }
 
     @Test
     public void testAcrossPartitions() throws IOException {
-        Assertions.assertTrue(localStorage.store("A very nice message!", 1));
-        Assertions.assertTrue(localStorage.store("A very nice message!", 2));
-        Assertions.assertFalse(localStorage.store("A very nice message!", 1));
-        Assertions.assertFalse(localStorage.store("A very nice message!", 2));
-        Assertions.assertTrue(localStorage.store("Second message!", 1));
-        Assertions.assertTrue(localStorage.store("Second message!", 2));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 2, "dummy_topic"));
+        Assertions.assertFalse(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertFalse(localStorage.store("A very nice message!", 2, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("Second message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("Second message!", 2, "dummy_topic"));
     }
 
     @Test
     public void testClearPartitions() throws IOException {
-        Assertions.assertTrue(localStorage.store("A very nice message!", 1));
-        Assertions.assertTrue(localStorage.store("A very nice message!", 2));
-        Assertions.assertTrue(localStorage.store("A very nice message!", 3));
-        Assertions.assertTrue(localStorage.store("A very nice message!", 4));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 2, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 3, "dummy_topic"));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 4, "dummy_topic"));
 
-        localStorage.clear(List.of(1, 2, 3));
+        localStorage.clear(List.of(1, 2, 3), "dummy_topic");
 
-        Assertions.assertFalse(localStorage.exists("A very nice message!", 1));
-        Assertions.assertFalse(localStorage.exists("A very nice message!", 2));
-        Assertions.assertFalse(localStorage.exists("A very nice message!", 3));
-        Assertions.assertTrue(localStorage.exists("A very nice message!", 4));
+        Assertions.assertFalse(localStorage.exists("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertFalse(localStorage.exists("A very nice message!", 2, "dummy_topic"));
+        Assertions.assertFalse(localStorage.exists("A very nice message!", 3, "dummy_topic"));
+        Assertions.assertTrue(localStorage.exists("A very nice message!", 4, "dummy_topic"));
     }
 
 
     @Test
     public void testRemove() throws IOException {
-        Assertions.assertTrue(localStorage.store("A very nice message!", 1));
-        Assertions.assertTrue(localStorage.exists("A very nice message!", 1));
-        Assertions.assertTrue(localStorage.delete("A very nice message!", 1));
-        Assertions.assertFalse(localStorage.exists("A very nice message!", 1));
+        Assertions.assertTrue(localStorage.store("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.exists("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.delete("A very nice message!", 1, "dummy_topic"));
+        Assertions.assertFalse(localStorage.exists("A very nice message!", 1, "dummy_topic"));
     }
 
     @Test
     public void testRemoveNegative() throws IOException {
-        Assertions.assertFalse(localStorage.delete("Non existent message", 1));
+        Assertions.assertFalse(localStorage.delete("Non existent message", 1, "dummy_topic"));
     }
 
     @Test
@@ -112,13 +114,13 @@ public class LocalStorageTest {
 
     @Test
     public void testClear() throws IOException {
-        localStorage.store("Number 1", 1);
-        localStorage.store("Number 2", 1);
-        Assertions.assertTrue(localStorage.exists("Number 1", 1));
-        Assertions.assertTrue(localStorage.exists("Number 2", 1));
-        localStorage.clear(List.of(1));
-        Assertions.assertFalse(localStorage.exists("Number 1", 1));
-        Assertions.assertFalse(localStorage.exists("Number 2", 1));
+        localStorage.store("Number 1", 1, "dummy_topic");
+        localStorage.store("Number 2", 1, "dummy_topic");
+        Assertions.assertTrue(localStorage.exists("Number 1", 1, "dummy_topic"));
+        Assertions.assertTrue(localStorage.exists("Number 2", 1, "dummy_topic"));
+        localStorage.clear(List.of(1), "dummy_topic");
+        Assertions.assertFalse(localStorage.exists("Number 1", 1, "dummy_topic"));
+        Assertions.assertFalse(localStorage.exists("Number 2", 1, "dummy_topic"));
     }
 
 


### PR DESCRIPTION
## Description
This PR addresses the performance issue in #448 by making changes to the FASTEN server:
- The `sendHeartBeat` method is now called when processing both priority and normal records to keep both consumers alive.
- Cleans up the local storage for priority records.
- Adds the Kafka topic name to the local storage directory structure, i.e., `plugin/instance id/topic/partition`.

## Motivation and context
The FASTEN server becomes slower over time by processing more and more priority records. Because the local storage for priority records was not cleaned up and hence the FASTEN server had to read tons of hash messages from the filesystem.

## Testing
Tested with the DC.