### PR TITLE
Fix Broken PyPI Ingestion Mechanism

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/LazyIngestionProvider.java
@@ -117,12 +117,12 @@ public class LazyIngestionProvider {
      * @return whether it was necessary to ingest artifact
      */
     public boolean ingestPypiArtifactIfNecessary(String packageName, String version) {
-        var query = "https://pypi.org/pypi/" + packageName + "/" + version +"/json";
+        var query = "https://pypi.org/pypi/" + packageName + "/json";
         String result;
         try {
             result = MavenUtilities.sendGetRequest(query);
         } catch (IllegalStateException ex) {
-            throw new IllegalArgumentException("PyPI package " + packageName + ":" + version
+            throw new IllegalArgumentException("PyPI package " + packageName
                     + " could not be found. Make sure the PyPI coordinate is correct");
         }
         if (!hasArtifactBeenIngested(packageName, version)) {


### PR DESCRIPTION
## Description
This Pull Request aims to fix the issue described on #488 :

- Precisely, it enables the PyPI ingestion mechanism to check the existence of a PyPI coordinate and consequently consume packaging information throughout the use of the https://pypi.org/pypi/package_name/json endpoint instead of the https://pypi.org/pypi/package_name/package_version/json. We use the package-only endpoint because it is the only endpoint containing the json field with all the release information of the package. Consuming this information is essential, because further in the pipeline it enables PyPI Filter to ingest all the missing versions of a corresponding package.

- Moreover, in order to check whether a specific package version exists on PyPI, we search  whether the specific version of the package exists in  the `releases` key of the json response of the pypi.org package endpoint. 

## Motivation and context
Fixes #488

## Testing
Tested in a local deployment on monster, and the release information could be succesfully consumed by the kafka topic.


