### PR TITLE
Several improvements to performance and code quality of the REST API

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
@@ -36,6 +36,12 @@ import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 @RequestMapping("/packages")
 public class BinaryModuleApi {
 
+    private LazyIngestionProvider ingestion = new LazyIngestionProvider();
+
+    public void setLazyIngestionProvider(LazyIngestionProvider ingestion) {
+        this.ingestion = ingestion;
+    }
+
     @GetMapping(value = "/{pkg}/{pkg_ver}/binary-modules", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getPackageBinaryModules(@PathVariable("pkg") String packageName,
                                                    @PathVariable("pkg_ver") String packageVersion,
@@ -48,7 +54,7 @@ public class BinaryModuleApi {
             result = KnowledgeBaseConnector.kbDao.getPackageBinaryModules(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");
@@ -66,7 +72,7 @@ public class BinaryModuleApi {
             result = KnowledgeBaseConnector.kbDao.getBinaryModuleMetadata(
                     packageName, packageVersion, binary_module);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {
@@ -89,7 +95,7 @@ public class BinaryModuleApi {
             result = KnowledgeBaseConnector.kbDao.getBinaryModuleFiles(
                     packageName, packageVersion, binary_module, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
@@ -39,6 +39,12 @@ import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 @RestController
 public class CallableApi {
 
+    private LazyIngestionProvider ingestion = new LazyIngestionProvider();
+
+    public void setLazyIngestionProvider(LazyIngestionProvider ingestion) {
+        this.ingestion = ingestion;
+    }
+
     @GetMapping(value = "/packages/{pkg}/{pkg_ver}/callables", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getPackageCallables(@PathVariable("pkg") String packageName,
                                                @PathVariable("pkg_ver") String packageVersion,
@@ -51,7 +57,7 @@ public class CallableApi {
             result = KnowledgeBaseConnector.kbDao.getPackageCallables(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");
@@ -67,7 +73,7 @@ public class CallableApi {
         String result = KnowledgeBaseConnector.kbDao.getCallableMetadata(
                 packageName, packageVersion, fasten_uri);
         if (result == null) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
@@ -36,6 +36,12 @@ import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 @RequestMapping("/packages")
 public class DependencyApi {
 
+    private LazyIngestionProvider ingestion = new LazyIngestionProvider();
+
+    public void setLazyIngestionProvider(LazyIngestionProvider ingestion) {
+        this.ingestion = ingestion;
+    }
+
     @GetMapping(value = "/{pkg}/{pkg_ver}/deps", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getPackageDependencies(@PathVariable("pkg") String packageName,
                                                   @PathVariable("pkg_ver") String packageVersion,
@@ -48,7 +54,7 @@ public class DependencyApi {
             result = KnowledgeBaseConnector.kbDao.getPackageDependencies(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
@@ -36,6 +36,12 @@ import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 @RequestMapping("/packages")
 public class EdgeApi {
 
+    private LazyIngestionProvider ingestion = new LazyIngestionProvider();
+
+    public void setLazyIngestionProvider(LazyIngestionProvider ingestion) {
+        this.ingestion = ingestion;
+    }
+
     @GetMapping(value = "/{pkg}/{pkg_ver}/edges", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getPackageEdges(@PathVariable("pkg") String packageName,
                                            @PathVariable("pkg_ver") String packageVersion,
@@ -48,7 +54,7 @@ public class EdgeApi {
             result = KnowledgeBaseConnector.kbDao.getPackageEdges(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
@@ -36,6 +36,12 @@ import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 @RequestMapping("/packages")
 public class FileApi {
 
+    private LazyIngestionProvider ingestion = new LazyIngestionProvider();
+
+    public void setLazyIngestionProvider(LazyIngestionProvider ingestion) {
+        this.ingestion = ingestion;
+    };
+
     @GetMapping(value = "/{pkg}/{pkg_ver}/files", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getPackageFiles(@PathVariable("pkg") String packageName,
                                            @PathVariable("pkg_ver") String packageVersion,
@@ -48,7 +54,7 @@ public class FileApi {
             result = KnowledgeBaseConnector.kbDao.getPackageFiles(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
@@ -38,6 +38,12 @@ import eu.fasten.core.maven.data.PackageVersionNotFoundException;
 @RequestMapping("/packages")
 public class ModuleApi {
 
+    private LazyIngestionProvider ingestion = new LazyIngestionProvider();
+
+    public void setLazyIngestionProvider(LazyIngestionProvider ingestion) {
+        this.ingestion = ingestion;
+    }
+
     @GetMapping(value = "/{pkg}/{pkg_ver}/modules", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getPackageModules(@PathVariable("pkg") String packageName,
                                              @PathVariable("pkg_ver") String packageVersion,
@@ -50,7 +56,7 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getPackageModules(
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         result = result.replace("\\/", "/");
@@ -68,7 +74,7 @@ public class ModuleApi {
         try {
             result = KnowledgeBaseConnector.kbDao.getModuleMetadata(packageName, packageVersion, module_namespace);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {
@@ -92,7 +98,7 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getModuleFiles(
                     packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {
@@ -116,7 +122,7 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getModuleCallables(
                     KnowledgeBaseConnector.forge, packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
-            LazyIngestionProvider.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
+            ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
             return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
         }
         if (result == null) {

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerabilityApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerabilityApi.java
@@ -18,7 +18,13 @@ import java.util.List;
 @RestController
 public class VulnerabilityApi {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(VulnerabilityApi.class);
+
+    private LazyIngestionProvider ingestion = new LazyIngestionProvider();
+
+    public void setLazyIngestionProvider(LazyIngestionProvider ingestion) {
+        this.ingestion = ingestion;
+    }
 
     @GetMapping(value = "/vulnerabilities", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getAllVulnerabilities(@RequestParam(required = false, defaultValue = "0") int offset,
@@ -80,7 +86,7 @@ public class VulnerabilityApi {
     ResponseEntity<String> getCoordinatesVulnerabilities(@RequestBody List<String> coordinates,
                                                          @RequestParam(required = false, defaultValue = "") List<String> attributes) {
         JSONArray jsonArray = new JSONArray();
-        logger.info("Received a list of coordinates");
+        LOG.info("Received a list of coordinates");
         coordinates.stream().map(c -> {
             String packageName, packageVersion;
             switch (KnowledgeBaseConnector.forge) {
@@ -99,10 +105,10 @@ public class VulnerabilityApi {
             var vulnerabilities = "";
             if (!KnowledgeBaseConnector.kbDao.assertPackageExistence(packageName, packageVersion)) {
                 try {
-                    LazyIngestionProvider.ingestArtifactWithDependencies(packageName, packageVersion);
-                    logger.info("Coordinate " + c + " not found, but should be processed soon. Try again later");
+                    ingestion.ingestArtifactWithDependencies(packageName, packageVersion);
+                    LOG.info("Coordinate " + c + " not found, but should be processed soon. Try again later");
                 } catch (Exception e) {
-                    logger.info("Cannot find coordinate " + c + ": " +e.getMessage());
+                    LOG.info("Cannot find coordinate " + c + ": " +e.getMessage());
                 }
             } else {
                 var statements = KnowledgeBaseConnector.kbDao
@@ -126,7 +132,7 @@ public class VulnerabilityApi {
         
         if (!KnowledgeBaseConnector.kbDao.assertPackageExistence(packageName, packageVersion)) {
             try {
-                LazyIngestionProvider.ingestArtifactWithDependencies(packageName, packageVersion);
+                ingestion.ingestArtifactWithDependencies(packageName, packageVersion);
             } catch (IllegalArgumentException | IOException e) {
                 return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
             }

--- a/analyzer/restapi-plugin/src/main/resources/application.properties
+++ b/analyzer/restapi-plugin/src/main/resources/application.properties
@@ -2,7 +2,6 @@ logging.level.org.springframework.web=DEBUG
 spring.mvc.async.request-timeout=60000
 server.tomcat.connection-timeout=60000
 server.port=8080
-server.tomcat.threads.max=20
 kb.user=${db.user}
 kb.url=${db.url}
 kb.depgraph.path=${dg.path}


### PR DESCRIPTION
During my investigation of the slow response time of the package version endpoint, I made three improvements in the REST API:

1) The `LazyIngestionProvider` was a static monster. I have made the first step towards dependency injection and made it a regular class. We should consider making it a `@Component` moving forward, so Spring can take care of the lifecycle management and the injection. An advantage of the current refactoring is also an improved testability of all dependent classes.
2) For unclear reasons, our config has limited the REST API to 20 threads, while even the default is 200 threads already. To prevent a potential bottleneck, I have removed this artificial limit.
3) I have introduced a minor performance improvement in the package version endpoint. Yet un-ingested packages result in a short-circuit and the logic will avoid an expensive, joined call to the database.

None of these improvements has solved the major performance issue (it looks like we were just missing an index), but this PR makes some small contributions to performance and code quality.