### PR TITLE
Improved callable name matching of the QualityAnalyzer (again).

### DIFF
--- a/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtils.java
+++ b/analyzer/quality-analyzer/src/main/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtils.java
@@ -79,28 +79,29 @@ public class MetadataUtils {
     }
 
     public static String normalizeCallableName(String callableName) {
-        StringBuilder result = new StringBuilder();
-        if(callableName == null) {
+        if(callableName == null || callableName.equals("")) {
             return "";
         }
-        var components = callableName.split(LIZARD_CALLABLE_SEPARATOR);
-
-        if(components.length == 1) {
-            result = new StringBuilder(components[0]);
-        }
-        else if(components.length > 1) {
-            if(components[components.length - 2].equals(components[components.length - 1])) {
-                components[components.length - 1] = JAVA_CONSTRUCTOR_NAME;
+        else {
+            StringBuilder result = new StringBuilder();
+            var components = callableName.split(LIZARD_CALLABLE_SEPARATOR);
+            if(components.length == 1) {
+                result = new StringBuilder(components[0]);
             }
-            result.append(components[0]);
-            int i = 1;
-            while(i < components.length - 1) {
-                result.append("$").append(components[i]);
-                i++;
+            else if(components.length > 1) {
+                if(components[components.length - 2].equals(components[components.length - 1])) {
+                    components[components.length - 1] = JAVA_CONSTRUCTOR_NAME;
+                }
+                result.append(components[0]);
+                int i = 1;
+                while(i < components.length - 1) {
+                    result.append("$").append(components[i]);
+                    i++;
+                }
+                result.append(".").append(components[i]);
             }
-            result.append(".").append(components[i]);
+            return result.append("(").toString();
         }
-        return result.toString();
     }
 
     private JSONObject getQualityMetadata(JSONObject payload, String rapidVersion) {

--- a/analyzer/quality-analyzer/src/test/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtilsTest.java
+++ b/analyzer/quality-analyzer/src/test/java/eu/fasten/analyzer/qualityanalyzer/MetadataUtilsTest.java
@@ -12,37 +12,37 @@ class MetadataUtilsTest {
         assertEquals("",
                 normalizeCallableName(""));
 
-        assertEquals("NDC.clear",
+        assertEquals("NDC.clear(",
                 normalizeCallableName("NDC::clear"));
 
-        assertEquals("SMTPAppender.%3Cinit%3E",
+        assertEquals("SMTPAppender.%3Cinit%3E(",
                 normalizeCallableName("SMTPAppender::SMTPAppender"));
 
-        assertEquals("LoggingReceiver$Slurper.run",
+        assertEquals("LoggingReceiver$Slurper.run(",
                 normalizeCallableName("LoggingReceiver::Slurper::run"));
 
-        assertEquals("LoggingReceiver$Slurper.%3Cinit%3E",
+        assertEquals("LoggingReceiver$Slurper.%3Cinit%3E(",
                 normalizeCallableName("LoggingReceiver::Slurper::Slurper"));
 
-        assertEquals("PatternParser$NamedPatternConverter.%3Cinit%3E",
+        assertEquals("PatternParser$NamedPatternConverter.%3Cinit%3E(",
                 normalizeCallableName("PatternParser::NamedPatternConverter::NamedPatternConverter"));
     }
 
     @Test
     void normalizeCallableNamePythonTest() {
-        assertEquals("get_filing_list",
+        assertEquals("get_filing_list(",
                 normalizeCallableName("get_filing_list"));
 
-        assertEquals("_get_daily_listing_url",
+        assertEquals("_get_daily_listing_url(",
                 normalizeCallableName("_get_daily_listing_url"));
     }
 
     @Test
     void normalizeCallableNameCTest() {
-        assertEquals("drop_excludes",
+        assertEquals("drop_excludes(",
                 normalizeCallableName("drop_excludes"));
 
-        assertEquals("gda_xslt_getxmlvalue_function",
+        assertEquals("gda_xslt_getxmlvalue_function(",
                 normalizeCallableName("gda_xslt_getxmlvalue_function"));
     }
 }


### PR DESCRIPTION
## Description
Further tightened up the callable name matching in the QualityAnalyzer. A "(" is required at the end of a callable name to ensure that indeed we are matching against the callable part of a FASTEN URI.

Fixes #476.
