### PR TITLE
Java license feeding cleaning

### DIFF
--- a/.github/workflows/docker-license-feeder-plugin.yml
+++ b/.github/workflows/docker-license-feeder-plugin.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - develop
-      - endocode/compliancePlugin
+      - java-license-feeding-cleaning
 
     # Publish `v1.2.3` tags as releases.
     tags:

--- a/analyzer/license-feeder/src/main/java/eu/fasten/analyzer/licensefeeder/LicenseFeederPlugin.java
+++ b/analyzer/license-feeder/src/main/java/eu/fasten/analyzer/licensefeeder/LicenseFeederPlugin.java
@@ -150,6 +150,29 @@ public class LicenseFeederPlugin extends Plugin {
                         (file.has("path") ? "" : "no ") + "path and " +
                         (file.has("licenses") ? file.getJSONArray("licenses").length() : "no") + " licenses.");
                 if (file.has("path") && file.has("licenses")) {
+                    String path = file.getString("path");
+                    path = path.replace(sourcePath+"/","");
+                    //logger.info("path before to insertFileLicenses:");
+                    //logger.info(path);
+                    JSONArray FileLicenses = file.getJSONArray("licenses");
+                    JSONArray FileLicensesParsed = new JSONArray();
+                    JSONObject packageLicenseInfo = new JSONObject();
+                    for (int i = 0; i < FileLicenses.length(); i++) {
+                        JSONObject jsonObj = FileLicenses.getJSONObject(i);
+                        if (jsonObj.has("spdx_license_key")){
+                            String spdx_id = jsonObj.getString("spdx_license_key");
+                            packageLicenseInfo.put("spdx_license_key", spdx_id);
+                            FileLicensesParsed.put(packageLicenseInfo);
+                        }
+                        if (jsonObj.has("key")){
+                            String license_key = jsonObj.getString("key");
+                            //System.out.println("license_key");
+                            //System.out.println(license_key);
+                            packageLicenseInfo.put("key", license_key);
+                            FileLicensesParsed.put(packageLicenseInfo);
+                        }
+                    }
+                    String fileMetadata = new JSONObject().put("licenses", FileLicensesParsed).toString();
                     metadataDao.insertFileLicenses(
                             coordinates,
                             file.getString("path"),

--- a/analyzer/license-feeder/src/main/java/eu/fasten/analyzer/licensefeeder/LicenseFeederPlugin.java
+++ b/analyzer/license-feeder/src/main/java/eu/fasten/analyzer/licensefeeder/LicenseFeederPlugin.java
@@ -151,7 +151,7 @@ public class LicenseFeederPlugin extends Plugin {
                         (file.has("licenses") ? file.getJSONArray("licenses").length() : "no") + " licenses.");
                 if (file.has("path") && file.has("licenses")) {
                     String path = file.getString("path");
-                    path = path.replace(sourcePath+"/","");
+                    //path = path.replace(sourcePath+"/","");
                     //logger.info("path before to insertFileLicenses:");
                     //logger.info(path);
                     JSONArray FileLicenses = file.getJSONArray("licenses");


### PR DESCRIPTION
## Description
The Java license feeder inserts only essential data on the metadata field of the `files` table.
E.g.
`"metadata": {"licenses": [{"key": "apache-2.0", "spdx_license_key": "Apache-2.0"}]
`

## Testing
It has been tested directly on Monster.
