### PR TITLE
Refactor response creation in API and add ingestion to pkg/version/metadata

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
@@ -55,7 +55,7 @@ public class BinaryModuleApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
@@ -73,7 +73,7 @@ public class BinaryModuleApi {
                     packageName, packageVersion, binary_module);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         if (result == null) {
             return new ResponseEntity<>("Binary module not found", HttpStatus.NOT_FOUND);
@@ -96,7 +96,7 @@ public class BinaryModuleApi {
                     packageName, packageVersion, binary_module, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/BinaryModuleApi.java
@@ -55,10 +55,10 @@ public class BinaryModuleApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}/{pkg_ver}/binary-modules/{binary}/metadata", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -73,13 +73,13 @@ public class BinaryModuleApi {
                     packageName, packageVersion, binary_module);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         if (result == null) {
-            return new ResponseEntity<>("Binary module not found", HttpStatus.NOT_FOUND);
+            return Responses.binaryModuleNotFound();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}/{pkg_ver}/binary-modules/{binary}/files", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -96,9 +96,9 @@ public class BinaryModuleApi {
                     packageName, packageVersion, binary_module, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
@@ -21,7 +21,6 @@ package eu.fasten.analyzer.restapiplugin.api;
 import java.util.List;
 
 import org.json.JSONObject;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -58,10 +57,10 @@ public class CallableApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/packages/{pkg}/{pkg_ver}/callable/metadata", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -74,10 +73,10 @@ public class CallableApi {
                 packageName, packageVersion, fasten_uri);
         if (result == null) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/callables", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -90,6 +89,6 @@ public class CallableApi {
         }
         var result = json.toString();
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/CallableApi.java
@@ -58,7 +58,7 @@ public class CallableApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
@@ -74,7 +74,7 @@ public class CallableApi {
                 packageName, packageVersion, fasten_uri);
         if (result == null) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
@@ -55,7 +55,7 @@ public class DependencyApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/DependencyApi.java
@@ -18,7 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,9 +54,9 @@ public class DependencyApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
@@ -55,7 +55,7 @@ public class EdgeApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/EdgeApi.java
@@ -18,7 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,9 +54,9 @@ public class EdgeApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
@@ -55,7 +55,7 @@ public class FileApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/FileApi.java
@@ -18,7 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,9 +54,9 @@ public class FileApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
@@ -18,7 +18,6 @@
 
 package eu.fasten.analyzer.restapiplugin.api;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,10 +56,10 @@ public class ModuleApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/{pkg}/{pkg_ver}/modules/metadata", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -75,13 +74,13 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getModuleMetadata(packageName, packageVersion, module_namespace);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         if (result == null) {
