### PR TITLE
Exclude derived fields from Pom serialization

### DIFF
--- a/core/src/main/java/eu/fasten/core/maven/data/Pom.java
+++ b/core/src/main/java/eu/fasten/core/maven/data/Pom.java
@@ -55,9 +55,9 @@ public class Pom {
     public final String sourcesUrl;
     public final String artifactRepository;
 
-    private final int hashCode;
-    private final GAV gav;
-    private final GA ga;
+    private transient final int hashCode;
+    private transient final GAV gav;
+    private transient final GA ga;
 
     // use LinkedHashSet for dependencies, because order is relevant for resolution
     public Pom(String groupId, String artifactId, String packagingType, String version, String parentCoordinate,

--- a/core/src/test/java/eu/fasten/core/json/CoreMavenDataModuleTest.java
+++ b/core/src/test/java/eu/fasten/core/json/CoreMavenDataModuleTest.java
@@ -15,6 +15,7 @@
  */
 package eu.fasten.core.json;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.util.Set;
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -51,6 +53,16 @@ public class CoreMavenDataModuleTest {
                 return om.enable(SerializationFeature.INDENT_OUTPUT);
             }
         }.build();
+    }
+
+    @Test
+    public void testPom() throws Exception {
+        var pom = new PomBuilder().pom();
+        var json = om.writeValueAsString(pom);
+        var obj = new JSONObject(json);
+        assertFalse(obj.has("ga"));
+        assertFalse(obj.has("gav"));
+        assertFalse(obj.has("hashCode"));
     }
 
     @Test


### PR DESCRIPTION
The `Pom` class contain some pre-computed fields to improve performance of the Maven resolution. Erroneously, these fields are included in the serialization right now, which does not make sense as they get re-computed on de-serialization anyways. This PR removes the fields from serialization.