### PR TITLE
Use lazy fetch in `MavenResolverIO` when reading POMs from the DB

### DIFF
--- a/analyzer/restapi-plugin/Dockerfile
+++ b/analyzer/restapi-plugin/Dockerfile
@@ -3,6 +3,6 @@ FROM openjdk:11-jre-slim
 WORKDIR /app
 COPY ./target/*.jar ./rest-api.jar
 
-ENTRYPOINT java $JAVA_OPTS -jar /app/rest-api.jar $0 $@
+ENTRYPOINT java $JAVA_OPTS -XX:+UseG1GC -XX:+UseStringDeduplication -XX:-CompactStrings -jar /app/rest-api.jar $0 $@
 
 EXPOSE 8080

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/KnowledgeBaseConnector.java
@@ -133,8 +133,10 @@ public class KnowledgeBaseConnector {
     @PostConstruct
     public void connectToKnowledgeBase() {
         try {
-            logger.info("Establishing connection to the " + kbForge +  " KnowledgeBase at " + kbUrl + ", user " + kbUser +"...");
-            dbContext = PostgresConnector.getDSLContext(kbUrl, kbUser, true);
+            logger.info("Establishing connection to the " + kbForge + " KnowledgeBase at " + kbUrl + ", user " + kbUser + "...");
+            // JDBC auto-commit should be false: (1) Postgres doesn't like it when using non-zero fetch size.
+            // (2) It is not usually a good practice.
+            dbContext = PostgresConnector.getDSLContext(kbUrl, kbUser, false);
             kbDao = new MetadataDao(dbContext);
         } catch (SQLException e) {
             logger.error("Couldn't connect to the KnowledgeBase", e);


### PR DESCRIPTION
## Description
Specifically, this PR makes the following changes:
- Use JOOQ's `lazyFetch()` in `readFromDB()` to avoid loading lots of table rows in a list and causing `OOM`.
- Set JDBC `AutoCommit` to false when creating a PG connection in the REST API. This is needed as PG doesn't like non-zero fetch size and `autocommit == false` together. See [this](https://www.jooq.org/doc/latest/manual/sql-execution/fetching/lazy-fetching/#fetch-sizes) for more info.

## Motivation and context
As described in #471, the Java REST API currently crashes due to `OOM`, which is caused by reading all package versions' metadata into memory. This should be done lazily, i.e., one by one.

## Testing
Tested with the DC and within the IDE. 
Also, with this fix, in production, the Java REST API is now responsive and the `OOM` exception does not occur.