### PR TITLE
Handle `PSQLException` in the FASTEN server and `MetadataDBExtension`

### DIFF
--- a/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
+++ b/analyzer/debian-license-feeder/src/main/java/eu/fasten/analyzer/debianlicensefeeder/DebianLicenseFeederPlugin.java
@@ -2,9 +2,6 @@ package eu.fasten.analyzer.debianlicensefeeder;
 
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
-//This import should probably be different
-import eu.fasten.core.maven.data.Revision;
-import eu.fasten.core.plugins.AbstractKafkaPlugin;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
 import org.jooq.DSLContext;
@@ -17,8 +14,13 @@ import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Timestamp;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+//This import should probably be different
 
 public class DebianLicenseFeederPlugin extends Plugin {
 
@@ -82,7 +84,7 @@ public class DebianLicenseFeederPlugin extends Plugin {
 
             } catch (Exception e) { // Fasten error-handling guidelines
                 logger.error(e.getMessage(), e.getCause());
-                setPluginError(e);
+                throw e;
             }
         }
 

--- a/analyzer/license-feeder/src/main/java/eu/fasten/analyzer/licensefeeder/LicenseFeederPlugin.java
+++ b/analyzer/license-feeder/src/main/java/eu/fasten/analyzer/licensefeeder/LicenseFeederPlugin.java
@@ -3,7 +3,6 @@ package eu.fasten.analyzer.licensefeeder;
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.maven.data.Revision;
-import eu.fasten.core.plugins.AbstractKafkaPlugin;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
 import org.jooq.DSLContext;
@@ -17,7 +16,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class LicenseFeederPlugin extends Plugin {
 
@@ -74,7 +77,7 @@ public class LicenseFeederPlugin extends Plugin {
 
             } catch (Exception e) { // Fasten error-handling guidelines
                 logger.error(e.getMessage(), e.getCause());
-                setPluginError(e);
+                throw e;
             }
         }
 

--- a/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
+++ b/analyzer/metadata-plugin/src/main/java/eu/fasten/analyzer/metadataplugin/MetadataDBExtension.java
@@ -173,15 +173,15 @@ public abstract class MetadataDBExtension implements KafkaPlugin, DBConnector {
                         setOutputPath(callgraph);
                     }
                 });
