### PR TITLE
Add `exec` to the entry points of Docker files in the project

### DIFF
--- a/analyzer/restapi-plugin/Dockerfile
+++ b/analyzer/restapi-plugin/Dockerfile
@@ -3,6 +3,6 @@ FROM openjdk:11-jre-slim
 WORKDIR /app
 COPY ./target/*.jar ./rest-api.jar
 
-ENTRYPOINT java $JAVA_OPTS -XX:+UseG1GC -XX:+UseStringDeduplication -XX:-CompactStrings -jar /app/rest-api.jar $0 $@
+ENTRYPOINT exec java $JAVA_OPTS -XX:+UseG1GC -XX:+UseStringDeduplication -XX:-CompactStrings -jar /app/rest-api.jar $0 $@
 
 EXPOSE 8080

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -7,4 +7,4 @@ COPY /plugins/. /plugins
 
 ENV JVM_MEM_MAX=-Xmx16g
 
-ENTRYPOINT java $JVM_MEM_MAX -XX:+ExitOnOutOfMemoryError -cp server-with-dependencies.jar eu.fasten.server.FastenServer -p ./plugins $0 $@
+ENTRYPOINT exec java $JVM_MEM_MAX -XX:+ExitOnOutOfMemoryError -cp server-with-dependencies.jar eu.fasten.server.FastenServer -p ./plugins $0 $@


### PR DESCRIPTION
## Description
This is a tiny PR to add `exec` to `ENTRYPOINT` of Docker files. This is recommended in the official Docker documentation [here](https://docs.docker.com/engine/reference/builder/#entrypoint).

## Motivation and context
Currently, Docker files use the _shell_ form for `ENTRYPOINT`, which prevents the Docker container to receive Unix signals. This PR addresses this issue.

## Testing
Not yet.
