### PR TITLE
Add Lazy Ingestion Mechanism for PyPI

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
@@ -210,7 +210,7 @@ public class KnowledgeBaseConnector {
 
     @PostConstruct
     public void initKafkaProducer() {
-        if (this.forge.equals(Constants.mvnForge)) {
+        if (!this.forge.equals(Constants.debianForge)) {
             ingestTopic = this.kafkaOutputTopic;
             var producerProperties = new Properties();
             producerProperties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
@@ -196,7 +196,7 @@ public class KnowledgeBaseConnector {
      */
     @PostConstruct
     public void connectToGraphDB() {
-        if (this.forge.equals(Constants.mvnForge)) {
+        if (forge.equals(Constants.mvnForge)) {
             logger.info("Establishing connection to the Graph Database at " + graphdbPath + "...");
             try {
                 graphDao = RocksDBConnector.createReadOnlyRocksDBAccessObject(graphdbPath);
@@ -210,14 +210,14 @@ public class KnowledgeBaseConnector {
 
     @PostConstruct
     public void initKafkaProducer() {
-        if (!this.forge.equals(Constants.debianForge)) {
+        if (forge.equals(Constants.pypiForge) | forge.equals(Constants.mvnForge)) {
             ingestTopic = this.kafkaOutputTopic;
             var producerProperties = new Properties();
             producerProperties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);
             producerProperties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "fasten_restapi_producer");
             producerProperties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
             producerProperties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-            producerProperties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "1000000");
+            producerProperties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "3000000");
             kafkaProducer = new KafkaProducer<>(producerProperties);
         }
     }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
@@ -18,18 +18,13 @@
 
 package eu.fasten.analyzer.restapiplugin;
 
-<<<<<<< HEAD
+
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-=======
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import eu.fasten.core.data.Constants;
-import eu.fasten.core.maven.MavenResolver;
-import eu.fasten.core.maven.utils.MavenUtilities;
-import org.json.JSONObject;
->>>>>>> Ingest the whole transitive closure of a pypi coordinate
 
 import java.io.IOException;
 import java.util.List;
@@ -105,36 +100,22 @@ public class LazyIngestionProvider {
     }
 
     public static void ingestArtifactWithDependencies(String packageName, String version) throws IllegalArgumentException, IOException {
-<<<<<<< HEAD
-        var groupId = packageName.split(Constants.mvnCoordinateSeparator)[0];
-        var artifactId = packageName.split(Constants.mvnCoordinateSeparator)[0];
-        ingestArtifactIfNecessary(packageName, version, null, null);
-        var mavenResolver = new NativeMavenResolver();
-        var dependencies = mavenResolver.resolveDependencies(groupId + ":" + artifactId + ":" + version);
-        ingestArtifactIfNecessary(packageName, version, null, null);
-        dependencies.forEach(d -> {
-            try {
-                ingestArtifactIfNecessary(d.getGroupId() + Constants.mvnCoordinateSeparator + d.getArtifactId(), d.version.toString(), null, null);
-            } catch (IOException e) {
-                e.printStackTrace();
-=======
         switch(KnowledgeBaseConnector.forge){
             case Constants.mvnForge: {
                 var groupId = packageName.split(Constants.mvnCoordinateSeparator)[0];
                 var artifactId = packageName.split(Constants.mvnCoordinateSeparator)[0];
                 ingestArtifactIfNecessary(packageName, version, null, null);
-                var mavenResolver = new MavenResolver();
+                var mavenResolver = new NativeMavenResolver();
                 var dependencies = mavenResolver.resolveDependencies(groupId + ":" + artifactId + ":" + version);
                 ingestArtifactIfNecessary(packageName, version, null, null);
                 dependencies.forEach(d -> {
                     try {
-                        ingestArtifactIfNecessary(d.groupId + Constants.mvnCoordinateSeparator + d.artifactId, d.version.toString(), null, null);
+                        ingestArtifactIfNecessary(d.getGroupId() + Constants.mvnCoordinateSeparator + d.getArtifactId(), d.version.toString(), null, null);
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
                 });
                 break;
->>>>>>> Ingest the whole transitive closure of a pypi coordinate
             }
             case Constants.pypiForge: {
                 var query = KnowledgeBaseConnector.dependencyResolverAddress+"/dependencies/"+packageName+"/"+version;

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
@@ -82,14 +82,13 @@ public class LazyIngestionProvider {
                             + " could not be found. Make sure the PyPI coordinate is correct");
                 }
                 JSONObject json = new JSONObject(result);
-                var requiresDist = json.getJSONObject("info").get("requires_dist");
-                var createdAt = ((JSONObject) json.getJSONObject("releases").getJSONArray(version).get(1)).get("upload_time");
                 var jsonRecord = new JSONObject();
-                jsonRecord.put("product", packageName);
-                jsonRecord.put("version", version);
-                jsonRecord.put("version_timestamp", createdAt);
-                jsonRecord.put("requires_dist", requiresDist);
-                System.out.println(jsonRecord.toString());
+                jsonRecord.put("title", packageName + " " + version);
+                jsonRecord.put("project", json);
+                jsonRecord.put("ingested", true);
+                if (KnowledgeBaseConnector.kafkaProducer != null && KnowledgeBaseConnector.ingestTopic != null) {
+                    KafkaWriter.sendToKafka(KnowledgeBaseConnector.kafkaProducer, KnowledgeBaseConnector.ingestTopic, jsonRecord.toString());
+                }
                 break;
             }
         }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApiTest.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.restapiplugin.api;
 
 import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,7 @@ public class BinaryModuleApiTest {
         service = new BinaryModuleApi();
         kbDao = Mockito.mock(MetadataDao.class);
         KnowledgeBaseConnector.kbDao = kbDao;
+        KnowledgeBaseConnector.forge = Constants.mvnForge;
     }
 
     @Test

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/CallableApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/CallableApiTest.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.restapiplugin.api;
 
 import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.json.JSONObject;
@@ -44,6 +45,7 @@ public class CallableApiTest {
         service = new CallableApi();
         kbDao = Mockito.mock(MetadataDao.class);
         KnowledgeBaseConnector.kbDao = kbDao;
+        KnowledgeBaseConnector.forge = Constants.mvnForge;
     }
 
     @Test

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/DependencyApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/DependencyApiTest.java
@@ -21,6 +21,7 @@ package eu.fasten.analyzer.restapiplugin.api;
 import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.RestApplication;
 import eu.fasten.analyzer.restapiplugin.api.DependencyApi;
+import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 
@@ -44,6 +45,7 @@ public class DependencyApiTest {
         service = new DependencyApi();
         kbDao = Mockito.mock(MetadataDao.class);
         KnowledgeBaseConnector.kbDao = kbDao;
+        KnowledgeBaseConnector.forge = Constants.mvnForge;
     }
 
     @Test

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/EdgeApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/EdgeApiTest.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.restapiplugin.api;
 
 import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,7 @@ public class EdgeApiTest {
         service = new EdgeApi();
         kbDao = Mockito.mock(MetadataDao.class);
         KnowledgeBaseConnector.kbDao = kbDao;
+        KnowledgeBaseConnector.forge = Constants.mvnForge;
     }
 
     @Test

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/FileApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/FileApiTest.java
@@ -20,6 +20,7 @@ package eu.fasten.analyzer.restapiplugin.api;
 
 import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
 import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.data.Constants;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,7 @@ public class FileApiTest {
         service = new FileApi();
         kbDao = Mockito.mock(MetadataDao.class);
         KnowledgeBaseConnector.kbDao = kbDao;
+        KnowledgeBaseConnector.forge = Constants.mvnForge;
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR aims to extend REST-API plugin to support a lazy ingestion mechanism for PyPI:

More precisely, we extended the methods `ingestArtifactIfNecessary()` and `ingestArtifactWithDependencies()` in order to ingest single pypi coordinates and the transitive closure of their dependencies.

* In the `ingestArtifactIfNecessary()` method we search if the specific coordinate exists in the db, and if not we check through the PyPI Rest-API if it exists on PyPI. If this is a case, we produce in an output topic the  information of the specific coordinate retrieved from the rest-api, which is then  processed and checked for deduplication by the [PyPI Filter ](https://github.com/fasten-project/pypi-tools/pull/4)tool and consequently fed to the PyPI pipeline.
* In the `ingestArtifactWithDependencies()` method we employ the pypi-resolver to retrieve the transitive dependencies of the coordinate and for each coordinate we call the `ingestArtifactIfNecessary()` method. 
* We enabled triggering  the `ingestArtifactWithDependencies()` method when the dependency resolution endpoint is triggered for a specific coordinate
* We also increased the maximum request size of the kafka producer to 3mb, in order to be able to handle large records produxed by the PyPI Api, like the on of the [cryptography](https://pypi.org/project/cryptography/) cooridnate, which previously could not be processed due to limited request size.

## Motivation and context
The Fasten Python pipeline did not support a lazy-ingestion mechanism, making it difficult to use the REST-API for various analysies. An ingestion mechanism will allow users to observe fine-grained information of a specific requested PyPI coordinate faster.

## Testing
Tested the changes locally and on docker compose, on the [pypi-lazy-ingestion branch](https://github.com/fasten-project/fasten-docker-deployment/tree/pypi-lazy-ingestion). The cooridnates could be succesfully be fed to the python pipeline, along with the transitive closure of their dependencies
## Task list  
- [x] Add lazy-ingestion for a single coordinate
- [x] Add lazy-ingestion for the transitive closure of the specific coordinate
- [x] Test the REST-API on docker compose
- [x] Resolved conflicts via rebasing
