### PR TITLE
Revise exception handling and lazy ingestion of REST API

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
@@ -61,7 +61,7 @@ public class LazyIngestionProvider {
         return key;
     }
 
-    public static void ingestArtifactIfNecessary(String packageName, String version, String artifactRepo, Long date) throws IllegalArgumentException, IOException {
+    public static void ingestArtifactIfNecessary(String packageName, String version, String artifactRepo, Long date) {
         switch(KnowledgeBaseConnector.forge){
             case Constants.mvnForge: {
                 ingestMvnArtifactIfNecessary(packageName, version, artifactRepo, date);
@@ -74,7 +74,7 @@ public class LazyIngestionProvider {
         }
     }
 
-    public static void ingestMvnArtifactIfNecessary(String packageName, String version, String artifactRepo, Long date) throws IllegalArgumentException, IOException {
+    public static void ingestMvnArtifactIfNecessary(String packageName, String version, String artifactRepo, Long date) {
         var groupId = packageName.split(Constants.mvnCoordinateSeparator)[0];
         var artifactId = packageName.split(Constants.mvnCoordinateSeparator)[1];
         if(artifactRepo == null || artifactRepo.isEmpty()) {
@@ -102,7 +102,7 @@ public class LazyIngestionProvider {
         }
     }
 
-    public static void ingestPypiArtifactIfNecessary(String packageName, String version) throws IllegalArgumentException, IOException {
+    public static void ingestPypiArtifactIfNecessary(String packageName, String version) {
         var query = "https://pypi.org/pypi/" + packageName + "/" + version +"/json";
         String result;
         try {
@@ -145,11 +145,7 @@ public class LazyIngestionProvider {
         var dependencies = mavenResolver.resolveDependencies(groupId + ":" + artifactId + ":" + version);
         ingestMvnArtifactIfNecessary(packageName, version, null, null);
         dependencies.forEach(d -> {
-            try {
-                ingestMvnArtifactIfNecessary(d.getGroupId() + Constants.mvnCoordinateSeparator + d.getArtifactId(), d.version.toString(), null, null);
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            ingestMvnArtifactIfNecessary(d.getGroupId() + Constants.mvnCoordinateSeparator + d.getArtifactId(), d.version.toString(), null, null);
         });
     }
 
@@ -162,11 +158,7 @@ public class LazyIngestionProvider {
             JsonObject jsonObject = coordinate.getAsJsonObject();
             String dependencyPackage = jsonObject.get("product").getAsString();
             String dependencyVersion = jsonObject.get("version").getAsString();
-            try {
-                ingestPypiArtifactIfNecessary(dependencyPackage, dependencyVersion);
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            ingestPypiArtifactIfNecessary(dependencyPackage, dependencyVersion);
         }
     }
 

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
@@ -18,10 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
-import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
-import eu.fasten.analyzer.restapiplugin.RestApplication;
-import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +27,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
+import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
+import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
+import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 
 @RestController
 @RequestMapping("/packages")
@@ -49,13 +48,7 @@ public class BinaryModuleApi {
             result = KnowledgeBaseConnector.kbDao.getPackageBinaryModules(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            } catch (IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");
@@ -73,11 +66,7 @@ public class BinaryModuleApi {
             result = KnowledgeBaseConnector.kbDao.getBinaryModuleMetadata(
                     packageName, packageVersion, binary_module);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException | IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {
@@ -100,11 +89,7 @@ public class BinaryModuleApi {
             result = KnowledgeBaseConnector.kbDao.getBinaryModuleFiles(
                     packageName, packageVersion, binary_module, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException | IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
@@ -18,14 +18,10 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
-import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
-import eu.fasten.analyzer.restapiplugin.RestApplication;
-import eu.fasten.core.maven.data.PackageVersionNotFoundException;
+import java.util.List;
+
 import org.json.JSONObject;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,8 +30,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import java.io.IOException;
-import java.util.List;
+
+import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
+import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
+import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 
 @RestController
 public class CallableApi {
@@ -52,13 +51,7 @@ public class CallableApi {
             result = KnowledgeBaseConnector.kbDao.getPackageCallables(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            } catch (IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");
@@ -74,11 +67,7 @@ public class CallableApi {
         String result = KnowledgeBaseConnector.kbDao.getCallableMetadata(
                 packageName, packageVersion, fasten_uri);
         if (result == null) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException | IllegalStateException | IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
@@ -18,10 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
-import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
-import eu.fasten.analyzer.restapiplugin.RestApplication;
-import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +26,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import java.io.IOException;
+
+import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
+import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
+import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 
 @RestController
 @RequestMapping("/packages")
@@ -48,13 +48,7 @@ public class DependencyApi {
             result = KnowledgeBaseConnector.kbDao.getPackageDependencies(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            } catch (IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
@@ -18,10 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
-import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
-import eu.fasten.analyzer.restapiplugin.RestApplication;
-import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +27,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
+import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
+import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
+import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 
 @RestController
 @RequestMapping("/packages")
@@ -49,13 +48,7 @@ public class EdgeApi {
             result = KnowledgeBaseConnector.kbDao.getPackageEdges(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            } catch (IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
@@ -18,10 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
-import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
-import eu.fasten.analyzer.restapiplugin.RestApplication;
-import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +26,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import java.io.IOException;
+
+import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
+import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
+import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 
 @RestController
 @RequestMapping("/packages")
@@ -48,13 +48,7 @@ public class FileApi {
             result = KnowledgeBaseConnector.kbDao.getPackageFiles(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            } catch (IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
@@ -18,10 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
-import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
-import eu.fasten.analyzer.restapiplugin.RestApplication;
-import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +28,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import java.io.IOException;
+
+import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
+import eu.fasten.analyzer.restapiplugin.LazyIngestionProvider;
+import eu.fasten.analyzer.restapiplugin.RestApplication;
+import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 
 @RestController
 @RequestMapping("/packages")
@@ -50,13 +50,7 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getPackageModules(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            } catch (IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");
@@ -74,11 +68,7 @@ public class ModuleApi {
         try {
             result = KnowledgeBaseConnector.kbDao.getModuleMetadata(packageName, packageVersion, module_namespace);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException | IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {
@@ -102,11 +92,7 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getModuleFiles(
                     packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException | IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {
@@ -130,11 +116,7 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getModuleCallables(
                     KnowledgeBaseConnector.forge, packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            try {
-                LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            } catch (IllegalArgumentException | IOException ex) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-            }
+            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/CallableApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/CallableApiTest.java
@@ -32,6 +32,8 @@ import org.springframework.http.ResponseEntity;
 import java.util.HashMap;
 import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CallableApiTest {
 
@@ -91,10 +93,11 @@ public class CallableApiTest {
         var version = "version";
         var callable = "callable uri";
         Mockito.when(kbDao.getCallableMetadata(packageName, version, callable)).thenReturn(null);
-        var result = service.getCallableMetadata(packageName, version, callable, null, null);
-        assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
-
-        Mockito.verify(kbDao, Mockito.times(1)).getCallableMetadata(packageName, version, callable);
+        var e = assertThrows(IllegalArgumentException.class, () -> {
+            service.getCallableMetadata(packageName, version, callable, null, null);
+        });
+        var expectedMsg = "Maven artifact 'group:artifact:version' could not be found in the repository of '";
+        assertTrue(e.getMessage().startsWith(expectedMsg));
     }
 
     @Test

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/PackageApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/PackageApiTest.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PackageApiTest {
 
@@ -111,10 +113,11 @@ public class PackageApiTest {
         var packageName = "group:artifact";
         var version = "version";
         Mockito.when(kbDao.getPackageVersion(packageName, version)).thenReturn(null);
-        var result = service.getPackageVersion(packageName, version, null, null);
-        assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
-
-        Mockito.verify(kbDao, Mockito.times(1)).getPackageVersion(packageName, version);
+        var e = assertThrows(IllegalArgumentException.class, () -> {
+            service.getPackageVersion(packageName, version, null, null);
+        });
+        var expectedMsg = "Maven artifact 'group:artifact:version' could not be found in the repository of '";
+        assertTrue(e.getMessage().startsWith(expectedMsg));
     }
 
     @Test


### PR DESCRIPTION
The lazy ingestion of packages is not only quite slow. Looking at the implementation, I found the current exception handling to be unnecessarily complex and the business logic for the ingestion to be very convoluted. We currently also download POM files on *every* request, which is quite an unnecessary load that we put on Maven Central.

This PR addresses these two points and consists of two main changes:

- I have revised the exception handling and by doing so simplified the API signatures for all related endpoints
- I have improved the ingestion logic. We first check now for already ingested packages, which is the fastest check we can do. Only for un-ingested packages, we will now contact Maven Central to verify their existence. However, instead of downloading the POM file via GET, we now only send a HEAD request and check for the existence. Validated, non-ingested artifacts will then be added to the Kafka input topic.

As a result, the answer to previously ingested packages should be *much* faster now and most requests should consume fewer resources, both for us and Maven Central.