### PR TITLE
Escape < > characters in FastenPythonURI creation.

### DIFF
--- a/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPluginTest.java
+++ b/analyzer/metadata-plugin/src/test/java/eu/fasten/analyzer/metadataplugin/MetadataDatabasePythonPluginTest.java
@@ -27,13 +27,20 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Optional;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static eu.fasten.core.utils.TestUtils.getTestResource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MetadataDatabasePythonPluginTest {
 
@@ -170,5 +177,14 @@ public class MetadataDatabasePythonPluginTest {
                 + " and populates metadata database with consumed data"
                 + " and writes graph of GIDs of callgraph to another Kafka topic.";
         assertEquals(description, metadataDBExtension.description());
+    }
+
+    @Test
+    public void lambaTest() throws IOException {
+        var json = Files.readString(getTestResource("call-graph-with-lambda.json").toPath());
+        var cg = new PartialPythonCallGraph(new JSONObject(json));
+        var methods = cg.mapOfAllMethods();
+        var lambda = methods.get(1);
+        assertEquals(lambda.getUri(), "/main/test.%3Clambda1%3E()");
     }
 }

--- a/analyzer/metadata-plugin/src/test/resources/call-graph-with-lambda.json
+++ b/analyzer/metadata-plugin/src/test/resources/call-graph-with-lambda.json
@@ -1,0 +1,39 @@
+{
+  "product": "Test",
+  "forge": "PyPI",
+  "generator": "PyCG",
+  "depset": [],
+  "version": "TEST",
+  "timestamp": "0",
+  "modules": {
+    "internal": {
+      "/main": {
+        "sourceFile": "main.py",
+        "namespaces": {
+          "1": {
+            "namespace": "/main/test.<lambda1>()",
+            "metadata": {
+              "first": 1,
+              "last": 2
+            }
+          }
+        }
+      }
+    },
+    "external": {
+    }
+  },
+  "graph": {
+    "internalCalls": [],
+    "externalCalls": [],
+    "resolvedCalls": []
+  },
+  "nodes": 1,
+  "metadata": {
+    "loc": 1,
+    "time_elapsed": 1,
+    "max_rss": 1,
+    "num_files": 1
+  },
+  "sourcePath": "TEST"
+}

--- a/core/src/main/java/eu/fasten/core/data/FastenPythonURI.java
+++ b/core/src/main/java/eu/fasten/core/data/FastenPythonURI.java
@@ -18,6 +18,8 @@
 
 package eu.fasten.core.data;
 
+import com.google.common.net.UrlEscapers;
+
 import java.net.URI;
 
 /** A class representing a Fasten URI for the Python language; it has to be considered experimental
@@ -29,7 +31,7 @@ public class FastenPythonURI extends FastenURI {
     protected final boolean isFunction;
 
     public FastenPythonURI(final String s) {
-        this(URI.create(s));
+        this(URI.create(UrlEscapers.urlFragmentEscaper().escape(s)));
     }
 
     public FastenPythonURI(final URI uri) {
@@ -88,7 +90,7 @@ public class FastenPythonURI extends FastenURI {
      * @return a {@link FastenPythonURI}.
      */
     public static FastenPythonURI create(final String s) {
-        return new FastenPythonURI(URI.create(s));
+        return new FastenPythonURI(s);
     }
 
     /**


### PR DESCRIPTION
## Description
PyCG generates namespaces that can include `<` and `>` to denote lambdas. The creation of FastenPythonURIs does not take that into account and hence fails. See issue https://github.com/fasten-project/pypi-tools/issues/15.

This PR escapes the `<` and `>` characters so that URI creation succeeds.

## Testing
Unit tests succeed locally.