-            return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
+            return Responses.moduleNotFound();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/{pkg}/{pkg_ver}/modules/files", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -99,13 +98,13 @@ public class ModuleApi {
                     packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         if (result == null) {
-            return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
+            return Responses.moduleNotFound();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/{pkg}/{pkg_ver}/modules/callables", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -123,12 +122,12 @@ public class ModuleApi {
                     KnowledgeBaseConnector.forge, packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         if (result == null) {
-            return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
+            return Responses.moduleNotFound();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ModuleApi.java
@@ -57,7 +57,7 @@ public class ModuleApi {
                     packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
@@ -75,7 +75,7 @@ public class ModuleApi {
             result = KnowledgeBaseConnector.kbDao.getModuleMetadata(packageName, packageVersion, module_namespace);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         if (result == null) {
             return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
@@ -99,7 +99,7 @@ public class ModuleApi {
                     packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         if (result == null) {
             return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
@@ -123,7 +123,7 @@ public class ModuleApi {
                     KnowledgeBaseConnector.forge, packageName, packageVersion, module_namespace, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepository, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         if (result == null) {
             return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/PackageApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/PackageApi.java
@@ -80,8 +80,7 @@ public class PackageApi {
         var hasNeededIngestion = ingestion.ingestArtifactIfNecessary(packageName, packageVersion,
                 artifactRepo, releaseDate);
         if (hasNeededIngestion) {
-            return new ResponseEntity<>("Package version not found, started processing... try again later",
-                    HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         var result = KnowledgeBaseConnector.kbDao.getPackageVersion(packageName, packageVersion);
         result = result.replace("\\/", "/");
@@ -111,8 +110,7 @@ public class PackageApi {
             result = KnowledgeBaseConnector.kbDao.getPackageCallgraph(packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepo, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later",
-                    HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         result = result.replace("\\/", "/");
         return new ResponseEntity<>(result, HttpStatus.OK);
@@ -138,8 +136,7 @@ public class PackageApi {
         String url;
         if (!KnowledgeBaseConnector.kbDao.assertPackageExistence(packageName, version)) {
             ingestion.ingestArtifactIfNecessary(packageName, version, artifactRepo, releaseDate);
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later",
-                    HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         switch (KnowledgeBaseConnector.forge) {
         case Constants.mvnForge: {

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/PackageApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/PackageApi.java
@@ -49,17 +49,17 @@ public class PackageApi {
             @RequestParam(required = false, defaultValue = RestApplication.DEFAULT_PAGE_SIZE) int limit) {
         var result = KnowledgeBaseConnector.kbDao.getAllPackages(offset, limit);
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getPackageLastVersion(@PathVariable("pkg") String packageName) {
         String result = KnowledgeBaseConnector.kbDao.getPackageLastVersion(packageName);
         if (result == null) {
-            return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+            return Responses.packageNotFound();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}/versions", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -68,7 +68,7 @@ public class PackageApi {
             @RequestParam(required = false, defaultValue = RestApplication.DEFAULT_PAGE_SIZE) int limit) {
         String result = KnowledgeBaseConnector.kbDao.getPackageVersions(packageName, offset, limit);
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}/{pkg_ver}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -80,11 +80,11 @@ public class PackageApi {
         var hasNeededIngestion = ingestion.ingestArtifactIfNecessary(packageName, packageVersion,
                 artifactRepo, releaseDate);
         if (hasNeededIngestion) {
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         var result = KnowledgeBaseConnector.kbDao.getPackageVersion(packageName, packageVersion);
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}/{pkg_ver}/metadata", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -92,10 +92,10 @@ public class PackageApi {
             @PathVariable("pkg_ver") String packageVersion) {
         String result = KnowledgeBaseConnector.kbDao.getPackageMetadata(packageName, packageVersion);
         if (result == null) {
-            return new ResponseEntity<>("Package version not found", HttpStatus.NOT_FOUND);
+            return Responses.packageVersionNotFound();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}/{pkg_ver}/callgraph", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -110,10 +110,10 @@ public class PackageApi {
             result = KnowledgeBaseConnector.kbDao.getPackageCallgraph(packageName, packageVersion, offset, limit);
         } catch (PackageVersionNotFoundException e) {
             ingestion.ingestArtifactIfNecessary(packageName, packageVersion, artifactRepo, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -122,10 +122,10 @@ public class PackageApi {
             @RequestParam(required = false, defaultValue = RestApplication.DEFAULT_PAGE_SIZE) int limit) {
         var result = KnowledgeBaseConnector.kbDao.searchPackageNames(packageName, offset, limit);
         if (result == null) {
-            return new ResponseEntity<>("Packages version not found", HttpStatus.NOT_FOUND);
+            return Responses.packageVersionNotFound();
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/{pkg}/{pkg_ver}/rcg", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -136,7 +136,7 @@ public class PackageApi {
         String url;
         if (!KnowledgeBaseConnector.kbDao.assertPackageExistence(packageName, version)) {
             ingestion.ingestArtifactIfNecessary(packageName, version, artifactRepo, releaseDate);
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         switch (KnowledgeBaseConnector.forge) {
         case Constants.mvnForge: {
@@ -160,12 +160,12 @@ public class PackageApi {
             break;
         }
         default:
-            return new ResponseEntity<>("Incorrect forge", HttpStatus.BAD_REQUEST);
+            return Responses.incorrectForge();
         }
         result = MavenUtilities.sendGetRequest(url);
         if (result == null) {
-            return new ResponseEntity<>("Could not find the requested data at " + url, HttpStatus.NOT_FOUND);
+            return Responses.dataNotFound();
         }
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/PackageVersionApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/PackageVersionApi.java
@@ -20,7 +20,6 @@ package eu.fasten.analyzer.restapiplugin.api;
 
 import eu.fasten.analyzer.restapiplugin.KnowledgeBaseConnector;
 import eu.fasten.core.data.Constants;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,7 +37,7 @@ public class PackageVersionApi {
         String url;
         var artifact = KnowledgeBaseConnector.kbDao.getArtifactName(packageVersionId);
         if (artifact == null) {
-            return new ResponseEntity<>("Package version not found", HttpStatus.NOT_FOUND);
+            return Responses.packageVersionNotFound();
         }
         var coordinate = artifact.split(Constants.mvnCoordinateSeparator);
         switch (KnowledgeBaseConnector.forge) {
@@ -65,10 +64,10 @@ public class PackageVersionApi {
                 break;
             }
             default:
-                return new ResponseEntity<>("Incorrect forge", HttpStatus.BAD_REQUEST);
+                return Responses.incorrectForge();
         }
         url = url.replace("\\/", "/");
-        return new ResponseEntity<>(url, HttpStatus.OK);
+        return Responses.ok(url);
     }
 }
 

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ResolutionApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ResolutionApi.java
@@ -113,7 +113,7 @@ public class ResolutionApi {
                     } catch (IOException e) {
                         return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
                     }
-                    return Responses.getLazyIngestionResponse();
+                    return Responses.lazyIngestion();
                 }
                 var groupId = packageName.split(Constants.mvnCoordinateSeparator)[0];
                 var artifactId = packageName.split(Constants.mvnCoordinateSeparator)[1];
@@ -153,18 +153,18 @@ public class ResolutionApi {
                 query = KnowledgeBaseConnector.dependencyResolverAddress+"/dependencies/"+packageName+"/"+packageVersion;
                 result = MavenUtilities.sendGetRequest(query);
                 if (result == null || result.contains("\"error\"")) {
-                    return new ResponseEntity<>("Could not find the requested data", HttpStatus.NOT_FOUND);
+                    return Responses.dataNotFound();
                 }
                 result = result.replaceAll("\\s+","");
-                return new ResponseEntity<>(result, HttpStatus.OK);
+                return Responses.ok(result);
             default: {
                 query = KnowledgeBaseConnector.dependencyResolverAddress+"/dependencies/"+packageName+"/"+packageVersion;
                 result = MavenUtilities.sendGetRequest(query);
                 if (result == null || result.contains("\"error\"")) {
-                    return new ResponseEntity<>("Could not find the requested data", HttpStatus.NOT_FOUND);
+                    return Responses.dataNotFound();
                 }
                 result = result.replaceAll("\\s+","");
-                return new ResponseEntity<>(result, HttpStatus.OK);
+                return Responses.ok(result);
             }
         }
     }
@@ -204,7 +204,7 @@ public class ResolutionApi {
                         json.put("url", url);
                     }).forEach(jsonArray::put);
                } catch (RuntimeException e) {
-                    return new ResponseEntity<>("Failed to resolve dependents for revision "+packageName+":"+ packageVersion , HttpStatus.NOT_FOUND);
+                    return Responses.failedToResolveDependents(packageName, packageVersion);
                }
                 break;
             }
@@ -220,7 +220,7 @@ public class ResolutionApi {
                         json.put("url", url);
                     }).forEach(jsonArray::put);
                 } catch (RuntimeException e) {
-                    return new ResponseEntity<>("Failed to resolve dependents for revision "+packageName+":"+ packageVersion , HttpStatus.NOT_FOUND);
+                    return Responses.failedToResolveDependents(packageName, packageVersion);
                 }
                 break;
             }
@@ -236,16 +236,16 @@ public class ResolutionApi {
                         json.put("url", url);
                     }).forEach(jsonArray::put);
                 } catch (RuntimeException e) {
-                    return new ResponseEntity<>("Failed to resolve dependents for revision "+packageName+":"+ packageVersion , HttpStatus.NOT_FOUND);
+                    return Responses.failedToResolveDependents(packageName, packageVersion);
                 }
                 break;
             }
             default:
-                return new ResponseEntity<>("Incorrect forge", HttpStatus.BAD_REQUEST);
+                return Responses.incorrectForge();
         }
         var result = jsonArray.toString();
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/resolve_dependencies", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -294,7 +294,7 @@ public class ResolutionApi {
         if (needStitching) {
             var mavenCoordinate = KnowledgeBaseConnector.kbDao.getMavenCoordinate(packageVersionId);
             if (mavenCoordinate == null) {
-                return new ResponseEntity<>("Package version ID not found", HttpStatus.NOT_FOUND);
+                return Responses.packageVersionNotFound();
             }
             var groupId = mavenCoordinate.split(Constants.mvnCoordinateSeparator)[0];
             var artifactId = mavenCoordinate.split(Constants.mvnCoordinateSeparator)[1];

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ResolutionApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/ResolutionApi.java
@@ -113,7 +113,7 @@ public class ResolutionApi {
                     } catch (IOException e) {
                         return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
                     }
-                    return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+                    return Responses.getLazyIngestionResponse();
                 }
                 var groupId = packageName.split(Constants.mvnCoordinateSeparator)[0];
                 var artifactId = packageName.split(Constants.mvnCoordinateSeparator)[1];

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/Responses.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/Responses.java
@@ -4,8 +4,44 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 public class Responses {
-    public static ResponseEntity<String> getLazyIngestionResponse() {
+
+    public static ResponseEntity<String> ok(String body) {
+        return new ResponseEntity<>(body, HttpStatus.OK);
+    }
+
+    public static ResponseEntity<String> incorrectForge() {
+        return new ResponseEntity<>("Incorrect forge", HttpStatus.BAD_REQUEST);
+    }
+
+    public static ResponseEntity<String> lazyIngestion() {
         return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later.",
                 HttpStatus.CREATED);
+    }
+
+    public static ResponseEntity<String> packageNotFound() {
+        return new ResponseEntity<>("Package not found", HttpStatus.NOT_FOUND);
+    }
+    public static ResponseEntity<String> packageVersionNotFound() {
+        return new ResponseEntity<>("Package version not found", HttpStatus.NOT_FOUND);
+    }
+
+    public static ResponseEntity<String> moduleNotFound() {
+        return new ResponseEntity<>("Module not found", HttpStatus.NOT_FOUND);
+    }
+
+    public static ResponseEntity<String> binaryModuleNotFound() {
+        return new ResponseEntity<>("Binary module not found", HttpStatus.NOT_FOUND);
+    }
+
+    public static ResponseEntity<String> failedToResolveDependents(String packageName, String packageVersion) {
+        return new ResponseEntity<>("Failed to resolve dependents for revision " +
+                packageName +
+                ":" +
+                packageVersion,
+                HttpStatus.NOT_FOUND);
+    }
+
+    public static ResponseEntity<String> dataNotFound() {
+        return new ResponseEntity<>("Could not find the requested data", HttpStatus.NOT_FOUND);
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/Responses.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/Responses.java
@@ -1,0 +1,11 @@
+package eu.fasten.analyzer.restapiplugin.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class Responses {
+    public static ResponseEntity<String> getLazyIngestionResponse() {
+        return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later.",
+                HttpStatus.CREATED);
+    }
+}

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/StitchingApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/StitchingApi.java
@@ -58,7 +58,7 @@ public class StitchingApi {
         fastenUris.forEach((key, value) -> json.put(String.valueOf(key), value));
         var result = json.toString();
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/metadata/callables", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -125,7 +125,7 @@ public class StitchingApi {
         result = result.replace("\\/", "/");
         LOG.info("Done: {}ms. Sending response", System.currentTimeMillis() - start);
         LOG.info("In total everything took {}ms", System.currentTimeMillis() - total);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/__INTERNAL__/ingest/batch", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -146,6 +146,6 @@ public class StitchingApi {
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
-        return new ResponseEntity<>("Ingested successfully", HttpStatus.OK);
+        return Responses.ok("Ingested successfully");
     }
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerabilityApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerabilityApi.java
@@ -136,7 +136,7 @@ public class VulnerabilityApi {
             } catch (IllegalArgumentException | IOException e) {
                 return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
             }
-            return new ResponseEntity<>("Package version not found, but should be processed soon. Try again later", HttpStatus.CREATED);
+            return Responses.getLazyIngestionResponse();
         }
         var statements = KnowledgeBaseConnector.kbDao.getPackageVersionVulnerabilities(packageName, packageVersion, true);
         JSONArray vulnerabilities = new JSONArray(statements);

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerabilityApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerabilityApi.java
@@ -35,7 +35,7 @@ public class VulnerabilityApi {
         JSONArray vulnerabilities = new JSONArray(statements);
         var result = getStatementsAttributes(vulnerabilities, attributes)
                 .toString().replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/vulnerabilities/{external_id}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -50,7 +50,7 @@ public class VulnerabilityApi {
         JSONObject needed = getStatementAttributes(vulnerability.getJSONObject("statement"), attributes);
         vulnerability.put("statement", needed);
         var result = vulnerability.toString().replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/vulnerabilities/{external_id}/purls", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -63,7 +63,7 @@ public class VulnerabilityApi {
             return new ResponseEntity<>("Vulnerability not found", HttpStatus.NOT_FOUND);
         }
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/vulnerabilities/{external_id}/callables", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -79,7 +79,7 @@ public class VulnerabilityApi {
         uriMap.forEach((key, value) -> json.put(String.valueOf(key), value));
         var result = json.toString();
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/vulnerabilities/coordinates", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -122,7 +122,7 @@ public class VulnerabilityApi {
         }).forEach(jsonArray::put);                                                
         var result = jsonArray.toString();
         result = result.replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @GetMapping(value = "/packages/{pkg}/{pkg_ver}/vulnerabilities", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -136,13 +136,13 @@ public class VulnerabilityApi {
             } catch (IllegalArgumentException | IOException e) {
                 return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
             }
-            return Responses.getLazyIngestionResponse();
+            return Responses.lazyIngestion();
         }
         var statements = KnowledgeBaseConnector.kbDao.getPackageVersionVulnerabilities(packageName, packageVersion, true);
         JSONArray vulnerabilities = new JSONArray(statements);
         var result = getStatementsAttributes(vulnerabilities, attributes)
                 .toString().replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/vulnerabilities/purls", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -153,7 +153,7 @@ public class VulnerabilityApi {
         JSONArray vulnerabilities = new JSONArray((statements));
         var result = getStatementsAttributes(vulnerabilities, attributes)
                 .toString().replace("\\/", "/");
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     private JSONObject getStatementAttributes(JSONObject statement, List<String> attributes) {

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerableCallChainsApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/VulnerableCallChainsApi.java
@@ -27,7 +27,6 @@ import eu.fasten.core.vulchains.VulnerableCallChainRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -75,7 +74,7 @@ public class VulnerableCallChainsApi {
 
         Set<VulnerableCallChain> chains = vulnerableCallChainRepository.getChainsForPackage(packageName, packageVersion);
         var result = VulnerableCallChainsToJSON(chains);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/module", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -86,7 +85,7 @@ public class VulnerableCallChainsApi {
         FastenURI fastenUri = FastenURI.create(KnowledgeBaseConnector.forge, packageName, packageVersion, rawPath);
         Set<VulnerableCallChain> chains = vulnerableCallChainRepository.getChainsForModule(fastenUri);
         var result = VulnerableCallChainsToJSON(chains);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 
     @PostMapping(value = "/callable", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -97,6 +96,6 @@ public class VulnerableCallChainsApi {
         FastenURI fastenUri = FastenURI.create(KnowledgeBaseConnector.forge, packageName, packageVersion, rawPath);
         Set<VulnerableCallChain> chains = vulnerableCallChainRepository.getChainsForCallable(fastenUri);
         var result = VulnerableCallChainsToJSON(chains);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return Responses.ok(result);
     }
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/PackageApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/PackageApiTest.java
@@ -142,27 +142,28 @@ public class PackageApiTest {
     }
 
     @Test
-    void getPackageMetadataPositiveTest() {
+    void getPVMetadataPositiveTest() {
         var packageName = "group:artifact";
         var version = "version";
         var response = "package metadata";
         Mockito.when(kbDao.getPackageMetadata(packageName, version)).thenReturn(response);
         var expected = new ResponseEntity<>(response, HttpStatus.OK);
-        var result = sut.getPackageMetadata(packageName, version);
+        var result = sut.getPackageMetadata(packageName, version, null, null);
         assertEquals(expected, result);
 
         Mockito.verify(kbDao, Mockito.times(1)).getPackageMetadata(packageName, version);
     }
 
     @Test
-    void getPackageNegativeMetadataTest() {
+    void getPVMetadataNeededIngestion() {
         var packageName = "group:artifact";
         var version = "version";
-        Mockito.when(kbDao.getPackageMetadata(packageName, version)).thenReturn(null);
-        var result = sut.getPackageMetadata(packageName, version);
-        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+        when(kbDao.getPackageVersion(packageName, version)).thenReturn(null);
+        when(ingestion.ingestArtifactIfNecessary(anyString(), anyString(), isNull(), isNull())).thenReturn(true);
+        var result = sut.getPackageMetadata(packageName, version, null, null);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
 
-        Mockito.verify(kbDao, Mockito.times(1)).getPackageMetadata(packageName, version);
+        Mockito.verify(kbDao, Mockito.times(0)).getPackageMetadata(packageName, version);
     }
 
     @Test


### PR DESCRIPTION
## Description
- Created a Responses class that creates repeating HTTP response entity objects.
- Refactor most reponse creation instances to use methods of the new class.
- Added ingestion behavior to the package/version/metadata endpoint.

## Motivation and context
In our integration with FASTEN, we need ingestion to trigger on a package/version/metadata endpoint query, if the package-version is missing.

## Testing
- Unit tests succeed.

## Task list  
- [ ] DC test
- [ ] Alignment with on-going refactoring by @proksch 
- [ ] Resolve that some endpoints package/version are dysfunctional due to recent refactoring (see issue #500).
