### PR TITLE
Fix the heartbeat call crashing the server plugin: check if consumer is subscribed to the heartbeat topic(s).

### DIFF
--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -553,13 +553,16 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
     /**
      * This method can be used to simulate Kafka's heartbeat to avoid the eviction
      * of a consumer.
+     *
+     * See https://stackoverflow.com/a/43722731
      */
     private static void sendHeartBeat(KafkaConsumer<String, String> kafkaConn) {
-        // See https://stackoverflow.com/a/43722731
-        var currentlyAssignedPartitions = kafkaConn.assignment();
-        kafkaConn.pause(currentlyAssignedPartitions);
-        kafkaConn.poll(Duration.ZERO);
-        kafkaConn.resume(currentlyAssignedPartitions);
+        if(!kafkaConn.subscription().isEmpty()) {
+            var currentlyAssignedPartitions = kafkaConn.assignment();
+            kafkaConn.pause(currentlyAssignedPartitions);
+            kafkaConn.poll(Duration.ZERO);
+            kafkaConn.resume(currentlyAssignedPartitions);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix for issue #452 by adding a check if the consumer is indeed subscribed to the topics it wants to do the heartbeat on.