-            } catch (Exception expected) {
-                if (expected instanceof DataAccessException) {
-                    // The error codes starting with 57P0 are related to the DB connection issues.
-                    // See https://www.postgresql.org/docs/current/errcodes-appendix.html
-                    if (((DataAccessException) expected).sqlState().contains("57P0")) {
-                        throw new UnrecoverableError("Could not connect to the Postgres DB and the plug-in should be stopped and restarted.",
-                                expected.getCause());
-                    }
+            } catch (DataAccessException e) {
+                // The error codes starting with 57P0 are related to the DB connection issues.
+                // See https://www.postgresql.org/docs/current/errcodes-appendix.html
+                if (e.sqlState().contains("57P0")) {
+                    throw new UnrecoverableError("Could not connect to the Postgres DB and the plug-in should be stopped and restarted.",
+                            e.getCause());
                 }
+            } catch (Exception expected) {
+
             }
             transactionRestartCount++;
         } while (restartTransaction && !processedRecord

--- a/analyzer/python-license-feeder/src/main/java/eu/fasten/analyzer/pythonlicensefeeder/PythonLicenseFeederPlugin.java
+++ b/analyzer/python-license-feeder/src/main/java/eu/fasten/analyzer/pythonlicensefeeder/PythonLicenseFeederPlugin.java
@@ -2,8 +2,6 @@ package eu.fasten.analyzer.pythonlicensefeeder;
 
 import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
-import eu.fasten.core.maven.data.Revision;
-import eu.fasten.core.plugins.AbstractKafkaPlugin;
 import eu.fasten.core.plugins.DBConnector;
 import eu.fasten.core.plugins.KafkaPlugin;
 import org.jooq.DSLContext;
@@ -16,8 +14,11 @@ import org.pf4j.PluginWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Timestamp;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class PythonLicenseFeederPlugin extends Plugin {
 
@@ -77,7 +78,7 @@ public class PythonLicenseFeederPlugin extends Plugin {
 
             } catch (Exception e) { // Fasten error-handling guidelines
                 logger.error(e.getMessage(), e.getCause());
-                setPluginError(e);
+                throw e;
             }
         }
 

--- a/analyzer/python-license-feeder/src/main/java/eu/fasten/analyzer/pythonlicensefeeder/PythonLicenseFeederPlugin.java
+++ b/analyzer/python-license-feeder/src/main/java/eu/fasten/analyzer/pythonlicensefeeder/PythonLicenseFeederPlugin.java
@@ -54,32 +54,24 @@ public class PythonLicenseFeederPlugin extends Plugin {
 
         @Override
         public void consume(String record) {
-            try { // Fasten error-handling guidelines
+            this.pluginError = null;
 
-                this.pluginError = null;
+            logger.info("License feeder started.");
 
-                logger.info("License feeder started.");
+            String packageName = extractPackageName(record);
+            String packageVersion = extractPackageVersion(record);
+            String sourcePath = extractSourcePath(record);
 
-                String packageName = extractPackageName(record);
-                String packageVersion = extractPackageVersion(record);
-                String sourcePath = extractSourcePath(record);
+            logger.info("Package name: " + packageName + ".");
+            logger.info("Package version: " + packageVersion + ".");
 
-                logger.info("Package name: " + packageName + ".");
-                logger.info("Package version: " + packageVersion + ".");
-
-                // Inserting detected outbound into the database
-                var metadataDao = new MetadataDao(dslContext);
-                dslContext.transaction(transaction -> {
-                    metadataDao.setContext(DSL.using(transaction));
-                    insertOutboundLicenses(packageName, packageVersion, record, metadataDao);
-                    insertFileLicenses(packageName, packageVersion, sourcePath, record, metadataDao);
-                });
-
-
-            } catch (Exception e) { // Fasten error-handling guidelines
-                logger.error(e.getMessage(), e.getCause());
-                throw e;
-            }
+            // Inserting detected outbound into the database
+            var metadataDao = new MetadataDao(dslContext);
+            dslContext.transaction(transaction -> {
+                metadataDao.setContext(DSL.using(transaction));
+                insertOutboundLicenses(packageName, packageVersion, record, metadataDao);
+                insertFileLicenses(packageName, packageVersion, sourcePath, record, metadataDao);
+            });
         }
 
         protected String extractPackageName(String record) {

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -128,7 +128,6 @@ public class VulnerabilityPackagesListener extends Plugin {
             catch (Exception e) {
                 var error = "Error processing package update: " + e;
                 logger.error(error);
-                setPluginError(e);
                 throw(e);
             }
         }

--- a/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
+++ b/analyzer/vulnerability-packages-listener/src/main/java/eu/fasten/analyzer/vulnerabilitypackageslistener/VulnerabilityPackagesListener.java
@@ -109,26 +109,18 @@ public class VulnerabilityPackagesListener extends Plugin {
         @Override
         public void consume(String record) {
             setPluginError(null);
-            try {
-                statementsProcessor.setDBConnection(contexts);
-                statementsProcessor.setFastenApiClient(fastenApiClient);
-                var jsonRecord = new JSONObject(record);
-                var payload = findPayload(jsonRecord);
-                if(payload != null) {
-                    var ecosystem = payload.getString("forge");
-                    var packageName = getPackageName(payload);
-                    var version = payload.getString("version");
-                    logger.info("Processing package update for forge \"" + ecosystem + "\": " + packageName + ":" + version);
-                    statementsProcessor.updateNewPackageVersion(ecosystem, packageName, version);
-                }
-                else {
-                    logger.error("Could not parse payload in message: " + record);
-                }
-            }
-            catch (Exception e) {
-                var error = "Error processing package update: " + e;
-                logger.error(error);
-                throw(e);
+            statementsProcessor.setDBConnection(contexts);
+            statementsProcessor.setFastenApiClient(fastenApiClient);
+            var jsonRecord = new JSONObject(record);
+            var payload = findPayload(jsonRecord);
+            if (payload != null) {
+                var ecosystem = payload.getString("forge");
+                var packageName = getPackageName(payload);
+                var version = payload.getString("version");
+                logger.info("Processing package update for forge \"" + ecosystem + "\": " + packageName + ":" + version);
+                statementsProcessor.updateNewPackageVersion(ecosystem, packageName, version);
+            } else {
+                logger.error("Could not parse payload in message: " + record);
             }
         }
 

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -89,14 +89,9 @@ public class VulnerabilityStatementsProcessor extends Plugin {
         @Override
         public void consume(String record) {
             this.pluginError = null;
-            try {
-                var v = updateVulnerability(record);
-                outputPath = baseOutputPath + File.separator + v.getId() + ".json";
-                lastProcessedVulnerability = v;
-            } catch (Exception e) {
-                logger.error("Error processing vulnerability statement: " + e);
-                throw e;
-            }
+            var v = updateVulnerability(record);
+            outputPath = baseOutputPath + File.separator + v.getId() + ".json";
+            lastProcessedVulnerability = v;
         }
 
         @Override

--- a/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
+++ b/analyzer/vulnerability-statements-processor/src/main/java/eu/fasten/analyzer/vulnerabilitystatementsprocessor/VulnerabilityStatementsProcessor.java
@@ -95,7 +95,7 @@ public class VulnerabilityStatementsProcessor extends Plugin {
                 lastProcessedVulnerability = v;
             } catch (Exception e) {
                 logger.error("Error processing vulnerability statement: " + e);
-                setPluginError(e);
+                throw e;
             }
         }
 

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
+import org.jooq.exception.DataAccessException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -354,6 +355,14 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             logger.error("Forced to stop the plug-in due to ", e);
             throw e;
         } catch (Exception e) {
+            if (e instanceof DataAccessException) {
+                // The error codes starting with 57P0 are related to the DB connection issues.
+                // See https://www.postgresql.org/docs/current/errcodes-appendix.html
+                if (((DataAccessException) e).sqlState().contains("57P0")) {
+                    throw new UnrecoverableError("Could not connect to the Postgres DB and the plug-in should be stopped and restarted.",
+                            e.getCause());
+                }
+            }
             logger.error("An error occurred in " + plugin.getClass().getCanonicalName(), e);
             plugin.setPluginError(e);
         }

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -356,13 +356,9 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             throw e;
 
         } catch (DataAccessException e) {
-            // The error codes starting with 57P0 are related to the DB connection issues.
-            // See https://www.postgresql.org/docs/current/errcodes-appendix.html
-            if (e.sqlState().contains("57P0")) {
-                throw new UnrecoverableError("Could not connect to the Postgres DB and the plug-in should be stopped and restarted.",
-                        e.getCause());
-            }
-            plugin.setPluginError(e);
+            // Database-related errors
+            throw new UnrecoverableError("Could not connect to or query the Postgres DB and the plug-in should be stopped and restarted.",
+                    e.getCause());
         } catch (Exception e) {
             logger.error("An error occurred in " + plugin.getClass().getCanonicalName(), e);
             plugin.setPluginError(e);

--- a/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
+++ b/server/src/main/java/eu/fasten/server/plugins/kafka/FastenKafkaPlugin.java
@@ -354,15 +354,16 @@ public class FastenKafkaPlugin implements FastenServerPlugin {
             // therefore K8s will restart the plug-in.
             logger.error("Forced to stop the plug-in due to ", e);
             throw e;
-        } catch (Exception e) {
-            if (e instanceof DataAccessException) {
-                // The error codes starting with 57P0 are related to the DB connection issues.
-                // See https://www.postgresql.org/docs/current/errcodes-appendix.html
-                if (((DataAccessException) e).sqlState().contains("57P0")) {
-                    throw new UnrecoverableError("Could not connect to the Postgres DB and the plug-in should be stopped and restarted.",
-                            e.getCause());
-                }
+
+        } catch (DataAccessException e) {
+            // The error codes starting with 57P0 are related to the DB connection issues.
+            // See https://www.postgresql.org/docs/current/errcodes-appendix.html
+            if (e.sqlState().contains("57P0")) {
+                throw new UnrecoverableError("Could not connect to the Postgres DB and the plug-in should be stopped and restarted.",
+                        e.getCause());
             }
+            plugin.setPluginError(e);
+        } catch (Exception e) {
             logger.error("An error occurred in " + plugin.getClass().getCanonicalName(), e);
             plugin.setPluginError(e);
         }


### PR DESCRIPTION
## Description
This PR makes the following changes:
- The FASTEN server stops a plugin with a failed DB connection, that is, in the case where a `PSQLException` has occurred in the plugin.
- If `PSQLException` has happened in `MetadataDBExtension`, the plugin will be stopped and restarted by K8s or DC.

## Motivation and context
As discussed in #461, if a `PSQLException` happens in a plugin, it cannot proceed further due to a failed DB connection. Therefore, the plugin should be stopped and restarted by K8s/DC to make a new DB connection. 

## Testing
Tested with the DC.