### PR TITLE
Make `MavenResolverIO` to create the dependency graph directory if it doesn't exist 

### DIFF
--- a/core/src/main/java/eu/fasten/core/maven/resolution/MavenResolverIO.java
+++ b/core/src/main/java/eu/fasten/core/maven/resolution/MavenResolverIO.java
@@ -15,7 +15,16 @@
  */
 package eu.fasten.core.maven.resolution;
 
-import static eu.fasten.core.data.metadatadb.codegen.tables.PackageVersions.PACKAGE_VERSIONS;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.fasten.core.json.ObjectMapperBuilder;
+import eu.fasten.core.maven.data.Dependency;
+import eu.fasten.core.maven.data.Pom;
+import org.apache.commons.io.FileUtils;
+import org.jooq.DSLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,18 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.io.FileUtils;
-import org.jooq.DSLContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import eu.fasten.core.json.ObjectMapperBuilder;
-import eu.fasten.core.maven.data.Dependency;
-import eu.fasten.core.maven.data.Pom;
+import static eu.fasten.core.data.metadatadb.codegen.tables.PackageVersions.PACKAGE_VERSIONS;
 
 public class MavenResolverIO {
 
@@ -54,6 +52,10 @@ public class MavenResolverIO {
         this.dbContext = dbContext;
         this.baseDir = baseDir;
         this.om = om;
+
+        if (!this.baseDir.exists()) {
+            this.baseDir.mkdir();
+        }
     }
 
     public IMavenResolver loadResolver() {


### PR DESCRIPTION
## Description
This is a tiny PR to make `MavenResolverIO` create the dependency graph directory if it doesn't exist.

## Motivation and context
As reported in #464, the `MavenResolverIO` assumes that the dep. graph directory already exists. However, this is not always the case, especially when running the FASTEN DC.

## Testing
Tested within the IDE when running the REST API.