### PR TITLE
Generate Java call graphs from local JARs in `OPALPlugin`

### DIFF
--- a/analyzer/parallel-vulnerability-cache-invalidation-plugin/src/main/java/eu/fasten/analyzer/parallelvulnerabilitycacheinvalidationplugin/ParallelVulnerabilityCacheInvalidationPlugin.java
+++ b/analyzer/parallel-vulnerability-cache-invalidation-plugin/src/main/java/eu/fasten/analyzer/parallelvulnerabilitycacheinvalidationplugin/ParallelVulnerabilityCacheInvalidationPlugin.java
@@ -18,13 +18,15 @@
 
 package eu.fasten.analyzer.parallelvulnerabilitycacheinvalidationplugin;
 
-import java.io.File;
-import java.sql.Timestamp;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
+import eu.fasten.core.maven.data.Revision;
+import eu.fasten.core.maven.resolution.IMavenResolver;
+import eu.fasten.core.maven.resolution.MavenResolver;
+import eu.fasten.core.maven.resolution.MavenResolverIO;
+import eu.fasten.core.maven.utils.MavenUtilities;
+import eu.fasten.core.plugins.DataRW;
+import eu.fasten.core.plugins.DependencyGraphUser;
+import eu.fasten.core.plugins.KafkaPlugin;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import org.jooq.DSLContext;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -34,15 +36,12 @@ import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import eu.fasten.core.maven.data.Revision;
-import eu.fasten.core.maven.resolution.IMavenResolver;
-import eu.fasten.core.maven.resolution.MavenResolver;
-import eu.fasten.core.maven.resolution.MavenResolverIO;
-import eu.fasten.core.maven.utils.MavenUtilities;
-import eu.fasten.core.plugins.DataWriter;
-import eu.fasten.core.plugins.DependencyGraphUser;
-import eu.fasten.core.plugins.KafkaPlugin;
-import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 public class ParallelVulnerabilityCacheInvalidationPlugin extends Plugin {
     public ParallelVulnerabilityCacheInvalidationPlugin(PluginWrapper wrapper) {
@@ -50,7 +49,7 @@ public class ParallelVulnerabilityCacheInvalidationPlugin extends Plugin {
     }
 
     @Extension
-    public static class ParallelVulnerabilityCacheInvalidationExtension implements KafkaPlugin, DependencyGraphUser, DataWriter {
+    public static class ParallelVulnerabilityCacheInvalidationExtension implements KafkaPlugin, DependencyGraphUser, DataRW {
 
         private final Logger logger = LoggerFactory.getLogger(ParallelVulnerabilityCacheInvalidationExtension.class.getName());
 

--- a/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
+++ b/analyzer/repo-cloner-plugin/src/main/java/eu/fasten/analyzer/repoclonerplugin/RepoClonerPlugin.java
@@ -25,7 +25,7 @@ import eu.fasten.analyzer.repoclonerplugin.utils.HgCloner;
 import eu.fasten.analyzer.repoclonerplugin.utils.SvnCloner;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.plugins.AbstractKafkaPlugin;
-import eu.fasten.core.plugins.DataWriter;
+import eu.fasten.core.plugins.DataRW;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.commons.math3.util.Pair;
@@ -46,7 +46,7 @@ public class RepoClonerPlugin extends Plugin {
     }
 
     @Extension
-    public static class RepoCloner extends AbstractKafkaPlugin implements DataWriter {
+    public static class RepoCloner extends AbstractKafkaPlugin implements DataRW {
 
         private final Logger logger = LoggerFactory.getLogger(RepoCloner.class.getName());
         private String repoPath = null;

--- a/analyzer/vulnerability-cache-invalidation-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheinvalidationplugin/VulnerabilityCacheInvalidationPlugin.java
+++ b/analyzer/vulnerability-cache-invalidation-plugin/src/main/java/eu/fasten/analyzer/vulnerabilitycacheinvalidationplugin/VulnerabilityCacheInvalidationPlugin.java
@@ -18,14 +18,17 @@
 
 package eu.fasten.analyzer.vulnerabilitycacheinvalidationplugin;
 
-import java.io.File;
-import java.sql.Timestamp;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
+import eu.fasten.core.data.Constants;
+import eu.fasten.core.maven.data.ResolvedRevision;
+import eu.fasten.core.maven.data.Revision;
+import eu.fasten.core.maven.data.Scope;
+import eu.fasten.core.maven.resolution.IMavenResolver;
+import eu.fasten.core.maven.resolution.MavenResolver;
+import eu.fasten.core.maven.resolution.MavenResolverIO;
+import eu.fasten.core.maven.utils.MavenUtilities;
+import eu.fasten.core.plugins.DataRW;
+import eu.fasten.core.plugins.DependencyGraphUser;
+import eu.fasten.core.plugins.KafkaPlugin;
 import org.jooq.DSLContext;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -36,17 +39,13 @@ import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import eu.fasten.core.data.Constants;
-import eu.fasten.core.maven.data.ResolvedRevision;
-import eu.fasten.core.maven.data.Revision;
-import eu.fasten.core.maven.data.Scope;
-import eu.fasten.core.maven.resolution.IMavenResolver;
-import eu.fasten.core.maven.resolution.MavenResolver;
-import eu.fasten.core.maven.resolution.MavenResolverIO;
-import eu.fasten.core.maven.utils.MavenUtilities;
-import eu.fasten.core.plugins.DataWriter;
-import eu.fasten.core.plugins.DependencyGraphUser;
-import eu.fasten.core.plugins.KafkaPlugin;
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class VulnerabilityCacheInvalidationPlugin extends Plugin {
     public VulnerabilityCacheInvalidationPlugin(PluginWrapper wrapper) {
@@ -54,7 +53,7 @@ public class VulnerabilityCacheInvalidationPlugin extends Plugin {
     }
 
     @Extension
-    public static class VulnerabilityCacheInvalidationExtension implements KafkaPlugin, DependencyGraphUser, DataWriter {
+    public static class VulnerabilityCacheInvalidationExtension implements KafkaPlugin, DependencyGraphUser, DataRW {
 
         private final Logger logger = LoggerFactory.getLogger(VulnerabilityCacheInvalidationExtension.class.getName());
         private List<String> consumeTopics = new LinkedList<>(Collections.singletonList("fasten.CallableIndexExtension.out"));

--- a/core/src/main/java/eu/fasten/core/data/opal/MavenCoordinate.java
+++ b/core/src/main/java/eu/fasten/core/data/opal/MavenCoordinate.java
@@ -15,16 +15,16 @@
  */
 package eu.fasten.core.data.opal;
 
-import static eu.fasten.core.maven.utils.MavenUtilities.MAVEN_CENTRAL_REPO;
-
-import java.util.LinkedList;
-import java.util.List;
-
+import eu.fasten.core.data.Constants;
+import eu.fasten.core.maven.utils.MavenUtilities;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import eu.fasten.core.data.Constants;
-import eu.fasten.core.maven.utils.MavenUtilities;
+import java.nio.file.Paths;
+import java.util.LinkedList;
+import java.util.List;
+
+import static eu.fasten.core.maven.utils.MavenUtilities.MAVEN_CENTRAL_REPO;
 
 /**
  * Maven coordinate as g:a:v e.g. "com.google.guava:guava:jar:28.1-jre".
@@ -156,9 +156,15 @@ public class MavenCoordinate {
         var repo = mavenRepos.get(0);
         return this.toURL(repo) + "/" + artifactID + "-" + versionConstraint + "." + packaging;
     }
-    
+
     @Override
     public String toString() {
-    	return getCoordinate();
+        return getCoordinate();
     }
+
+    public String toPath() {
+        return Paths.get(groupID.replace('.', '/'), artifactID, versionConstraint,
+                artifactID + "-" + versionConstraint + "." + packaging).toString();
+    }
+
 }

--- a/core/src/main/java/eu/fasten/core/plugins/DataRW.java
+++ b/core/src/main/java/eu/fasten/core/plugins/DataRW.java
@@ -19,12 +19,12 @@
 package eu.fasten.core.plugins;
 
 /**
- * A plug-in that needs to write to disk some data should implement this interface.
+ * A plug-in that needs to read/write from/to disk some data should implement this interface.
  */
-public interface DataWriter extends FastenPlugin {
+public interface DataRW extends FastenPlugin {
 
     /**
-     * Sets base directory into which the data will be written.
+     * Sets base directory into which the data will be read/written.
      *
      * @param baseDir Path to base directory
      */

--- a/server/src/main/java/eu/fasten/server/FastenServer.java
+++ b/server/src/main/java/eu/fasten/server/FastenServer.java
@@ -24,7 +24,7 @@ import eu.fasten.core.dbconnectors.RocksDBConnector;
 import eu.fasten.core.plugins.CallableIndexConnector;
 import eu.fasten.core.plugins.CallableIndexReader;
 import eu.fasten.core.plugins.DBConnector;
-import eu.fasten.core.plugins.DataWriter;
+import eu.fasten.core.plugins.DataRW;
 import eu.fasten.core.plugins.DependencyGraphUser;
 import eu.fasten.core.plugins.FastenPlugin;
 import eu.fasten.core.plugins.KafkaPlugin;
@@ -184,7 +184,7 @@ public class FastenServer implements Runnable {
         var dbPlugins = pluginManager.getExtensions(DBConnector.class);
         var kafkaPlugins = pluginManager.getExtensions(KafkaPlugin.class);
         var graphDbPlugins = pluginManager.getExtensions(CallableIndexConnector.class);
-        var dataWriterPlugins = pluginManager.getExtensions(DataWriter.class);
+        var dataRWPlugins = pluginManager.getExtensions(DataRW.class);
         var graphResolverUserPlugins = pluginManager.getExtensions(DependencyGraphUser.class);
         var graphDbReaderPlugins = pluginManager.getExtensions(CallableIndexReader.class);
 
@@ -193,7 +193,7 @@ public class FastenServer implements Runnable {
 
         registerDBConnections(dbPlugins);
         makeGraphDBConnection(graphDbPlugins);
-        setBaseDirectory(dataWriterPlugins);
+        setBaseDirectory(dataRWPlugins);
         loadDependencyGraphResolvers(graphResolverUserPlugins);
         makeReadOnlyGraphDBConnection(graphDbReaderPlugins);
 
@@ -390,15 +390,15 @@ public class FastenServer implements Runnable {
     /**
      * Sets base directory to Data Writer plugins
      *
-     * @param dataWriterPlugins list of Data Writer plugins
+     * @param dataRWPlugins list of Data Writer plugins
      */
-    private void setBaseDirectory(List<DataWriter> dataWriterPlugins) {
-        dataWriterPlugins.forEach((p) -> {
+    private void setBaseDirectory(List<DataRW> dataRWPlugins) {
+        dataRWPlugins.forEach((p) -> {
             if (ObjectUtils.allNotNull(baseDir)) {
                 p.setBaseDir(baseDir);
             } else {
                 logger.error("Couldn't set a base directory. Make sure that you have "
-                    + "provided a valid path to base directory.");
+                        + "provided a valid path to base directory.");
             }
         });
     }


### PR DESCRIPTION
## Description
This PR makes the following changes:
- Changes the `DataWriter` interface to `DataRW` so that the plugins can read/write from/to the disk given a base directory. 
- `OPALPlugin` first tries to generate a call graph from a local JAR file if available. If not, it downloads the JAR file from Maven central like before.

## Motivation and context
`POMAnalyzer` stores JAR files to the disk when resolving dependencies. Therefore, it is desirable to generate CGs from local JAR files and also reduce the network activity of `OPALPlugin`. 

## Testing
Tested with the DC.