### PR TITLE
Trim trailing and leading whitespace when getting upper/lower bound versions

### DIFF
--- a/core/src/main/java/eu/fasten/core/maven/data/VersionConstraint.java
+++ b/core/src/main/java/eu/fasten/core/maven/data/VersionConstraint.java
@@ -15,13 +15,13 @@
  */
 package eu.fasten.core.maven.data;
 
-import static eu.fasten.core.utils.Asserts.assertNotNull;
-import static eu.fasten.core.utils.Asserts.assertTrue;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import static eu.fasten.core.utils.Asserts.assertNotNull;
+import static eu.fasten.core.utils.Asserts.assertTrue;
 
 public class VersionConstraint {
 
@@ -63,7 +63,7 @@ public class VersionConstraint {
     public String getLowerBound() {
         if (isRange) {
             var parts = spec.substring(1, spec.length() - 1).split(",", -1);
-            return parts[0].isEmpty() ? "0" : parts[0];
+            return parts[0].isEmpty() ? "0" : parts[0].trim();
         }
         if (isHard) {
             return spec.substring(1, spec.length() - 1);
@@ -78,7 +78,7 @@ public class VersionConstraint {
     public String getUpperBound() {
         if (isRange) {
             var parts = spec.substring(1, spec.length() - 1).split(",", -1);
-            return parts[1].isEmpty() ? "999" : parts[1];
+            return parts[1].isEmpty() ? "999" : parts[1].trim();
 
         }
         if (isHard) {

--- a/core/src/test/java/eu/fasten/core/maven/data/VersionConstraintTest.java
+++ b/core/src/test/java/eu/fasten/core/maven/data/VersionConstraintTest.java
@@ -15,12 +15,7 @@
  */
 package eu.fasten.core.maven.data;
 
-import static eu.fasten.core.maven.data.VersionConstraint.parseVersionSpec;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -28,7 +23,12 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Test;
+import static eu.fasten.core.maven.data.VersionConstraint.parseVersionSpec;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("unchecked")
 public class VersionConstraintTest {
@@ -137,6 +137,15 @@ public class VersionConstraintTest {
         validate("[1.1],[1.2]", //
                 vc(false, true, "+1.1", "+1.1"), //
                 vc(false, true, "+1.2", "+1.2"));
+    }
+
+    @Test
+    public void spaceInVersionConstraint() {
+        var actual = new VersionConstraint("[ 1.2 , 1.3 )");
+        var expectedLowerBound = "1.2";
+        var expectedUpperBound = "1.3";
+        assertEquals(actual.getLowerBound(), expectedLowerBound);
+        assertEquals(actual.getUpperBound(), expectedUpperBound);
     }
 
     @Test


### PR DESCRIPTION
## Description
This is a small fix to the `getUpperBound` and `getLowerBound` methods in `VersionConstraint` to trim trailing and leading whitespace.  

## Motivation and context
Whitespace in version strings might cause issues, for example, when downloading Jars or doing comparisons.

## Testing
Added a unit test.
