### PR TITLE
Fix quality analyzer overmatches and exceptions

### DIFF
--- a/analyzer/quality-analyzer/pom.xml
+++ b/analyzer/quality-analyzer/pom.xml
@@ -16,17 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-            <version>3.14.4</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
-            <version>4.0.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20180813</version>
@@ -40,6 +29,18 @@
             <groupId>eu.fasten</groupId>
             <artifactId>server</artifactId>
             <version>0.0.10-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
+            <version>3.16.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.t9t.jooq</groupId>
+            <artifactId>jooq-postgresql-json</artifactId>
+            <version>3.2.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtils.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtils.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 import static eu.fasten.analyzer.qualityanalyzer.data.QAConstants.QA_CALLABLE_START_END_LINE_TOLERANCE;
+import static eu.fasten.analyzer.qualityanalyzer.data.QAConstants.QA_VERSION_NUMBER;
 
 public class MetadataUtils {
 
@@ -93,6 +94,7 @@ public class MetadataUtils {
                 "callable_parameters",
                 "metrics"});
         quality.put("rapid_plugin_version", rapidVersion);
+        quality.put("rapid_metadata_plugin_version", QA_VERSION_NUMBER);
         var metadata = new JSONObject();
         metadata.put("quality", quality);
         return metadata;

--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/data/QAConstants.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/data/QAConstants.java
@@ -22,7 +22,6 @@ public class QAConstants {
     public static final String QA_VERSION_NUMBER = "1.2.2";
     public static final String QA_PLUGIN_NAME = "Quality Analyzer Plugin";
 
-    // Number of lines difference allowed between the start of a callable measured by Lizard and
-    // stored in the metadata DB.
-    public static final int QA_CALLABLE_START_END_LINE_TOLERANCE = 2;
+    public static final String LIZARD_CALLABLE_SEPARATOR = "::";
+    public static final String JAVA_CONSTRUCTOR_NAME = "%3Cinit%3E";
 }

--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/data/QAConstants.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/data/QAConstants.java
@@ -19,7 +19,7 @@
 package eu.fasten.analyzer.qualityanalyzer.data;
 
 public class QAConstants {
-    public static final String QA_VERSION_NUMBER = "1.2.1";
+    public static final String QA_VERSION_NUMBER = "1.2.2";
     public static final String QA_PLUGIN_NAME = "Quality Analyzer Plugin";
 
     // Number of lines difference allowed between the start of a callable measured by Lizard and

--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/data/QAConstants.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/data/QAConstants.java
@@ -21,4 +21,8 @@ package eu.fasten.analyzer.qualityanalyzer.data;
 public class QAConstants {
     public static final String QA_VERSION_NUMBER = "1.2.1";
     public static final String QA_PLUGIN_NAME = "Quality Analyzer Plugin";
+
+    // Number of lines difference allowed between the start of a callable measured by Lizard and
+    // stored in the metadata DB.
+    public static final int QA_CALLABLE_START_END_LINE_TOLERANCE = 2;
 }

--- a/analyzer/quality-analyzer/src/test/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtilsTest.java
+++ b/analyzer/quality-analyzer/src/test/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtilsTest.java
@@ -1,0 +1,48 @@
+package eu.fasten.analyzer.qualityanalyzer;
+
+import org.junit.jupiter.api.Test;
+
+import static eu.fasten.analyzer.qualityanalyzer.MetadataUtils.normalizeCallableName;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetadataUtilsTest {
+
+    @Test
+    void normalizeCallableNameJavaTest() {
+        assertEquals("",
+                normalizeCallableName(""));
+
+        assertEquals("NDC.clear",
+                normalizeCallableName("NDC::clear"));
+
+        assertEquals("SMTPAppender.%3Cinit%3E",
+                normalizeCallableName("SMTPAppender::SMTPAppender"));
+
+        assertEquals("LoggingReceiver$Slurper.run",
+                normalizeCallableName("LoggingReceiver::Slurper::run"));
+
+        assertEquals("LoggingReceiver$Slurper.%3Cinit%3E",
+                normalizeCallableName("LoggingReceiver::Slurper::Slurper"));
+
+        assertEquals("PatternParser$NamedPatternConverter.%3Cinit%3E",
+                normalizeCallableName("PatternParser::NamedPatternConverter::NamedPatternConverter"));
+    }
+
+    @Test
+    void normalizeCallableNamePythonTest() {
+        assertEquals("get_filing_list",
+                normalizeCallableName("get_filing_list"));
+
+        assertEquals("_get_daily_listing_url",
+                normalizeCallableName("_get_daily_listing_url"));
+    }
+
+    @Test
+    void normalizeCallableNameCTest() {
+        assertEquals("drop_excludes",
+                normalizeCallableName("drop_excludes"));
+
+        assertEquals("gda_xslt_getxmlvalue_function",
+                normalizeCallableName("gda_xslt_getxmlvalue_function"));
+    }
+}


### PR DESCRIPTION
## Description
Improved the matching of quality analysis results to callables in the metadata DB. In particular, when constructors contained nested classes, callables could be accidentally matched. This has been improved by requiring the uri of callables to include leading class name + the callable name itself.

## Testing
Tested locally with DC for Java, Python, and C.

Fixes #474.